### PR TITLE
Use specified compiler in is_flag_supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,9 @@ impl Build {
             .debug(false)
             .cpp(self.cpp)
             .cuda(self.cuda);
+        if let Some(ref c) = self.compiler {
+            cfg.compiler(c.clone());
+        }
         let mut compiler = cfg.try_get_compiler()?;
 
         // Clang uses stderr for verbose output, which yields a false positive


### PR DESCRIPTION
Use the compiler specified instead of the default one to test whether a flag can be accepted.
Fixes https://github.com/alexcrichton/cc-rs/issues/675.