### PR TITLE
refactor target flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1890,93 +1890,39 @@ impl Build {
         }
 
         // Target flags
+        if target.contains("-apple-") {
+            self.apple_flags(cmd, target)?;
+        } else {
+            self.target_flags(cmd, target);
+        }
+
+        if self.static_flag.unwrap_or(false) {
+            cmd.args.push("-static".into());
+        }
+        if self.shared_flag.unwrap_or(false) {
+            cmd.args.push("-shared".into());
+        }
+
+        if self.cpp {
+            match (self.cpp_set_stdlib.as_ref(), cmd.family) {
+                (None, _) => {}
+                (Some(stdlib), ToolFamily::Gnu) | (Some(stdlib), ToolFamily::Clang) => {
+                    cmd.push_cc_arg(format!("-stdlib=lib{}", stdlib).into());
+                }
+                _ => {
+                    self.cargo_output.print_warning(&format_args!("cpp_set_stdlib is specified, but the {:?} compiler does not support this option, ignored", cmd.family));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn target_flags(&self, cmd: &mut Tool, target: &str) {
         match cmd.family {
             ToolFamily::Clang => {
                 if !(target.contains("android") && cmd.has_internal_target_arg) {
-                    if target.contains("darwin") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            cmd.args
-                                .push(format!("--target={}-apple-darwin", arch).into());
-                        }
-                    } else if target.contains("macabi") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            cmd.args
-                                .push(format!("--target={}-apple-ios-macabi", arch).into());
-                        }
-                    } else if target.contains("ios-sim") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            let sdk_details =
-                                apple_os_sdk_parts(AppleOs::Ios, &AppleArchSpec::Simulator(""));
-                            let deployment_target =
-                                self.apple_deployment_version(AppleOs::Ios, None, &sdk_details.sdk);
-                            cmd.args.push(
-                                format!(
-                                    "--target={}-apple-ios{}-simulator",
-                                    arch, deployment_target
-                                )
-                                .into(),
-                            );
-                        }
-                    } else if target.contains("watchos-sim") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            let sdk_details =
-                                apple_os_sdk_parts(AppleOs::WatchOs, &AppleArchSpec::Simulator(""));
-                            let deployment_target = self.apple_deployment_version(
-                                AppleOs::WatchOs,
-                                None,
-                                &sdk_details.sdk,
-                            );
-                            cmd.args.push(
-                                format!(
-                                    "--target={}-apple-watchos{}-simulator",
-                                    arch, deployment_target
-                                )
-                                .into(),
-                            );
-                        }
-                    } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            let sdk_details =
-                                apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Simulator(""));
-                            let deployment_target = self.apple_deployment_version(
-                                AppleOs::TvOs,
-                                None,
-                                &sdk_details.sdk,
-                            );
-                            cmd.args.push(
-                                format!(
-                                    "--target={}-apple-tvos{}-simulator",
-                                    arch, deployment_target
-                                )
-                                .into(),
-                            );
-                        }
-                    } else if target.contains("aarch64-apple-tvos") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            let sdk_details =
-                                apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Device(""));
-                            let deployment_target = self.apple_deployment_version(
-                                AppleOs::TvOs,
-                                None,
-                                &sdk_details.sdk,
-                            );
-                            cmd.args.push(
-                                format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
-                            );
-                        }
-                    } else if target.starts_with("riscv64gc-") {
+                    if target.starts_with("riscv64gc-") {
                         cmd.args.push(
                             format!("--target={}", target.replace("riscv64gc", "riscv64")).into(),
                         );
@@ -2059,14 +2005,6 @@ impl Build {
                 }
             }
             ToolFamily::Gnu => {
-                if target.contains("darwin") {
-                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
-                    {
-                        cmd.args.push("-arch".into());
-                        cmd.args.push(arch.into());
-                    }
-                }
-
                 if target.contains("-kmc-solid_") {
                     cmd.args.push("-finput-charset=utf-8".into());
                 }
@@ -2254,31 +2192,6 @@ impl Build {
                 }
             }
         }
-
-        if target.contains("-apple-") {
-            self.apple_flags(cmd)?;
-        }
-
-        if self.static_flag.unwrap_or(false) {
-            cmd.args.push("-static".into());
-        }
-        if self.shared_flag.unwrap_or(false) {
-            cmd.args.push("-shared".into());
-        }
-
-        if self.cpp {
-            match (self.cpp_set_stdlib.as_ref(), cmd.family) {
-                (None, _) => {}
-                (Some(stdlib), ToolFamily::Gnu) | (Some(stdlib), ToolFamily::Clang) => {
-                    cmd.push_cc_arg(format!("-stdlib=lib{}", stdlib).into());
-                }
-                _ => {
-                    self.cargo_output.print_warning(&format_args!("cpp_set_stdlib is specified, but the {:?} compiler does not support this option, ignored", cmd.family));
-                }
-            }
-        }
-
-        Ok(())
     }
 
     fn has_flags(&self) -> bool {
@@ -2469,8 +2382,7 @@ impl Build {
         Ok(())
     }
 
-    fn apple_flags(&self, cmd: &mut Tool) -> Result<(), Error> {
-        let target = self.get_target()?;
+    fn apple_flags(&self, cmd: &mut Tool, target: &str) -> Result<(), Error> {
         let os = if target.contains("-darwin") {
             AppleOs::MacOs
         } else if target.contains("-watchos") {
@@ -2599,6 +2511,87 @@ impl Build {
 
             cmd.args.push("-isysroot".into());
             cmd.args.push(sdk_path);
+        }
+
+        match cmd.family {
+            ToolFamily::Gnu => {
+                if target.contains("darwin") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        cmd.args.push("-arch".into());
+                        cmd.args.push(arch.into());
+                    }
+                }
+            }
+            ToolFamily::Clang => {
+                if target.contains("darwin") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        cmd.args
+                            .push(format!("--target={}-apple-darwin", arch).into());
+                    }
+                } else if target.contains("macabi") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        cmd.args
+                            .push(format!("--target={}-apple-ios-macabi", arch).into());
+                    }
+                } else if target.contains("ios-sim") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        let sdk_details =
+                            apple_os_sdk_parts(AppleOs::Ios, &AppleArchSpec::Simulator(""));
+                        let deployment_target =
+                            self.apple_deployment_version(AppleOs::Ios, None, &sdk_details.sdk);
+                        cmd.args.push(
+                            format!("--target={}-apple-ios{}-simulator", arch, deployment_target)
+                                .into(),
+                        );
+                    }
+                } else if target.contains("watchos-sim") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        let sdk_details =
+                            apple_os_sdk_parts(AppleOs::WatchOs, &AppleArchSpec::Simulator(""));
+                        let deployment_target =
+                            self.apple_deployment_version(AppleOs::WatchOs, None, &sdk_details.sdk);
+                        cmd.args.push(
+                            format!(
+                                "--target={}-apple-watchos{}-simulator",
+                                arch, deployment_target
+                            )
+                            .into(),
+                        );
+                    }
+                } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        let sdk_details =
+                            apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Simulator(""));
+                        let deployment_target =
+                            self.apple_deployment_version(AppleOs::TvOs, None, &sdk_details.sdk);
+                        cmd.args.push(
+                            format!(
+                                "--target={}-apple-tvos{}-simulator",
+                                arch, deployment_target
+                            )
+                            .into(),
+                        );
+                    }
+                } else if target.contains("aarch64-apple-tvos") {
+                    if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
+                    {
+                        let sdk_details =
+                            apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Device(""));
+                        let deployment_target =
+                            self.apple_deployment_version(AppleOs::TvOs, None, &sdk_details.sdk);
+                        cmd.args.push(
+                            format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
+                        );
+                    }
+                }
+            }
+            _ => unreachable!("unexpected compiler for apple architectures"),
         }
 
         if let AppleArchSpec::Catalyst(_) = arch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2539,55 +2539,30 @@ impl Build {
                 } else if target.contains("ios-sim") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {
-                        let sdk_details =
-                            apple_os_sdk_parts(AppleOs::Ios, &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(AppleOs::Ios, None, &sdk_details.sdk);
                         cmd.args.push(
-                            format!("--target={}-apple-ios{}-simulator", arch, deployment_target)
-                                .into(),
+                            format!("--target={}-apple-ios{}-simulator", arch, min_version).into(),
                         );
                     }
                 } else if target.contains("watchos-sim") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {
-                        let sdk_details =
-                            apple_os_sdk_parts(AppleOs::WatchOs, &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(AppleOs::WatchOs, None, &sdk_details.sdk);
                         cmd.args.push(
-                            format!(
-                                "--target={}-apple-watchos{}-simulator",
-                                arch, deployment_target
-                            )
-                            .into(),
+                            format!("--target={}-apple-watchos{}-simulator", arch, min_version)
+                                .into(),
                         );
                     }
                 } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {
-                        let sdk_details =
-                            apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(AppleOs::TvOs, None, &sdk_details.sdk);
                         cmd.args.push(
-                            format!(
-                                "--target={}-apple-tvos{}-simulator",
-                                arch, deployment_target
-                            )
-                            .into(),
+                            format!("--target={}-apple-tvos{}-simulator", arch, min_version).into(),
                         );
                     }
                 } else if target.contains("aarch64-apple-tvos") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {
-                        let sdk_details =
-                            apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Device(""));
-                        let deployment_target =
-                            self.apple_deployment_version(AppleOs::TvOs, None, &sdk_details.sdk);
-                        cmd.args.push(
-                            format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
-                        );
+                        cmd.args
+                            .push(format!("--target={}-apple-tvos{}", arch, min_version).into());
                     }
                 }
             }


### PR DESCRIPTION
Since Apple architectures have very specific ways of dealing with compiler flags, dividing Apple and the rest of the architecture helps lump similar logic together. We will not have to fix 2 unrelated places for Apple architecture issues anymore.

Now deployment target version is reused for both architecture and target. I didn't finish it here yet, but target handling can be smarter by reusing architecture handling result.