### PR TITLE
Support clang >13.1 for aarch64-apple-ios-macabi and x86_64-apple-ios-macabi targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1581,7 +1581,7 @@ impl Build {
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
                             cmd.args
-                                .push(format!("--target={}-apple-ios13.0-macabi", arch).into());
+                                .push(format!("--target={}-apple-ios-macabi", arch).into());
                         }
                     } else if target.contains("ios-sim") {
                         if let Some(arch) =


### PR DESCRIPTION
Please see the details in the issue #726 

This solves the problem for Clang 13.1 and above (including 14.0)

My main concern is that it is going to break the above targets for Clang 13.0 and below. 
Is it acceptable? Maybe we could suggest using older version of the CC crate if you use out of date compiler?

Alternatively, we could check the version of clang used, but I did not find a way to perform this check. Does anyone has any suggestions?

Overall hardcoding 13.0 is very strange idea