### PR TITLE
minimal maxosx deployment target is 10.9 when cpp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3464,7 +3464,11 @@ impl Build {
                     if arch_str == Some("aarch64") {
                         "11.0"
                     } else {
-                        "10.7"
+                        if self.cpp {
+                            "10.9"
+                        } else {
+                            "10.7"
+                        }
                     }
                     .into()
                 }),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -343,11 +343,9 @@ fn gnu_flag_if_supported() {
         .must_not_have("-std=c++11");
 }
 
+#[cfg(not(windows))]
 #[test]
 fn gnu_flag_if_supported_cpp() {
-    if cfg!(windows) {
-        return;
-    }
     let test = Test::gnu();
     test.gcc()
         .cpp(true)


### PR DESCRIPTION
It was the cause of gnu_flag_if_supported_cpp failure on macOS