### PR TITLE
use debug version of C runtime with MSVC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1487,7 +1487,7 @@ impl Build {
             ToolFamily::Msvc { .. } => {
                 cmd.push_cc_arg("-nologo".into());
 
-                let crt_flag = match self.static_crt {
+                let mut crt_flag: OsString = match self.static_crt {
                     Some(true) => "-MT",
                     Some(false) => "-MD",
                     None => {
@@ -1500,8 +1500,14 @@ impl Build {
                             "-MD"
                         }
                     }
-                };
-                cmd.push_cc_arg(crt_flag.into());
+                }
+                .into();
+
+                if self.get_debug() {
+                    crt_flag.push("d");
+                }
+
+                cmd.push_cc_arg(crt_flag);
 
                 match &opt_level[..] {
                     // Msvc uses /O1 to enable all optimizations that minimize code size.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library

I encountered a link error when linking a Rust library with some C++ built by cc with other C++ code built by CMake because cc wasn't using the debug version of the C runtime.