### PR TITLE
Initial pass at supporting nasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ impl Build {
         let mut cmd = compiler.to_command();
         let is_msvc = target.contains("msvc");
         let clang = compiler.family == ToolFamily::Clang;
-        command_add_output_file(&mut cmd, &obj, !is_msvc && !clang && !self.cuda);
+        command_add_output_file(&mut cmd, &obj, is_msvc && !clang && !self.cuda);
 
         // We need to explicitly tell msvc not to link and create an exe
         // in the root directory of the crate


### PR DESCRIPTION
When targetting the Windows msvc environment, cc currently assumes you are compiling on a Windows host and attempts to find specifically named assemblers based on the target architecture when compiling `.asm` files, which obviously doesn't work great when you aren't on a windows host. This adds initial support for having a `AS` environment variable where the user can specify the assembler they actually want to use, with explicit support for `nasm`, which can assemble x86 and x86_64 windows targets from windows and non-windows hosts.