### PR TITLE
Check exit status only in `Build::is_flag_supported`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,11 +507,8 @@ impl Build {
             .host(&host)
             .debug(false)
             .cpp(self.cpp)
-            .cuda(self.cuda);
-
-        if !cfg.has_flags() {
-            cfg.warnings_into_errors(true);
-        }
+            .cuda(self.cuda)
+            .warnings_into_errors(true);
 
         if let Some(ref c) = self.compiler {
             cfg.compiler(c.clone());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,8 +6,8 @@ mod support;
 // CFLAGS or CXXFLAGS environment variables.  This function clears the CFLAGS and CXXFLAGS
 // variables to make sure that the tests can run correctly.
 fn reset_env() {
-    std::env::set_var("CFLAGS", "");
-    std::env::set_var("CXXFLAGS", "");
+    std::env::remove_var("CFLAGS");
+    std::env::remove_var("CXXFLAGS");
 }
 
 #[test]


### PR DESCRIPTION
This commit/PR enables warnings_into_errors, which causes the compiler to fail if there is any warning unless user override them by specifying env variable `CFLAGS` or `CXXFLAGS`.

Thus we no longer need to check stderr for warnings and can now only check exit status of the compiler.

This commit also fixed the fn `reset_env` in `tests/test.rs` to use `std::env::remove_var` instead of `std::env::set_env($var, "")`.

This commit/PR is done according to the advice from @mqudsi in https://github.com/rust-lang/cc-rs/pull/784#issuecomment-1414333799

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>