### PR TITLE
Remove -fembed-bitcode flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2530,11 +2530,6 @@ impl Build {
             cmd.args.push(sdk_path);
         }
 
-        // TODO: Remove this once Apple stops accepting apps built with Xcode 13
-        if !is_mac {
-            cmd.args.push("-fembed-bitcode".into());
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Apple has recently stopped accepting apps built with any Xcode version below 14.1, and rejects apps built with bitcode starting with Xcode 14.