### PR TITLE
Be more stringent about handling Android NDK.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3616,13 +3616,12 @@ static NEW_STANDALONE_ANDROID_COMPILERS: [&str; 4] = [
 fn android_clang_compiler_uses_target_arg_internally(clang_path: &Path) -> bool {
     if let Some(filename) = clang_path.file_name() {
         if let Some(filename_str) = filename.to_str() {
-            filename_str.contains("android")
-        } else {
-            false
+            if let Some(idx) = filename_str.rfind("-") {
+                return filename_str.split_at(idx).0.contains("android");
+            }
         }
-    } else {
-        false
     }
+    false
 }
 
 #[test]
@@ -3635,6 +3634,9 @@ fn test_android_clang_compiler_uses_target_arg_internally() {
             &PathBuf::from(format!("armv7a-linux-androideabi{}-clang++", version))
         ));
     }
+    assert!(!android_clang_compiler_uses_target_arg_internally(
+        &PathBuf::from("clang-i686-linux-android")
+    ));
     assert!(!android_clang_compiler_uses_target_arg_internally(
         &PathBuf::from("clang")
     ));


### PR DESCRIPTION
Wrapper scripts for the NDK have the format `<target>-<clang>`, so when checking to see if the filename contains "android" (which will be part of the target), split off the target part of the filename and only check that, instead of checking the entire filename.

This is a very minor improvement, but it is more correct and does have a practical benefit for us on the Android toolchain team: Our build process for rustc uses wrapper scripts that include the target in their name, and the cc crate is misidentifying them as being from the NDK and causing our Windows build to fail without a workaround.