### PR TITLE
Use rustc's Apple deployment target defaults when available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1832,8 +1832,8 @@ impl Build {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
-                            let deployment_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
-                                .unwrap_or_else(|_| "7.0".into());
+                            let deployment_target =
+                                self.apple_deployment_version(AppleOs::Ios, target, None);
                             cmd.args.push(
                                 format!(
                                     "--target={}-apple-ios{}-simulator",
@@ -1846,8 +1846,8 @@ impl Build {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
-                            let deployment_target = env::var("WATCHOS_DEPLOYMENT_TARGET")
-                                .unwrap_or_else(|_| "5.0".into());
+                            let deployment_target =
+                                self.apple_deployment_version(AppleOs::WatchOs, target, None);
                             cmd.args.push(
                                 format!(
                                     "--target={}-apple-watchos{}-simulator",
@@ -2450,7 +2450,7 @@ impl Build {
             }
         };
 
-        let min_version = self.apple_deployment_version(os, &target, arch_str);
+        let min_version = self.apple_deployment_version(os, &target, Some(arch_str));
         let (sdk_prefix, sim_prefix) = match os {
             AppleOs::MacOs => ("macosx", ""),
             AppleOs::Ios => ("iphone", "ios-"),
@@ -3404,7 +3404,12 @@ impl Build {
         Ok(ret)
     }
 
-    fn apple_deployment_version(&self, os: AppleOs, target: &str, arch_str: &str) -> String {
+    fn apple_deployment_version(
+        &self,
+        os: AppleOs,
+        target: &str,
+        arch_str: Option<&str>,
+    ) -> String {
         fn rustc_provided_target(rustc: Option<&str>, target: &str) -> Option<String> {
             let rustc = rustc?;
             let output = Command::new(rustc)
@@ -3438,7 +3443,7 @@ impl Build {
                 .ok()
                 .or_else(|| rustc_provided_target(rustc, target))
                 .unwrap_or_else(|| {
-                    if arch_str == "aarch64" {
+                    if arch_str == Some("aarch64") {
                         "11.0"
                     } else {
                         "10.7"
@@ -3452,7 +3457,7 @@ impl Build {
             AppleOs::WatchOs => env::var("WATCHOS_DEPLOYMENT_TARGET")
                 .ok()
                 .or_else(|| rustc_provided_target(rustc, target))
-                .unwrap_or_else(|| "2.0".into()),
+                .unwrap_or_else(|| "5.0".into()),
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -475,3 +475,21 @@ fn asm_flags() {
     test.cmd(1).must_have("--abc");
     test.cmd(2).must_have("--abc");
 }
+
+#[test]
+fn gnu_apple_darwin() {
+    for (arch, version) in &[("x86_64", "10.7"), ("aarch64", "11.0")] {
+        let target = format!("{}-apple-darwin", arch);
+        let test = Test::gnu();
+        test.gcc()
+            .target(&target)
+            .host(&target)
+            // Avoid test maintainence when minimum supported OSes change.
+            .__set_env("MACOSX_DEPLOYMENT_TARGET", version)
+            .file("foo.c")
+            .compile("foo");
+
+        test.cmd(0)
+            .must_have(format!("-mmacosx-version-min={}", version));
+    }
+}


### PR DESCRIPTION
To follow on https://github.com/rust-lang/rust/pull/105354 being released in 1.71, and soon https://github.com/rust-lang/rust/pull/104385, the changeset here aims to make Apple deployment targets more consistent and support future minimum bumps better. To do so, the root change is to try asking `rustc` for what it thinks the default deployment target version is before using a hardcoded one after `cc` checks the environment directly for an overridden version. For any users who aren't on 1.71+, everything will work exactly the same.

While in the area, duplication of checking the iOS and watchOS default deployment target elsewhere in the library was removed and a bad watchOS version (2.0 -> 5.0) was corrected. 

Also, this branch forks from #708 and has a rebased version of its one commit. If only GitHub supported stacked PRs... Due to that though, its better to review this per commit. 