### PR TITLE
Prefer `-ar` to `-gcc-ar`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2623,9 +2623,12 @@ impl Build {
             match self.prefix_for_target(&target) {
                 Some(p) => {
                     // GCC uses $target-gcc-ar, whereas binutils uses $target-ar -- try both.
-                    // Prefer -gcc-ar if it exists, since that matches what we'll use for $CC.
+                    // Prefer -ar if it exists, as builds of `-gcc-ar` have been observed to be
+                    // outright broken (such as when targetting freebsd with `--disable-lto`
+                    // toolchain where the archiver attempts to load the LTO plugin anyway but
+                    // fails to find one).
                     let mut ar = default_ar;
-                    for &infix in &["-gcc", ""] {
+                    for &infix in &["", "-gcc"] {
                         let target_ar = format!("{}{}-ar", p, infix);
                         if Command::new(&target_ar).output().is_ok() {
                             ar = target_ar;


### PR DESCRIPTION
As observed in https://github.com/cross-rs/cross/issues/1100, in some situations `*-gcc-ar` might actually be just broken.

I believe this is most likely just a plain bug in gcc (failing to consider `--disable-lto` configuration option somewhere in their build setup,) but for the time being `*-ar` tends to avoid this problem altogether.

Code added in https://github.com/rust-lang/cc-rs/pull/736 appears to be preferring `*-gcc-ar`, but no strong rationale is given to prefer one over the other. `*-gcc-ar` being outright broken sometimes seems like a rationale strong enough to continue preferring binutils’ `ar`.