### PR TITLE
Separate source args with -- when compiling assembly with clang-cl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1479,7 +1479,8 @@ impl Build {
         let clang = compiler.family == ToolFamily::Clang;
         let gnu = compiler.family == ToolFamily::Gnu;
 
-        let (mut cmd, name) = if msvc && asm_ext == Some(AsmFileExt::DotAsm) {
+        let is_assembler_msvc = msvc && asm_ext == Some(AsmFileExt::DotAsm);
+        let (mut cmd, name) = if is_assembler_msvc {
             self.msvc_macro_assembler()?
         } else {
             let mut cmd = compiler.to_command();
@@ -1510,7 +1511,7 @@ impl Build {
         if is_asm {
             cmd.args(self.asm_flags.iter().map(std::ops::Deref::deref));
         }
-        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) && !is_asm {
+        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) && !is_assembler_msvc {
             // #513: For `clang-cl`, separate flags/options from the input file.
             // When cross-compiling macOS -> Windows, this avoids interpreting
             // common `/Users/...` paths as the `/U` flag and triggering


### PR DESCRIPTION
Currently, when compiling with clang-cl, we separate the source from the arguments by inserting a `--`. This avoids compilation errors due to conflicts between source paths and arguments (especially on macos, where path will often begin with /Users, but /U is a clang-cl flag).

However, this separator is disabled when we are compiling assembly for msvc targets, as those will usually be compiled through `ml.exe`, which doesn't understand this separator. Problem is, this is not always the case: Only `.asm` files are compiled using `ml.exe`. Any asm using a different extension will still go through the normal C compiler (clang-cl), and hence we need to provide the separator in that case.