### PR TITLE
feat: Use channels to maintain job tokens & reuse the implicit token without dropping it first

### DIFF
--- a/src/job_token.rs
+++ b/src/job_token.rs
@@ -39,7 +39,8 @@ pub(crate) struct JobTokenServer {
 impl JobTokenServer {
     pub(crate) fn new(client: Client) -> Result<Self, crate::Error> {
         let (tx, rx) = mpsc::channel();
-        // Initialize the
+        // Push the implicit token. Since JobTokens only give back what they got,
+        // there should be at most one global implicit token in the wild.
         tx.send(None).unwrap();
         let pool = tx.clone();
         let helper = client.into_helper_thread(move |acq| {

--- a/src/job_token.rs
+++ b/src/job_token.rs
@@ -1,4 +1,4 @@
-use jobserver::{Acquired, Client, HelperThread};
+use jobserver::{Acquired, HelperThread};
 use std::{
     env,
     sync::{
@@ -47,7 +47,8 @@ pub(crate) struct JobTokenServer {
 }
 
 impl JobTokenServer {
-    pub(crate) fn new(client: Client) -> Result<Self, crate::Error> {
+    pub(crate) fn new() -> Result<Self, crate::Error> {
+        let client = jobserver();
         let (tx, rx) = mpsc::channel();
         // Push the implicit token. Since JobTokens only give back what they got,
         // there should be at most one global implicit token in the wild.
@@ -77,7 +78,7 @@ impl JobTokenServer {
 
 /// Returns a suitable `jobserver::Client` used to coordinate
 /// parallelism between build scripts.
-pub(super) fn jobserver() -> jobserver::Client {
+fn jobserver() -> jobserver::Client {
     static INIT: Once = Once::new();
     static mut JOBSERVER: Option<jobserver::Client> = None;
 

--- a/src/job_token.rs
+++ b/src/job_token.rs
@@ -40,7 +40,7 @@ impl JobToken {
 /// gives out tokens without exposing whether they're implicit tokens or tokens from jobserver.
 /// Furthermore, instead of giving up job tokens, it keeps them around
 /// for reuse if we know we're going to request another token after freeing the current one.
-pub(crate) struct JobTokenServer {
+pub(crate) struct GlobalJobTokenServer {
     helper: HelperThread,
     tx: Sender<Option<Acquired>>,
     rx: Receiver<Option<Acquired>>,
@@ -60,7 +60,7 @@ impl JobTokenServer {
         Ok(Self { helper, tx, rx })
     }
 
-    pub(crate) fn acquire(&mut self) -> JobToken {
+    pub(crate) fn acquire(&self) -> JobToken {
         let token = if let Ok(token) = self.rx.try_recv() {
             // Opportunistically check if there's a token that can be reused.
             token

--- a/src/job_token.rs
+++ b/src/job_token.rs
@@ -1,0 +1,66 @@
+use jobserver::{Acquired, Client, HelperThread};
+use std::sync::mpsc::{self, Receiver, Sender};
+
+pub(crate) struct JobToken {
+    /// The token can either be a fresh token obtained from the jobserver or - if `token` is None - an implicit token for this process.
+    /// Both are valid values to put into queue.
+    token: Option<Acquired>,
+    pool: Sender<Option<Acquired>>,
+    should_return_to_queue: bool,
+}
+
+impl Drop for JobToken {
+    fn drop(&mut self) {
+        if self.should_return_to_queue {
+            let _ = self.pool.send(self.token.take());
+        }
+    }
+}
+
+impl JobToken {
+    /// Ensure that this token is not put back into queue once it's dropped.
+    /// This also leads to releasing it sooner for other processes to use, which is a good thing to do once you know that
+    /// you're never going to request a token in this process again.
+    pub(crate) fn forget(&mut self) {
+        self.should_return_to_queue = false;
+    }
+}
+
+/// A thin wrapper around jobserver's Client.
+/// It would be perfectly fine to just use that, but we also want to reuse our own implicit token assigned for this build script.
+/// This struct manages that and gives out tokens without exposing whether they're implicit tokens or tokens from jobserver.
+/// Furthermore, instead of giving up job tokens, it keeps them around for reuse if we know we're going to request another token after freeing the current one.
+pub(crate) struct JobTokenServer {
+    helper: HelperThread,
+    tx: Sender<Option<Acquired>>,
+    rx: Receiver<Option<Acquired>>,
+}
+
+impl JobTokenServer {
+    pub(crate) fn new(client: Client) -> Result<Self, crate::Error> {
+        let (tx, rx) = mpsc::channel();
+        // Initialize the
+        tx.send(None).unwrap();
+        let pool = tx.clone();
+        let helper = client.into_helper_thread(move |acq| {
+            let _ = pool.send(Some(acq.unwrap()));
+        })?;
+        Ok(Self { helper, tx, rx })
+    }
+
+    pub(crate) fn acquire(&mut self) -> JobToken {
+        let token = if let Ok(token) = self.rx.try_recv() {
+            // Opportunistically check if we already have a token for our own reuse.
+            token
+        } else {
+            // Cold path, request a token and block
+            self.helper.request_token();
+            self.rx.recv().unwrap()
+        };
+        JobToken {
+            token,
+            pool: self.tx.clone(),
+            should_return_to_queue: true,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1427,7 +1427,7 @@ impl Build {
         })?;
         for obj in objs {
             let (mut cmd, program) = self.create_compile_object_cmd(obj)?;
-            let token = tokens.acquire();
+            let token = tokens.acquire()?;
             let child = spawn(&mut cmd, &program, print.pipe_writer_cloned()?.unwrap())?;
 
             tx.send((cmd, program, KillOnDrop(child), token))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,7 +1306,7 @@ impl Build {
         }
 
         // Limit our parallelism globally with a jobserver.
-        let mut tokens = crate::job_token::JobTokenServer::new()?;
+        let tokens = crate::job_token::JobTokenServer::new()?;
 
         // When compiling objects in parallel we do a few dirty tricks to speed
         // things up:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1294,7 +1294,7 @@ impl Build {
 
     #[cfg(feature = "parallel")]
     fn compile_objects(&self, objs: &[Object], print: &PrintThread) -> Result<(), Error> {
-        use std::sync::mpsc;
+        use std::sync::{mpsc, Once};
 
         if objs.len() <= 1 {
             for obj in objs {
@@ -1306,7 +1306,7 @@ impl Build {
         }
 
         // Limit our parallelism globally with a jobserver.
-        let server = unsafe { default_jobserver() };
+        let server = jobserver();
         // Reacquire our process's token on drop
 
         // When compiling objects in parallel we do a few dirty tricks to speed
@@ -1437,6 +1437,24 @@ impl Build {
         drop(tx);
 
         return wait_thread.join().expect("wait_thread panics");
+
+        /// Returns a suitable `jobserver::Client` used to coordinate
+        /// parallelism between build scripts.
+        fn jobserver() -> jobserver::Client {
+            static INIT: Once = Once::new();
+            static mut JOBSERVER: Option<jobserver::Client> = None;
+
+            fn _assert_sync<T: Sync>() {}
+            _assert_sync::<jobserver::Client>();
+
+            unsafe {
+                INIT.call_once(|| {
+                    let server = default_jobserver();
+                    JOBSERVER = Some(server);
+                });
+                JOBSERVER.clone().unwrap()
+            }
+        }
 
         unsafe fn default_jobserver() -> jobserver::Client {
             // Try to use the environmental jobserver which Cargo typically

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1342,9 +1342,11 @@ impl Build {
             loop {
                 let mut has_made_progress = false;
                 // If the other end of the pipe is already disconnected, then we're not gonna get any new jobs,
-                // so it doesn't make sense to reuse the tokens; in fact, releasing them as soon as possible (once we know that the other end is disconnected) is beneficial.
-                // Imagine that the last file built takes an hour to finish; in this scenario, by not releasing the tokens before other builds are done we'd effectively block other processes from
-                // starting sooner - even though we only need one token, not however many we've acquired.
+                // so it doesn't make sense to reuse the tokens; in fact,
+                // releasing them as soon as possible (once we know that the other end is disconnected) is beneficial.
+                // Imagine that the last file built takes an hour to finish; in this scenario,
+                // by not releasing the tokens before that last file is done we would effectively block other processes from
+                // starting sooner - even though we only need one token for that last file, not N others that were acquired.
                 let mut is_disconnected = false;
                 // Reading new pending tasks
                 loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,8 +1306,7 @@ impl Build {
         }
 
         // Limit our parallelism globally with a jobserver.
-        let server = job_token::jobserver();
-        // Reacquire our process's token on drop
+        let mut tokens = crate::job_token::JobTokenServer::new()?;
 
         // When compiling objects in parallel we do a few dirty tricks to speed
         // things up:
@@ -1426,7 +1425,6 @@ impl Build {
                 };
             }
         })?;
-        let mut tokens = crate::job_token::JobTokenServer::new(server)?;
         for obj in objs {
             let (mut cmd, program) = self.create_compile_object_cmd(obj)?;
             let token = tokens.acquire();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,7 +1306,7 @@ impl Build {
         }
 
         // Limit our parallelism globally with a jobserver.
-        let tokens = crate::job_token::JobTokenServer::new()?;
+        let tokens = crate::job_token::JobTokenServer::new();
 
         // When compiling objects in parallel we do a few dirty tricks to speed
         // things up:


### PR DESCRIPTION
This is a follow-up to #779 and addressing #858. This approach uses an additional thread for polling the jobserver. 
Per my local tests, it fixes #858 