### PR TITLE
add armv8r-none-eabihf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3036,6 +3036,7 @@ impl Build {
             "armebv7r-none-eabihf" => Some("arm-none-eabi"),
             "armv7r-none-eabi" => Some("arm-none-eabi"),
             "armv7r-none-eabihf" => Some("arm-none-eabi"),
+            "armv8r-none-eabihf" => Some("arm-none-eabi"),
             "thumbv6m-none-eabi" => Some("arm-none-eabi"),
             "thumbv7em-none-eabi" => Some("arm-none-eabi"),
             "thumbv7em-none-eabihf" => Some("arm-none-eabi"),


### PR DESCRIPTION
Let cc-rs recognize the armv8r-none-eabihf target.

Related to rust-lang/rust#110482.
