### PR TITLE
Use RUSTC_LINKER's prefix as last resort for prefix_for_target().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2595,11 +2595,22 @@ impl Build {
     }
 
     fn prefix_for_target(&self, target: &str) -> Option<String> {
+        // Put aside RUSTC_LINKER's prefix to be used as last resort
+        let rustc_linker = self.getenv("RUSTC_LINKER").unwrap_or("".to_string());
+        // let linker_prefix = rustc_linker.strip_suffix("-gcc"); // >=1.45.0
+        let linker_prefix = if rustc_linker.len() > 4 {
+            let (prefix, suffix) = rustc_linker.split_at(rustc_linker.len() - 4);
+            if suffix == "-gcc" {
+                Some(prefix)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"
         let cc_env = self.getenv("CROSS_COMPILE");
-        let cross_compile = cc_env
-            .as_ref()
-            .map(|s| s.trim_right_matches('-').to_owned());
+        let cross_compile = cc_env.as_ref().map(|s| s.trim_end_matches('-').to_owned());
         cross_compile.or(match &target[..] {
             "aarch64-pc-windows-gnu" => Some("aarch64-w64-mingw32"),
             "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
@@ -2706,7 +2717,7 @@ impl Build {
             ]), // explicit None if not found, so caller knows to fall back
             "x86_64-unknown-linux-musl" => Some("musl"),
             "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
-            _ => None,
+            _ => linker_prefix,
         }
         .map(|x| x.to_owned()))
     }


### PR DESCRIPTION
User-provided cross-linker is a working cross-compiler with a perfectly usable prefix. Usable in the prefix_for_target() context that is. One can wonder if it's possible to even remove the majority of the mapping table... (I write "majority" because \*-windows-gnu [and no-std?] users are excused from configuring cross-linker.) Potentially fixes #666 and #637. [~Possibly even #654.~ To help #654 one would have to remove the musl mappings. So that the fallback is actually fallen on.]