### PR TITLE
Add support for riscv32imc-esp-espidf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2947,6 +2947,7 @@ impl Build {
                 "riscv64-unknown-elf",
                 "riscv-none-embed",
             ]),
+            "riscv32imc-esp-espidf" => Some("riscv32-esp-elf"),
             "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
                 "riscv32-unknown-elf",
                 "riscv64-unknown-elf",


### PR DESCRIPTION
This is a Tier 3 supported platform now.