### PR TITLE
Use gnu -o flag for obj out path instead of -Fo when using gcc & g++ on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1370,7 +1370,9 @@ impl Build {
             )
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj.dst, self.cuda, msvc, clang, gnu, is_asm, is_arm);
+        command_add_output_file(
+            &mut cmd, &obj.dst, self.cuda, msvc, clang, gnu, is_asm, is_arm,
+        );
         // armasm and armasm64 don't requrie -c option
         if !msvc || !is_asm || !is_arm {
             cmd.arg("-c");


### PR DESCRIPTION
Did the same thing that @datalus did for clang in commit [e0d6380ddc038920e01a4778f9e3947bf8f40c30](https://github.com/rust-lang/cc-rs/pull/483/commits/e0d6380ddc038920e01a4778f9e3947bf8f40c30)
Resolves issues [#800](https://github.com/rust-lang/cc-rs/issues/800) and [#819](https://github.com/rust-lang/cc-rs/issues/819)