### PR TITLE
fix(flag_check): never link to avoid false positives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,11 +535,8 @@ impl Build {
             is_arm,
         );
 
-        // We need to explicitly tell msvc not to link and create an exe
-        // in the root directory of the crate
-        if target.contains("msvc") && !self.cuda {
-            cmd.arg("-c");
-        }
+        // Checking for compiler flags does not require linking
+        cmd.arg("-c");
 
         cmd.arg(&src);
 


### PR DESCRIPTION
Using `flag_if_supported` when targeting `wasm32-unknown-unknown` often (or maybe always) results in false negatives, causing supported flags to not be applied. This happens, because `clang` is trying to link the binary with `wasm-ld` which must be installed, and even with `wasm-ld` installed `clang` still gives me this error:

```
wasm-ld: error: unknown file type: /lib/crt1.o
wasm-ld: error: cannot open /usr/lib/clang/15.0.7/lib/libclang_rt.builtins-wasm32.a: No such file or directory
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is easily avoided by telling clang to skip linking by using `-c`.