### PR TITLE
[msvc] Don't use -M* flags.

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -377,8 +377,7 @@ fn msvc_smoke() {
         .must_have("-O2")
         .must_have("foo.c")
         .must_not_have("-Z7")
-        .must_have("-c")
-        .must_have("-MD");
+        .must_have("-c");
     test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 
@@ -417,22 +416,6 @@ fn msvc_define() {
         .compile("foo");
 
     test.cmd(0).must_have("-DFOO=bar").must_have("-DBAR");
-}
-
-#[test]
-fn msvc_static_crt() {
-    let test = Test::msvc();
-    test.gcc().static_crt(true).file("foo.c").compile("foo");
-
-    test.cmd(0).must_have("-MT");
-}
-
-#[test]
-fn msvc_no_static_crt() {
-    let test = Test::msvc();
-    test.gcc().static_crt(false).file("foo.c").compile("foo");
-
-    test.cmd(0).must_have("-MD");
 }
 
 #[test]


### PR DESCRIPTION
Since this crate doesn't actually make decisions about final application linking, it's only appropriate to not interfere with the process. This can be achieved ~with -MT -Zl, because object modules compiled with these flags can be linked~ by relying on default MSVC behaviour that allows linking with either VCCRT version, static or dynamic, debug or release...

It's suggested to use -Zl when building Rust static library. For reference, -Zl doesn't affect linking directives set with in Windows headers to add references to not-so-common libraries like mfc.lib, windowscodecs.lib to name just a pair.

[Even an alternative solution to #717.]