### PR TITLE
Disambiguate Windows run-times when using clang to compile.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2549,13 +2549,7 @@ impl Build {
         }
 
         if target.contains("msvc") && tool.family == ToolFamily::Gnu {
-            println!(
-                concat!(
-                    "cargo:warning=GNU compiler is not supported for this target, ",
-                    "consider --target={} instead."
-                ),
-                target.replace("msvc", "gnu")
-            );
+            println!("cargo:warning=GNU compiler is not supported for this target");
         }
 
         Ok(tool)


### PR DESCRIPTION
This is with reference to https://github.com/rust-lang/cc-rs/issues/819#issuecomment-1640309753. In the comment I'm suggesting to take it as far as rejecting the use of gcc in the msvc compilation, while this PR only issues a warning.