### PR TITLE
Add Loongarch64 support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2945,6 +2945,7 @@ impl Build {
             ]), // explicit None if not found, so caller knows to fall back
             "i686-unknown-linux-musl" => Some("musl"),
             "i686-unknown-netbsd" => Some("i486--netbsdelf"),
+            "loongarch64-unknown-linux-gnu" => Some("loongarch64-linux-gnu"),
             "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),
             "mips-unknown-linux-musl" => Some("mips-linux-musl"),
             "mipsel-unknown-linux-gnu" => Some("mipsel-linux-gnu"),


### PR DESCRIPTION
Loongarch is a new RISC architecture.
Loongarch doc: https://github.com/loongson-community/LoongArch-Documentation/