### PR TITLE
Update CUDA Linux GPG repository key [and compiler version].

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,16 +92,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
-    - name: Install cuda-minimal-build-11-4
+    - name: Install cuda-minimal-build-11-6
       shell: bash
       run: |
         # https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
         sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
         sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
         sudo apt-get update
-        sudo apt-get -y install cuda-minimal-build-11-4
+        sudo apt-get -y install cuda-minimal-build-11-6
     - name: Test 'cudart' feature
       shell: bash
       run: env PATH=/usr/local/cuda/bin:$PATH cargo test --manifest-path cc-test/Cargo.toml --features test_cuda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, linux32, macos, aarch64-ios, win32, win64, mingw32, mingw64, windows-2016]
+        build: [stable, beta, nightly, linux32, macos, aarch64-ios, win32, win64, mingw32, mingw64, windows-2019]
         include:
           - build: stable
             os: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             no_run: --no-run
           - build: win32
-            os: windows-2016
+            os: windows-2019
             rust: stable-i686-msvc
             target: i686-pc-windows-msvc
           - build: win64
@@ -55,8 +55,8 @@ jobs:
             os: windows-latest
             rust: stable-x86_64-gnu
             target: x86_64-pc-windows-gnu
-          - build: windows-2016
-            os: windows-2016
+          - build: windows-2019
+            os: windows-2019
             rust: stable-x86_64
             target: x86_64-pc-windows-msvc
     steps:


### PR DESCRIPTION
Nvidia rotated their repository signing key on April 27, 2022.