### PR TITLE
Force linking with spectre-mitigated libraries if /Qspectre is passed.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,6 +1041,29 @@ impl Build {
                     atlmfc_lib.display()
                 ));
             }
+
+            let compiler = self.try_get_compiler()?;
+            for arg in compiler.args.iter() {
+                if arg.to_str().unwrap().contains("Qspectre") {
+                    for (var, val) in compiler.env.iter() {
+                        if var == "LIB" {
+                            for path in env::split_paths(&val) {
+                                if let Some(last) = path.iter().last() {
+                                    // check upon .../lib/{platform}/../spectre/{platform}
+                                    let spectre = path.parent().unwrap().join("spectre").join(last);
+                                    if spectre.exists() {
+                                        self.print(&format!(
+                                            "cargo:rustc-link-search=native={}",
+                                            spectre.display()
+                                        ));
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         if self.link_lib_modifiers.is_empty() {


### PR DESCRIPTION
This is a kind of alternative to #673. I write "kind of" because it's not in direct opposition, but rather just a more sensible and robust approach.

I mark it as draft, because it needs more work, and maybe even further amendments based on feedback.
- a warning would be appropriate in case spectre-mitigated libraries are not installed;
- the section above, one that attempts to add reference to ATL, seems to be broken for contemporary compilers;
- examine `%LIB%` environment variable, combine it with the suggested list, and deduplicate the result;
- should there be a "global" method that would trigger linking with spectre-mitigated libraries in case the user doesn't compile any C/C++?
- ...