### PR TITLE
Bump MSRV to 1.46.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Rust
-      run: rustup update 1.34.0 --no-self-update && rustup default 1.34.0
+      run: rustup update 1.46.0 --no-self-update && rustup default 1.46.0
       shell: bash
     - run: cargo build
 


### PR DESCRIPTION
Discussed [here](https://rust-lang.zulipchat.com/#narrow/stream/351149-t-libs.2Fcrates/topic/Any.20objections.20to.20bumping.20.60cc.60's.20MSRV).

Motivation is #780, but better to do as a separate patch (both so that I remember to note it in relnotes and because it's not conceptually related to that change)