### PR TITLE
Remove bitcode from iOS / watchOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2279,18 +2279,6 @@ impl Build {
 
         cmd.args.push("-isysroot".into());
         cmd.args.push(sdk_path);
-        cmd.args.push("-fembed-bitcode".into());
-        /*
-         * TODO we probably ultimately want the -fembed-bitcode-marker flag
-         * but can't have it now because of an issue in LLVM:
-         * https://github.com/rust-lang/cc-rs/issues/301
-         * https://github.com/rust-lang/rust/pull/48896#comment-372192660
-         */
-        /*
-        if self.get_opt_level()? == "0" {
-            cmd.args.push("-fembed-bitcode-marker".into());
-        }
-        */
 
         Ok(())
     }


### PR DESCRIPTION
Starting with Xcode 14 Apple deprecated bitcode and stopped accepting applications built with it.