### PR TITLE
Prepare release 1.0.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"


### PR DESCRIPTION
This will go out tomorrow or Sunday (hopefully tomorrow).

CC @Mark-Simulacrum, who will need to cut the actual release for now (eventually some automation will crates-maintainers members to manage this, but I'd rather not wait on that, since people have asked me to release the pending changes).