### PR TITLE
use MACOSX_DEPLOYMENT_TARGET when set

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -475,3 +475,21 @@ fn asm_flags() {
     test.cmd(1).must_have("--abc");
     test.cmd(2).must_have("--abc");
 }
+
+#[test]
+fn gnu_apple_darwin() {
+    for (arch, version) in &[("x86_64", "10.7"), ("aarch64", "11.0")] {
+        let target = format!("{}-apple-darwin", arch);
+        let test = Test::gnu();
+        test.gcc()
+            .target(&target)
+            .host(&target)
+            // Avoid test maintainence when minimum supported OSes change.
+            .__set_env("MACOSX_DEPLOYMENT_TARGET", version)
+            .file("foo.c")
+            .compile("foo");
+
+        test.cmd(0)
+            .must_have(format!("-mmacosx-version-min={}", version));
+    }
+}


### PR DESCRIPTION
~10.4 for c and 10.9 for c++~

10.7 for x86 and 11.0 for aarch64.

ref: https://github.com/rust-lang/rust/blob/6365e5ad9fa9e2ec867a67aeeae414e7c62d8354/compiler/rustc_target/src/spec/apple_base.rs#L105-L114
which referred in https://github.com/rust-lang/cc-rs/pull/703#discussion_r1005188342