### PR TITLE
Tell MSVC to link with debug CRT on debug builds

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -405,9 +405,33 @@ fn msvc_static_crt() {
 }
 
 #[test]
+fn msvc_static_debug_crt() {
+    let test = Test::msvc();
+    test.gcc()
+        .debug(true)
+        .static_crt(true)
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_have("-MTd");
+}
+
+#[test]
 fn msvc_no_static_crt() {
     let test = Test::msvc();
     test.gcc().static_crt(false).file("foo.c").compile("foo");
 
     test.cmd(0).must_have("-MD");
+}
+
+#[test]
+fn msvc_no_static_debug_crt() {
+    let test = Test::msvc();
+    test.gcc()
+        .debug(true)
+        .static_crt(false)
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_have("-MDd");
 }


### PR DESCRIPTION
When doing a debug build, emits `/MTd` or `/MDd` instead of `/MT` or `/MD`, matching the usual flags for C++ code. When linking statically, `link.exe` requires all objects to be built with the same `/M*` flags, so hopefully this makes it easier to consume Rust static libraries while debugging.

I suspect that this might not be the way this change should be handled, and furthermore, it smells a little bit like it might be a breaking change when doing debug builds, but it's a start.

Background: I'm building a Rust `staticlib` targeting `x86_64-pc-windows-msvc`, then linking it against some C++ to make a DLL. To do this I'm using the [cxx](https://github.com/dtolnay/cxx) crate, but my understanding is that this problem would be triggered when consuming any crate containing C++ objects as cxx does.

Everything is fine when doing a release build, but on debug builds, my C++ code gets built using the `/MDd` flag for debugging purposes. However, the cc crate unconditionally builds objects using `/MD`. As per [the Microsoft documentation](https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019), this situation is not allowed. Helpfully, the 2019 MSVC toolchain throws up an error, instead of just letting it pass silently, like it used to.

I do have some concerns about my approach here, but I can't really go about addressing them without input from the maintainers:

1. My change doesn't provide a way to manually select the debug or non-debug versions without changing debug mode for all of the code. This might not be a problem depending on the API philosophy.
2. Depending on how they've worked around it (e.g. doing their debug builds with `/MD` instead of `/MDd`), any existing users with the same use-case as mine might have their debug builds broken by this change.