### PR TITLE
Add option to emit `rerun-if-env-changed` metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2802,12 +2802,12 @@ impl Build {
     }
 
     fn getenv(&self, v: &str) -> Option<String> {
-        if self.emit_rerun_if_env_changed {
-            self.print(&format!("cargo:rerun-if-env-changed={}", v));
-        }
         let mut cache = self.env_cache.lock().unwrap();
         if let Some(val) = cache.get(v) {
             return val.clone();
+        }
+        if self.emit_rerun_if_env_changed {
+            self.print(&format!("cargo:rerun-if-env-changed={}", v));
         }
         let r = env::var(v).ok();
         self.print(&format!("{} = {:?}", v, r));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -924,8 +924,8 @@ impl Build {
         self.use_plt = Some(use_plt);
         self
     }
-    
-    /// Define whether metadata should be emitted for cargo to detect environment 
+
+    /// Define whether metadata should be emitted for cargo to detect environment
     /// changes that should trigger a rebuild.
     ///
     /// This has no effect if the `cargo_metadata` option is `false`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub struct Build {
     extra_warnings: Option<bool>,
     env_cache: Arc<Mutex<HashMap<String, Option<String>>>>,
     apple_sdk_root_cache: Arc<Mutex<HashMap<String, OsString>>>,
+    emit_rerun_if_env_changed: bool,
 }
 
 /// Represents the types of errors that may occur while using cc-rs.
@@ -320,6 +321,7 @@ impl Build {
             warnings_into_errors: false,
             env_cache: Arc::new(Mutex::new(HashMap::new())),
             apple_sdk_root_cache: Arc::new(Mutex::new(HashMap::new())),
+            emit_rerun_if_env_changed: false,
         }
     }
 
@@ -892,6 +894,7 @@ impl Build {
     ///  - `rustc-link-search=native=`*target folder*
     ///  - When target is MSVC, the ATL-MFC libs are added via `rustc-link-search=native=`
     ///  - When C++ is enabled, the C++ stdlib is added via `rustc-link-lib`
+    ///  - If `emit_rerun_if_env_changed` is `true`, `rerun-if-env-changed=`*env*
     ///
     pub fn cargo_metadata(&mut self, cargo_metadata: bool) -> &mut Build {
         self.cargo_metadata = cargo_metadata;
@@ -919,6 +922,17 @@ impl Build {
     /// This only applies to ELF targets. It has no effect on other platforms.
     pub fn use_plt(&mut self, use_plt: bool) -> &mut Build {
         self.use_plt = Some(use_plt);
+        self
+    }
+    
+    /// Define whether metadata should be emitted for cargo to detect environment 
+    /// changes that should trigger a rebuild.
+    ///
+    /// This has no effect if the `cargo_metadata` option is `false`.
+    ///
+    /// This option defaults to `false`.
+    pub fn emit_rerun_if_env_changed(&mut self, emit_rerun_if_env_changed: bool) -> &mut Build {
+        self.emit_rerun_if_env_changed = emit_rerun_if_env_changed;
         self
     }
 
@@ -2788,6 +2802,9 @@ impl Build {
     }
 
     fn getenv(&self, v: &str) -> Option<String> {
+        if self.emit_rerun_if_env_changed {
+            self.print(&format!("cargo:rerun-if-env-changed={}", v));
+        }
         let mut cache = self.env_cache.lock().unwrap();
         if let Some(val) = cache.get(v) {
             return val.clone();


### PR DESCRIPTION
Partially fixes #230 by emitting directives for environment variables. Looking at #443, it seems uncontroversial to add an option to emit this metadata for environment variables. 

This PR adds an option called `emit_rerun_if_env_changed` to control this behavior, defaulted to false. I added a check in `getenv` to print the metadata if this flag is true. Since I use the `print` function, `cargo_metadata` must also be true for this flag to have any effect.