### PR TITLE
Use dep `jobslot` instead of `jobserver`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.github"]
 edition = "2018"
 
 [dependencies]
-jobslot = { version = "0.2.0", optional = true }
+jobslot = { version = "0.2.4", optional = true }
 
 [features]
 parallel = ["jobslot"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ exclude = ["/.github"]
 edition = "2018"
 
 [dependencies]
-jobserver = { version = "0.1.16", optional = true }
+jobslot = { version = "0.2.0", optional = true }
 
 [features]
-parallel = ["jobserver"]
+parallel = ["jobslot"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1217,12 +1217,12 @@ impl Build {
 
         /// Returns a suitable `jobserver::Client` used to coordinate
         /// parallelism between build scripts.
-        fn jobserver() -> &'static jobserver::Client {
+        fn jobserver() -> &'static jobslot::Client {
             static INIT: Once = Once::new();
-            static mut JOBSERVER: Option<jobserver::Client> = None;
+            static mut JOBSERVER: Option<jobslot::Client> = None;
 
             fn _assert_sync<T: Sync>() {}
-            _assert_sync::<jobserver::Client>();
+            _assert_sync::<jobslot::Client>();
 
             unsafe {
                 INIT.call_once(|| {
@@ -1233,10 +1233,10 @@ impl Build {
             }
         }
 
-        unsafe fn default_jobserver() -> jobserver::Client {
+        unsafe fn default_jobserver() -> jobslot::Client {
             // Try to use the environmental jobserver which Cargo typically
             // initializes for us...
-            if let Some(client) = jobserver::Client::from_env() {
+            if let Some(client) = jobslot::Client::from_env() {
                 return client;
             }
 
@@ -1255,9 +1255,9 @@ impl Build {
 
             // If we create our own jobserver then be sure to reserve one token
             // for ourselves.
-            let client = jobserver::Client::new(parallelism).expect("failed to create jobserver");
+            let client = jobslot::Client::new(parallelism).expect("failed to create jobserver");
             client.acquire_raw().expect("failed to acquire initial");
-            return client;
+            client
         }
 
         struct JoinOnDrop(Option<thread::JoinHandle<Result<(), Error>>>);


### PR DESCRIPTION
## What is jobslot?

jobslot is a fork of jobserver.

## Advantages over `jobserver`?

 - `jobslot` contains bug fix for [Client::configure is unsafe]
 - `jobslot` removed use of signal handling in the helper thread on unix
 - `jobslot` uses `winapi` on windows instead of manually declaring bindings (some of the bindings seem to be wrong)
 - `jobslot` uses `getrandom` on windows instead of making homebrew one using raw windows api

[Client::configure is unsafe]: https://github.com/alexcrichton/jobserver-rs/issues/25

[this PR]: https://github.com/alexcrichton/jobserver-rs/pull/40#issuecomment-1195689752
[`std::os::unix::process::CommandExt::pre_exec`]: https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.pre_exec

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>