### PR TITLE
Fix linking issue due to missing crt flags on windows msvc targets compiled by clang (not clang-cl).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1587,22 +1587,6 @@ impl Build {
             ToolFamily::Msvc { .. } => {
                 cmd.push_cc_arg("-nologo".into());
 
-                let crt_flag = match self.static_crt {
-                    Some(true) => "-MT",
-                    Some(false) => "-MD",
-                    None => {
-                        let features = self
-                            .getenv("CARGO_CFG_TARGET_FEATURE")
-                            .unwrap_or(String::new());
-                        if features.contains("crt-static") {
-                            "-MT"
-                        } else {
-                            "-MD"
-                        }
-                    }
-                };
-                cmd.push_cc_arg(crt_flag.into());
-
                 match &opt_level[..] {
                     // Msvc uses /O1 to enable all optimizations that minimize code size.
                     "z" | "s" | "1" => cmd.push_opt_unless_duplicate("-O1".into()),
@@ -1647,6 +1631,24 @@ impl Build {
                     }
                 }
             }
+        }
+
+        if target.contains("msvc") {
+            let crt_flag = match self.static_crt {
+                Some(true) => "-MT",
+                Some(false) => "-MD",
+                None => {
+                    let features = self
+                        .getenv("CARGO_CFG_TARGET_FEATURE")
+                        .unwrap_or(String::new());
+                    if features.contains("crt-static") {
+                        "-MT"
+                    } else {
+                        "-MD"
+                    }
+                }
+            };
+            cmd.push_cc_arg(crt_flag.into());
         }
 
         if self.get_debug() {


### PR DESCRIPTION
The msvc runtime library needs to be added for all targets compiled for the windows-msvc abi, regardless of the compiler. There are three options to compile code for windows msvc:
- with the official msvc toolchain
- with clang-cl, which has commandline syntax compatible with the msvc toolchain
- with clang, which uses the GNU commandline syntax.

In all three cases the -MT or -MD flag must be added. Without this commit, the option is only added in the first two cases.