### PR TITLE
For non-MSVC, separate flags/options from the input file. (#513)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1171,6 +1171,13 @@ impl Build {
         if !msvc || !is_asm || !is_arm {
             cmd.arg("-c");
         }
+        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) {
+            // #513: For `clang-cl`, separate flags/options from the input file.
+            // When cross-compiling macOS -> Windows, this avoids interpreting
+            // common `/Users/...` paths as the `/U` flag and triggering
+            // `-Wslash-u-filename` warning.
+            cmd.arg("--");
+        }
         cmd.arg(&obj.src);
 
         run(&mut cmd, &name)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -344,6 +344,14 @@ fn gnu_static() {
 }
 
 #[test]
+fn gnu_no_dash_dash() {
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    test.cmd(0).must_not_have("--");
+}
+
+#[test]
 fn msvc_smoke() {
     reset_env();
 
@@ -410,4 +418,12 @@ fn msvc_no_static_crt() {
     test.gcc().static_crt(false).file("foo.c").compile("foo");
 
     test.cmd(0).must_have("-MD");
+}
+
+#[test]
+fn msvc_no_dash_dash() {
+    let test = Test::msvc();
+    test.gcc().file("foo.c").compile("foo");
+
+    test.cmd(0).must_not_have("--");
 }


### PR DESCRIPTION
This avoids a `clang-cl` issue common when cross-compiling from macOS
to Windows: the `-Wslash-u-filename` where a `/Users/...` path is
interpreted as the `cl.exe` flag `/U`.

In general it's somewhere between harmless and good form to separate
flags/options from input files, so `--` is used for all compilers save
MSVC.

There are no existing tests mocking out `clang-cl` and surface efforts
didn't succeed, so that will have to wait for follow-up.