### PR TITLE
Add support for riscv32imac-unknown-xous-elf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2694,6 +2694,11 @@ impl Build {
                 "riscv64-unknown-elf",
                 "riscv-none-embed",
             ]),
+            "riscv32imac-unknown-xous-elf" => self.find_working_gnu_prefix(&[
+                "riscv32-unknown-elf",
+                "riscv64-unknown-elf",
+                "riscv-none-embed",
+            ]),
             "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
                 "riscv32-unknown-elf",
                 "riscv64-unknown-elf",


### PR DESCRIPTION
The `riscv32imac-unknown-xous-elf` target is a new Tier 3 platform. This platform uses standard Os-less `-none-` toolchains, as Rust provides all standard libraries and IPC functionality.