### PR TITLE
Don't separate files/opt when using msvc assembler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1345,7 +1345,7 @@ impl Build {
         if self.cuda && self.files.len() > 1 {
             cmd.arg("--device-c");
         }
-        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) {
+        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) && !is_asm {
             // #513: For `clang-cl`, separate flags/options from the input file.
             // When cross-compiling macOS -> Windows, this avoids interpreting
             // common `/Users/...` paths as the `/U` flag and triggering


### PR DESCRIPTION
The MSVC assemblers don't support using `--` to mark the end of the options and the start of the "verbatim" file list. When the compiler family is MSVC with clang-cl, the assembler used will be the standard MSVC assembler.

See https://github.com/rust-lang/rust/pull/104152#issuecomment-1307816424