### PR TITLE
Add `-mwin32` flag on Windows targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ pub fn compile_library(output: &str, config: &Config, files: &[&str]) {
     if target.as_slice().contains("-ios") {
         cmd.args(ios_flags(target.as_slice()).as_slice());
     } else {
+        if target.contains("windows") {
+            cmd.arg("-mwin32");
+        }
+
         if target.as_slice().contains("i686") {
             cmd.arg("-m32");
         } else if target.as_slice().contains("x86_64") {


### PR DESCRIPTION
See rust-lang/time#45.

I figured adding it to the defaults would be the most controllable way of implementing this fix. That way users can opt-out if it's inducing unwanted behavior. I'll reboot into Windows in a second to test this.

Edit: I can't exactly attest to the fix as Cargo silences the prints from `gcc-rs`, however it does build correctly even after removing the patch I made to `time`, so I presume it works.
