### PR TITLE
Fix "-arch arm64" flag for aarch64-ios-sim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2212,7 +2212,7 @@ impl Build {
             }
         } else if is_sim {
             match arch {
-                "arm64" | "aarch64" => ArchSpec::Simulator("-arch arm64"),
+                "arm64" | "aarch64" => ArchSpec::Simulator("arm64"),
                 "x86_64" => ArchSpec::Simulator("-m64"),
                 _ => {
                     return Err(Error::new(
@@ -2262,7 +2262,13 @@ impl Build {
                 format!("{}os", sdk_prefix)
             }
             ArchSpec::Simulator(arch) => {
-                cmd.args.push(arch.into());
+                if arch.starts_with('-') {
+                    // -m32 or -m64
+                    cmd.args.push(arch.into());
+                } else {
+                    cmd.args.push("-arch".into());
+                    cmd.args.push(arch.into());
+                }
                 cmd.args
                     .push(format!("-m{}simulator-version-min={}", sim_prefix, min_version).into());
                 format!("{}simulator", sdk_prefix)


### PR DESCRIPTION
Passing "-arch arm64" as a single string to clang causes an "argument unused during compilation" warning that becomes an error if -Werror is enabled. Fix passes it as two separate arguments (unfortunately "-arch=arm64" does not work either).