### PR TITLE
Map source absolute paths to OUT_DIR as relative.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,12 @@
 #![allow(deprecated)]
 #![deny(missing_docs)]
 
-use std::collections::HashMap;
+use std::collections::{hash_map, HashMap};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter};
 use std::fs;
+use std::hash::Hasher;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -1038,6 +1039,21 @@ impl Build {
                             _ => (),
                         };
                     }
+                }
+                // ... and prefix the `basename` with the `dirname`'s hash
+                // to ensure name uniqueness.
+                let basename = file
+                    .file_name()
+                    .ok_or_else(|| Error::new(ErrorKind::InvalidArgument, "file_name() failure"))?
+                    .to_string_lossy();
+                let dirname = file
+                    .parent()
+                    .ok_or_else(|| Error::new(ErrorKind::InvalidArgument, "parent() failure"))?
+                    .to_string_lossy();
+                let mut hasher = hash_map::DefaultHasher::new();
+                hasher.write(dirname.to_string().as_bytes());
+                if dst.pop() {
+                    dst.push(format!("{:016x}-{}", hasher.finish(), basename));
                 }
                 dst.with_extension("o")
             } else {


### PR DESCRIPTION
If a source file was specified by absolute path, then the corresponding
object file was placed into OUT_DIR. This posed a problem if multiple
files with the same base name were specified by absolute paths.

Fixes #683.