### PR TITLE
Add {i686,x86_64}-redhat-linux prefixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2577,7 +2577,10 @@ impl Build {
             "i686-uwp-windows-gnu" => Some("i686-w64-mingw32"),
             "i686-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
                 "i686-linux-gnu",
-                "x86_64-linux-gnu", // transparently support gcc-multilib
+                "i686-redhat-linux",
+                // transparently support gcc-multilib
+                "x86_64-linux-gnu",
+                "x86_64-redhat-linux",
             ]), // explicit None if not found, so caller knows to fall back
             "i686-unknown-linux-musl" => Some("musl"),
             "i686-unknown-netbsd" => Some("i486--netbsdelf"),


### PR DESCRIPTION
Fedora doesn't have x86_64-linux-gnu-\*, instead it has x86_64-redhat-linux-\*. This patch adds them to the detection, enabling out-of-the-box support for compiling 32-bit on both 64-bit and 32-bit Fedora.

I tested this on 64-bit Fedora 35 and on 32-bit Fedora 36 mock.
