### PR TITLE
Release cc v1.0.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.81"
+version = "1.0.82"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"


### PR DESCRIPTION
To fix the performance regression and potential deadlock in v1.0.82.