### PR TITLE
fix msbuild from vs2022 not being found

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -866,7 +866,9 @@ mod impl_ {
     // see http://stackoverflow.com/questions/328017/path-to-msbuild
     pub fn find_msbuild(target: &str) -> Option<Tool> {
         // VS 15 (2017) changed how to locate msbuild
-        if let Some(r) = find_msbuild_vs16(target) {
+        if let Some(r) = find_msbuild_vs17(target) {
+            return Some(r);
+        } else if let Some(r) = find_msbuild_vs16(target) {
             return Some(r);
         } else if let Some(r) = find_msbuild_vs15(target) {
             return Some(r);


### PR DESCRIPTION
Without this (and only VS 2022 installed), `find_tool` with `msbuild` returns `C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe` instead of the MSBuild.exe from the actual VS installation.

In other words:

```rs
cc::windows_registry::find_tool("x86_64-pc-windows-msvc", "msbuild.exe").unwrap().path()
```

returns `C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe` instead of something like `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe`, as `find_msbuild` is missing the check for VS17.