### PR TITLE
Improve docs for the C++ usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,6 +592,12 @@ impl Build {
     ///
     /// The other `cpp_*` options will only become active if this is set to
     /// `true`.
+    ///
+    /// The name of the C++ standard library to link is decided by:
+    /// 1. If [cpp_link_stdlib](Build::cpp_link_stdlib) is set, use its value.
+    /// 2. Else if the `CXXSTDLIB` environment variable is set, use its value.
+    /// 3. Else the default is `libc++` for OS X and BSDs, `libc++_shared` for Android,
+    /// `None` for MSVC and `libstdc++` for anything else.
     pub fn cpp(&mut self, cpp: bool) -> &mut Build {
         self.cpp = cpp;
         self
@@ -684,8 +690,6 @@ impl Build {
     /// Set the standard library to link against when compiling with C++
     /// support.
     ///
-    /// See [`get_cpp_link_stdlib`](cc::Build::get_cpp_link_stdlib) documentation
-    /// for the default value.
     /// If the `CXXSTDLIB` environment variable is set, its value will
     /// override the default value, but not the value explicitly set by calling
     /// this function.


### PR DESCRIPTION
I was having some issues with the c++ standard library on different platforms (since resolved), but that lead me to notice that there was a broken doc link for get_cpp_link_stdlib, which wasn't public, so its documentation is not in the html docs.

Making get_cpp_link_stdlib public provides a good place for the missing information in the html docs, so if only for that reason I think it should be public. Of course, I understand if y'all disagree.