### PR TITLE
Refine CUDA support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,16 +96,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
-    - name: Install cuda-minimal-build-11-6
+    - name: Install cuda-minimal-build-11-8
       shell: bash
       run: |
         # https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-        sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+        sudo dpkg -i cuda-keyring_1.0-1_all.deb
         sudo apt-get update
-        sudo apt-get -y install cuda-minimal-build-11-6
+        sudo apt-get -y install cuda-minimal-build-11-8
     - name: Test 'cudart' feature
       shell: bash
       run: env PATH=/usr/local/cuda/bin:$PATH cargo test --manifest-path cc-test/Cargo.toml --features test_cuda

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1367,7 +1367,7 @@ impl Build {
         if !msvc || !is_asm || !is_arm {
             cmd.arg("-c");
         }
-        if self.cuda && self.files.len() > 1 {
+        if self.cuda && self.cuda_file_count() > 1 {
             cmd.arg("--device-c");
         }
         if is_asm {
@@ -2035,7 +2035,7 @@ impl Build {
             self.assemble_progressive(dst, chunk)?;
         }
 
-        if self.cuda {
+        if self.cuda && self.cuda_file_count() > 0 {
             // Link the device-side code and add it to the target library,
             // so that non-CUDA linker can link the final binary.
 
@@ -3009,6 +3009,13 @@ impl Build {
         let ret: OsString = sdk_path.trim().into();
         cache.insert(sdk.into(), ret.clone());
         Ok(ret)
+    }
+
+    fn cuda_file_count(&self) -> usize {
+        self.files
+            .iter()
+            .filter(|file| file.extension() == Some(OsStr::new("cu")))
+            .count()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1690,7 +1690,7 @@ impl Build {
                             cmd.args.push("--target=aarch64-unknown-windows-gnu".into())
                         }
                     } else {
-                        cmd.args.push(format!("--target={}", target).into());
+                        cmd.push_cc_arg(format!("--target={}", target).into());
                     }
                 }
             }


### PR DESCRIPTION
Instead of counting all source files we count only .cu files, ones with device code that actually require the special treatment.

[Even fixes #641.]