### PR TITLE
detect clang/gcc using --version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3451,7 +3451,7 @@ impl Tool {
                 Some(s) => s,
                 None => {
                     // --version failed. fallback to gnu
-                    println!("cargo-warning:Running failed: {:?}", cmd);
+                    println!("cargo-warning:Failed to run: {:?}", cmd);
                     return ToolFamily::Gnu;
                 }
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1808,6 +1808,16 @@ impl Build {
             family.add_force_frame_pointer(cmd);
         }
 
+        if !cmd.is_like_msvc() {
+            if target.contains("i686") || target.contains("i586") {
+                cmd.args.push("-m32".into());
+            } else if target == "x86_64-unknown-linux-gnux32" {
+                cmd.args.push("-mx32".into());
+            } else if target.contains("x86_64") || target.contains("powerpc64") {
+                cmd.args.push("-m64".into());
+            }
+        }
+
         // Target flags
         match cmd.family {
             ToolFamily::Clang => {
@@ -1937,14 +1947,6 @@ impl Build {
                 }
             }
             ToolFamily::Gnu => {
-                if target.contains("i686") || target.contains("i586") {
-                    cmd.args.push("-m32".into());
-                } else if target == "x86_64-unknown-linux-gnux32" {
-                    cmd.args.push("-mx32".into());
-                } else if target.contains("x86_64") || target.contains("powerpc64") {
-                    cmd.args.push("-m64".into());
-                }
-
                 if target.contains("darwin") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -76,7 +76,11 @@ impl Test {
         let target = if self.msvc {
             "x86_64-pc-windows-msvc"
         } else {
-            "x86_64-unknown-linux-gnu"
+            if cfg!(target_os = "macos") {
+                "x86_64-apple-darwin"
+            } else {
+                "x86_64-unknown-linux-gnu"
+            }
         };
 
         cfg.target(target)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -55,7 +55,11 @@ fn gnu_opt_level_s() {
 #[test]
 fn gnu_debug() {
     let test = Test::gnu();
-    test.gcc().debug(true).file("foo.c").compile("foo");
+    test.gcc()
+        .target("x86_64-unknown-linux")
+        .debug(true)
+        .file("foo.c")
+        .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
 
     let test = Test::gnu();
@@ -70,7 +74,11 @@ fn gnu_debug() {
 #[test]
 fn gnu_debug_fp_auto() {
     let test = Test::gnu();
-    test.gcc().debug(true).file("foo.c").compile("foo");
+    test.gcc()
+        .target("x86_64-unknown-linux")
+        .debug(true)
+        .file("foo.c")
+        .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_have("-fno-omit-frame-pointer");
 }
@@ -78,7 +86,11 @@ fn gnu_debug_fp_auto() {
 #[test]
 fn gnu_debug_fp() {
     let test = Test::gnu();
-    test.gcc().debug(true).file("foo.c").compile("foo");
+    test.gcc()
+        .target("x86_64-unknown-linux")
+        .debug(true)
+        .file("foo.c")
+        .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_have("-fno-omit-frame-pointer");
 }
@@ -89,6 +101,7 @@ fn gnu_debug_nofp() {
 
     let test = Test::gnu();
     test.gcc()
+        .target("x86_64-unknown-linux")
         .debug(true)
         .force_frame_pointer(false)
         .file("foo.c")
@@ -98,6 +111,7 @@ fn gnu_debug_nofp() {
 
     let test = Test::gnu();
     test.gcc()
+        .target("x86_64-unknown-linux")
         .force_frame_pointer(false)
         .debug(true)
         .file("foo.c")


### PR DESCRIPTION
This is useful on macos because `gcc` and `cc` is actually `clang`.
`gcc` and `cc` were regarded as `clang` even when it was gcc.

`m32` and `m64` is not necessary for clang, but also harmless.
Do you want to do it as now or want to revert it and change tests run only for gcc?