### PR TITLE
Add method for specifying C/C++ standard version

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -367,6 +367,14 @@ fn gnu_no_dash_dash() {
 }
 
 #[test]
+fn gnu_std_c() {
+    let test = Test::gnu();
+    test.gcc().file("foo.c").std("c11").compile("foo");
+
+    test.cmd(0).must_have("-std=c11");
+}
+
+#[test]
 fn msvc_smoke() {
     reset_env();
 
@@ -441,6 +449,14 @@ fn msvc_no_dash_dash() {
     test.gcc().file("foo.c").compile("foo");
 
     test.cmd(0).must_not_have("--");
+}
+
+#[test]
+fn msvc_std_c() {
+    let test = Test::msvc();
+    test.gcc().file("foo.c").std("c11").compile("foo");
+
+    test.cmd(0).must_have("-std:c11");
 }
 
 // Disable this test with the parallel feature because the execution


### PR DESCRIPTION
As requested by https://github.com/rust-lang/cc-rs/issues/565.

Please have a look at the documentation I have included. :)

I am not doing any abstraction over special cases like the name for the work-in-progress standard version. It's just the basics.

I want to propose adding this to `cc` because:

* It should be useful fairly often, considering that using the right standard version can be critical to compiling modern code. I have a C++17 dependency in one of my projects, and I couldn't build my code interfacing with it without specifying the standard version, because even very new compilers seem to default to older versions. As far as I know, the compatibility between C++ versions isn't perfect, so that might be why.
* It can save people the effort of having to consult both GCC/Clang and MSVC documentation, and improve the portability of code from people who haven't tested on Windows:
  * The GCC/Clang and MSVC flag syntaxes are not quite the same, so without support in the `cc` crate, the developer has to write conditional, platform-specific code.
  * The common subset of supported versions between GCC/Clang and MSVC is not something you can intuitively guess. The documentation added here can help.
* While I haven't done that here, it could be enhanced in future to handle special cases like the different names for the WIP future C and C++ standards.