### PR TITLE
Default `emit_rerun_if_env_changed` to true

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ impl Build {
             warnings_into_errors: false,
             env_cache: Arc::new(Mutex::new(HashMap::new())),
             apple_sdk_root_cache: Arc::new(Mutex::new(HashMap::new())),
-            emit_rerun_if_env_changed: false,
+            emit_rerun_if_env_changed: true,
         }
     }
 
@@ -899,7 +899,7 @@ impl Build {
     ///  - `rustc-link-search=native=`*target folder*
     ///  - When target is MSVC, the ATL-MFC libs are added via `rustc-link-search=native=`
     ///  - When C++ is enabled, the C++ stdlib is added via `rustc-link-lib`
-    ///  - If `emit_rerun_if_env_changed` is `true`, `rerun-if-env-changed=`*env*
+    ///  - If `emit_rerun_if_env_changed` is not `false`, `rerun-if-env-changed=`*env*
     ///
     pub fn cargo_metadata(&mut self, cargo_metadata: bool) -> &mut Build {
         self.cargo_metadata = cargo_metadata;
@@ -945,7 +945,7 @@ impl Build {
     ///
     /// This has no effect if the `cargo_metadata` option is `false`.
     ///
-    /// This option defaults to `false`.
+    /// This option defaults to `true`.
     pub fn emit_rerun_if_env_changed(&mut self, emit_rerun_if_env_changed: bool) -> &mut Build {
         self.emit_rerun_if_env_changed = emit_rerun_if_env_changed;
         self


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/cc-rs/pull/701#issuecomment-1295758140, I don't think there's a reason to default this to false. `rerun-if-env-changed` is purely additive (unlike `rerun-if-changed`, which has a fairly good default cleared if you emit it at all), so it should never hurt.

---

I've also added code to skip emitting it for vars that provided by cargo, otherwise every use of `cc` will end up with `cargo:rerun-if-env-changed` invocations for pointless things like `DEBUG`, `OPT_LEVEL`, and so on. I don't think these are likely to hurt anything, but they definitely don't help, and [cargo's docs](https://doc.rust-lang.org/cargo/reference/build-scripts.html?highlight=rerun-if#cargorerun-if-env-changedname) say not to.

An alternative to this would be to add a different function for vars provided by cargo, but that sounds like a headache to maintain, as reviewers could easily not notice the wrong function getting called for a given variable.

---

I'd like to get this in before the release, but mostly for the change of the default (since changing this *after* the release would be breaking) rather than skipping the cargo vars (which is not actually necessary).