### PR TITLE
Be more specific about not passing -c to armasm[64].exe.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1535,7 +1535,7 @@ impl Build {
             &mut cmd, &obj.dst, self.cuda, msvc, clang, gnu, is_asm, is_arm,
         );
         // armasm and armasm64 don't requrie -c option
-        if !msvc || !is_asm || !is_arm {
+        if !is_assembler_msvc || !is_arm {
             cmd.arg("-c");
         }
         if self.cuda && self.cuda_file_count() > 1 {


### PR DESCRIPTION
4ce411709170197228d353aa2bbf385efe3b958a passes non-.asm files to the C compiler driver, which unlike armasm[64].exe does require -c flag.