### PR TITLE
Update bitcode TODO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2279,18 +2279,8 @@ impl Build {
 
         cmd.args.push("-isysroot".into());
         cmd.args.push(sdk_path);
+        // TODO: Remove this once Apple stops accepting apps built with Xcode 13
         cmd.args.push("-fembed-bitcode".into());
-        /*
-         * TODO we probably ultimately want the -fembed-bitcode-marker flag
-         * but can't have it now because of an issue in LLVM:
-         * https://github.com/rust-lang/cc-rs/issues/301
-         * https://github.com/rust-lang/rust/pull/48896#comment-372192660
-         */
-        /*
-        if self.get_opt_level()? == "0" {
-            cmd.args.push("-fembed-bitcode-marker".into());
-        }
-        */
 
         Ok(())
     }


### PR DESCRIPTION
As of Xcode 14 Bitcode is deprecated but Apple still accepts apps built with bitcode if you're still using Xcode 13. Once Apple stops allowing you to upload apps built with Xcode 13 this argument should be removed.

https://github.com/rust-lang/cc-rs/pull/768