### PR TITLE
MSVC: Add support for linking against the "spectre-mitigated" CRT

### DIFF
--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -575,8 +575,13 @@ mod impl_ {
         // architecture, because it contains dlls like mspdb140.dll compiled for
         // the host architecture.
         let host_dylib_path = host_path.join(host.to_lowercase());
-        let lib_path = path.join("lib").join(target);
-        let alt_lib_path = (target == "arm64ec").then(|| path.join("lib").join("arm64ec"));
+        let lib_fragment = if use_spectre_mitigated_libs() {
+            r"lib\spectre"
+        } else {
+            "lib"
+        };
+        let lib_path = path.join(lib_fragment).join(target);
+        let alt_lib_path = (target == "arm64ec").then(|| path.join(lib_fragment).join("arm64ec"));
         let include_path = path.join("include");
         Some((
             path,
@@ -623,6 +628,10 @@ mod impl_ {
         version_file.read_to_string(&mut version).ok()?;
         version.truncate(version.trim_end().len());
         Some(version)
+    }
+
+    fn use_spectre_mitigated_libs() -> bool {
+        env::var("VSCMD_ARG_VCVARS_SPECTRE").as_deref() == Ok("spectre")
     }
 
     fn atl_paths(target: TargetArch<'_>, path: &Path) -> Option<(PathBuf, PathBuf)> {


### PR DESCRIPTION
Issue Details:
Since VS 2017, MSVC has shipped a set of "spectre-mitigated" CRT static libs: https://devblogs.microsoft.com/cppblog/spectre-mitigations-in-msvc/

Typically these are used by opening a VS Command Prompt in "spectre mode" (https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax) which then sets the `LIB` environment variable to point to the directory with the spectre-mitigated libs. However, since `cc` prepends to the `LIB` environment variable, it uses the non-spectre-mitigated libs even when invoked from a VS Command Prompt in "spectre mode". This causes issues when trying to build a spectre-mitigated binary using Rust, as `rustc` uses `cc` for linking.

Fix Details:
When `cc` detects that the `VSCMD_ARG_VCVARS_SPECTRE` environment variable is set to `spectre` (either by being run from a VS Command Prompt in "spectre mode", or users may explicitly set this themselves), it will use the spectre-mitigated lib directory when building its `LIB` environment variable.