### PR TITLE
Fix --target cflag on FreeBSD when compiling against clang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1722,19 +1722,22 @@ impl Build {
                         } else if target.contains("aarch64") {
                             cmd.args.push("--target=aarch64-unknown-windows-gnu".into())
                         }
-                    } else if target.ends_with("-freebsd") {
-                        // clang 13 on FreeBSD doesn't support a target triple without at least the
-                        // major os version number appended; e.g. use x86_64-unknown-freebsd13
-                        // instead of x86-64-unknown-freebsd
-                        let uname_r = String::from_utf8(
-                            std::process::Command::new("uname")
-                                .args(&["-r"])
-                                .output()
-                                .expect("Failed to execute uname!")
-                                .stdout,
-                        )
-                        .expect("Failure parsing uname output as UTF-8!");
-                        let os_ver = uname_r.as_str().split('-').next().unwrap();
+                    } else if target.ends_with("-freebsd") && self.get_host()?.eq(target) {
+                        // clang <= 13 on FreeBSD doesn't support a target triple without at least
+                        // the major os version number appended; e.g. use x86_64-unknown-freebsd13
+                        // or x86_64-unknown-freebsd13.0 instead of x86_64-unknown-freebsd.
+                        let stdout = std::process::Command::new("freebsd-version")
+                            .output()
+                            .map_err(|e| {
+                                Error::new(
+                                    ErrorKind::ToolNotFound,
+                                    &format!("Error executing freebsd-version: {}", e),
+                                )
+                            })?
+                            .stdout;
+                        let stdout = String::from_utf8_lossy(&stdout);
+                        let os_ver = stdout.split('-').next().unwrap();
+
                         cmd.push_cc_arg(format!("--target={}{}", target, os_ver).into());
                     } else {
                         cmd.push_cc_arg(format!("--target={}", target).into());


### PR DESCRIPTION
Clang does not/did not support being invoked with a target triple that does not contain at least the major os version tacked on to the end, and will fail to find standard library headers if it's not present [0].

e.g. invoking `clang++` with `--target=x86_64-unknown-freebsd` may present errors like

```
warning: In file included from src/cxx.cc:1:
warning: src/../include/cxx.h:2:10: fatal error: 'algorithm' file not found
warning: #include <algorithm>
warning:          ^~~~~~~~~~~
warning: 1 error generated.

error: failed to run custom build command for `cxx v1.0.81`
```

This is rectified by detecting cases where clang is used and the target triple is set to `xxx-xxx-freebsd` and then invoking `uname -r` to obtain the os version and appending it to the triple before converting it into a `--target=...` argument to the compiler.

This has been fixed upstream in the LLVM project for Clang 14 and above [1], but systems not running the latest bleeding edge will not benefit from that. This issue may be reproduced with clang 13.0.0 on FreeBSD 13.1.

Closes #463.

[0]: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=238556
[1]: https://reviews.llvm.org/D77776

cc @valpackett