### PR TITLE
Mac Catalyst: Read `IPHONEOS_DEPLOYMENT_TARGET` from environment variable to support Clang 13

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1573,8 +1573,10 @@ impl Build {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
+                            let deployment_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
+                                .unwrap_or_else(|_| "13.0".into());
                             cmd.args
-                                .push(format!("--target={}-apple-ios13.0-macabi", arch).into());
+                                .push(format!("--target={}-apple-ios{}-macabi", arch, deployment_target).into());
                         }
                     } else if target.contains("ios-sim") {
                         if let Some(arch) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1575,8 +1575,10 @@ impl Build {
                         {
                             let deployment_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
                                 .unwrap_or_else(|_| "13.0".into());
-                            cmd.args
-                                .push(format!("--target={}-apple-ios{}-macabi", arch, deployment_target).into());
+                            cmd.args.push(
+                                format!("--target={}-apple-ios{}-macabi", arch, deployment_target)
+                                    .into(),
+                            );
                         }
                     } else if target.contains("ios-sim") {
                         if let Some(arch) =


### PR DESCRIPTION
## Background

Clang 13 removed the `x86_64-apple-ios13.0-macabi` target, where `13.0` is hardcoded in `cc-rs`.

Proof:

```shell
➜  temp clang -target x86_64-apple-ios13.1-macabi i.c
➜  temp clang -target x86_64-apple-ios13.0-macabi i.c
clang-13: error: invalid version number in '-target x86_64-apple-ios13.0-macabi'
➜  temp clang --version
Homebrew clang version 13.0.1
Target: arm64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /opt/homebrew/bin
➜  temp cat i.c

int main() {
	return 0;
}
➜  temp
```

This PR is to remove this hardcoded version and read it from `IPHONEOS_DEPLOYMENT_TARGET`.

## Credits

@ehuss helped me found this reason: https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Update.20Mac.20Catalyst.20support.20for.20Clang.2013/near/280745037

## How to test

In this commit <https://github.com/imWildCat/BLAKE3/commit/f7bfd7786dedbad7be3e263ee3282f2b36cacd1a>, I changed `cc-rs` to my branch.

The build command and its output is like

```shell
➜  BLAKE3 git:(clang-13-mac-catalyst-demo) ✗ IPHONEOS_DEPLOYMENT_TARGET=13.1 cargo +nightly build -Z build-std --target x86_64-apple-ios-macabi
   Compiling compiler_builtins v0.1.71
   Compiling core v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core)
   Compiling libc v0.2.121
   Compiling cc v1.0.69
   Compiling memchr v2.4.1
   Compiling std v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std)
   Compiling version_check v0.9.4
   Compiling typenum v1.15.0
   Compiling cc v1.0.73 (https://github.com/imWildCat/cc-rs?branch=clang-13-mac-catalyst#310a43a5)
   Compiling generic-array v0.14.5
   Compiling blake3 v1.3.1 (/Volumes/SharedVol/rust-projects/BLAKE3)
   Compiling unwind v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/unwind)
   Compiling rustc-std-workspace-core v1.99.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc)
   Compiling cfg-if v0.1.10
   Compiling adler v0.2.3
   Compiling rustc-demangle v0.1.21
   Compiling rustc-std-workspace-alloc v1.99.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
   Compiling panic_unwind v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/panic_unwind)
   Compiling panic_abort v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/panic_abort)
   Compiling gimli v0.25.0
   Compiling std_detect v0.1.5 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/stdarch/crates/std_detect)
   Compiling object v0.26.2
   Compiling hashbrown v0.12.0
   Compiling miniz_oxide v0.4.0
   Compiling addr2line v0.16.0
   Compiling proc_macro v0.0.0 (/Users/wildcat/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/proc_macro)
   Compiling subtle v2.4.1
   Compiling arrayref v0.3.6
   Compiling arrayvec v0.7.2
   Compiling constant_time_eq v0.1.5
   Compiling cfg-if v1.0.0
   Compiling block-buffer v0.10.2
   Compiling crypto-common v0.1.3
   Compiling digest v0.10.3
    Finished dev [unoptimized + debuginfo] target(s) in 12.88s
```
