### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 on: [push, pull_request]
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   test:
     name: Test
@@ -64,15 +68,13 @@ jobs:
             rust: stable-x86_64
             target: x86_64-pc-windows-msvc
     steps:
-    - uses: actions/checkout@master
-    - name: Update Rustup (temporary workaround)
-      run: rustup self update
-      shell: bash
-      if: startsWith(matrix.os, 'windows')
+    - uses: actions/checkout@v3
     - name: Install Rust (rustup)
-      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      run: |
+        set -euxo pipefail
+        rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal --target ${{ matrix.target }}
+        rustup default ${{ matrix.rust }}
       shell: bash
-    - run: rustup target add ${{ matrix.target }}
     - name: Install g++-multilib
       run: |
         set -e
@@ -84,7 +86,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install g++-multilib
       if: matrix.build == 'linux32'
-    - run: cargo build
     - run: cargo test ${{ matrix.no_run }}
     - run: cargo test ${{ matrix.no_run }} --features parallel
     - run: cargo test ${{ matrix.no_run }} --manifest-path cc-test/Cargo.toml --target ${{ matrix.target }}
@@ -95,7 +96,7 @@ jobs:
     name: Test CUDA support
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install cuda-minimal-build-11-8
       shell: bash
       run: |
@@ -106,7 +107,8 @@ jobs:
         sudo apt-get -y install cuda-minimal-build-11-8
     - name: Test 'cudart' feature
       shell: bash
-      run: env PATH=/usr/local/cuda/bin:$PATH cargo test --manifest-path cc-test/Cargo.toml --features test_cuda
+      run: |
+        PATH="/usr/local/cuda/bin:$PATH" cargo test --manifest-path cc-test/Cargo.toml --features test_cuda
 
   msrv:
     name: MSRV
@@ -115,17 +117,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update 1.46.0 --no-self-update && rustup default 1.46.0
+      run: |
+        rustup toolchain install 1.46.0 --no-self-update --profile minimal
+        rustup default 1.46.0
       shell: bash
-    - run: cargo build
+    - run: cargo check --lib
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
+      run: |
+        rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
+        rustup default stable
+      shell: bash
     - run: cargo fmt -- --check


### PR DESCRIPTION
 - Disable incremental build since it's always build from scratch
 - Use crates.io sparse registry
 - Use `actions/checkout@v3` instead of the master branch
 - Use `rustup toolchain install` instead of `rustup-update`,
   plus also pass `--profile minimal` for minimum installation.
 - Rm unnecessary `cargo-build` step in job test
 - Run `cargo-check` instead of `cargo-b` in job msrv

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>