### PR TITLE
When spawn() fails, include the underlying error in the message.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3041,9 +3041,12 @@ fn spawn(cmd: &mut Command, program: &str) -> Result<(Child, JoinHandle<()>), Er
                 &format!("Failed to find tool. Is `{}` installed?{}", program, extra),
             ))
         }
-        Err(_) => Err(Error::new(
+        Err(ref e) => Err(Error::new(
             ErrorKind::ToolExecError,
-            &format!("Command {:?} with args {:?} failed to start.", cmd, program),
+            &format!(
+                "Command {:?} with args {:?} failed to start: {:?}",
+                cmd, program, e
+            ),
         )),
     }
 }


### PR DESCRIPTION
Include spawn()'s error message when reporting a spawn error, as it may
contain information useful for determining the cause of the error.

This is motivated by the CI error messages in rust-lang/rust#87329.