### PR TITLE
If a file path references a parent directory, transform it to ensure we keep inside the OUT_DIR

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1037,9 +1037,10 @@ impl Build {
 
         let mut objects = Vec::new();
         for file in self.files.iter() {
-            let obj = if file.has_root() {
-                // If `file` is an absolute path, prefix the `basename`
-                // with the `dirname`'s hash to ensure name uniqueness.
+            let obj = if file.has_root() || file.components().any(|x| x == Component::ParentDir) {
+                // If `file` is an absolute path or might not be usable directly as a suffix due to
+                // using "..", use the `basename` prefixed with the `dirname`'s hash to ensure name
+                // uniqueness.
                 let basename = file
                     .file_name()
                     .ok_or_else(|| Error::new(ErrorKind::InvalidArgument, "file_name() failure"))?


### PR DESCRIPTION
Otherwise, source file paths like `../../../../foo.c` can result in writing `$CARGO_TARGET_DIR/foo.o` (or worse escapes into the wider filesystem).

This is a slightly more aggressive application of object path re-writing than strictly needed to ensure we don't have `OUT_DIR` escapes, but it should be perfectly effective.