### PR TITLE
Pick MSVC -arch: based on CARGO_CFG_TARGET_FEATURE for x86 / x86_64 targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1643,13 +1643,31 @@ impl Build {
                         cmd.push_cc_arg("-m64".into());
                     } else if target.contains("86") {
                         cmd.push_cc_arg("-m32".into());
-                        cmd.push_cc_arg("-arch:IA32".into());
                     } else {
                         cmd.push_cc_arg(format!("--target={}", target).into());
                     }
-                } else {
-                    if target.contains("i586") {
-                        cmd.push_cc_arg("-arch:IA32".into());
+                }
+
+                let is_x86 = target.contains("i686") || target.contains("i586");
+                let is_x64 = target.contains("x86_64");
+
+                if is_x86 || is_x64 {
+                    let features = self
+                        .getenv("CARGO_CFG_TARGET_FEATURE")
+                        .unwrap_or(String::new());
+
+                    if features.contains("avx2") {
+                        cmd.push_cc_arg("-arch:AVX2".into());
+                    } else if features.contains("avx") {
+                        cmd.push_cc_arg("-arch:AVX".into());
+                    } else if is_x86 {
+                        if features.contains("sse2") {
+                            cmd.push_cc_arg("-arch:SSE2".into());
+                        } else if features.contains("sse") {
+                            cmd.push_cc_arg("-arch:SSE".into());
+                        } else {
+                            cmd.push_cc_arg("-arch:IA32".into());
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is my first contribution to cc-rs, and I'm more than open to any critique or questions.

---

As it is now, `-arch:IA32` is passed for 32-bit builds if the target is `i586` or `clang-cl` is being used. This explicit override often breaks assumptions and *always* downgrades 32-bit `clang-cl` builds from the default `-arch:SSE2` to `-arch:IA32`, potentially impacting performance.

This PR attempts to only downgrade when there's reason to, and otherwise attempt to pick a target `-arch` that matches the features set in `CARGO_CFG_TARGET_FEATURE`. Picking an `-arch` that follows `CARGO_CFG_TARGET_FEATURE` also means crates (both x86 and x86_64) that opt into support for `AVX` or `AVX2` through `target-feature` will now also have any dependencies built with `cc` benefit from that.

---

I'm using `clang-cl` to build a few 32-bit projects, so I'm most likely running into issues with this far more often than most people are. While usually it's at most a bit annoying that `cc` builds aren't respecting `target-feature`, it actually breaks my builds.

Today I ran into this same issue again when trying to integrate [`mimalloc_rust`](https://github.com/purpleprotocol/mimalloc_rust/), which requires `SSE2` for atomics. 

Since this is the third crate I've attempted to use that has issues due to the same forced override, I decided to try fix the problem in `cc-rs` instead of forking yet another crate just to add `.flag_if_supported("-arch:SSE2")` to be able to build it successfully.

I opted to not add support for AVX512 for now since MSVC bundles *all* AVX512 extensions under the same `-arch:AVX512`, while Rust treats each extension as a separate feature. Adding support for it is possible, but I don't need it myself and I don't know how to do it cleanly, so I'll leave that to someone else. For now it should fallback to `AVX2`, which is still an upgrade over the previous `IA32` (`clang-cl`) / `SSE2` (`cl.exe`).

It's also possible to do the same thing for ARM builds, but since I have no experience with ARM I'll leave that task too for someone else.