### PR TITLE
Don't pass compiler flags to MSVC assembers.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2220,9 +2220,6 @@ impl Build {
         if target.contains("i686") || target.contains("i586") {
             cmd.arg("-safeseh");
         }
-        for flag in self.flags.iter() {
-            cmd.arg(&**flag);
-        }
 
         Ok((cmd, tool.to_string()))
     }


### PR DESCRIPTION
While ml[64] ignores the compiler flags with warnings, armasm[64] rejects them and fails.