### PR TITLE
Fix : Properly detect C runtime through target_feature cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1491,10 +1491,7 @@ impl Build {
                     Some(true) => "-MT",
                     Some(false) => "-MD",
                     None => {
-                        let features = self
-                            .getenv("CARGO_CFG_TARGET_FEATURE")
-                            .unwrap_or(String::new());
-                        if features.contains("crt-static") {
+                        if cfg!(target_feature = "crt-static") {
                             "-MT"
                         } else {
                             "-MD"


### PR DESCRIPTION
Currently, the `cc` crate tries to auto-detect the proper C runtime based on the contents of the `CARGO_CFG_TARGET_FEATURE`. Unfortunately, this env variable does not contain an accurate list of target features and may not contain the `crt-static` feature. 

For example, if your project depends on cc and is configured to set the `crt-static` feature through a `.cargo/config.toml` file, `cc` will compile using the dynamic C runtime as it wont be able to see the `crt-static` feature through `CARGO_CFG_TARGET_FEATURE`.

See https://github.com/rust-lang/cargo/issues/6858