### PR TITLE
Bump version to 1.0.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.80"
+version = "1.0.81"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"


### PR DESCRIPTION
This only has https://github.com/rust-lang/cc-rs/pull/842, but it seems fairly bad, so I'd like to put out a release.