### PR TITLE
fix: Add apple tvos support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2620,6 +2620,8 @@ impl Build {
                     clang.to_string()
                 } else if target.contains("apple-watchos") {
                     clang.to_string()
+                } else if target.contains("apple-tvos") {
+                    clang.to_string()
                 } else if target.contains("android") {
                     autodetect_android_compiler(&target, &host, gnu, clang)
                 } else if target.contains("cloudabi") {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -507,33 +507,3 @@ fn gnu_apple_darwin() {
         cmd.must_not_have("-isysroot");
     }
 }
-
-#[cfg(target_os = "macos")]
-#[test]
-fn apple_tvos() {
-    for target in &["aarch64-apple-tvos"] {
-        let test = Test::gnu();
-        test.gcc()
-            .target(&target)
-            .host(&target)
-            .file("foo.c")
-            .compile("foo");
-
-        test.cmd(0).must_have("-mappletvos-version-min=9.0");
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn apple_tvsimulator() {
-    for target in &["x86_64-apple-tvos"] {
-        let test = Test::gnu();
-        test.gcc()
-            .target(&target)
-            .host(&target)
-            .file("foo.c")
-            .compile("foo");
-
-        test.cmd(0).must_have("-mappletvsimulator-version-min=9.0");
-    }
-}


### PR DESCRIPTION
This PR allows using cc-rs lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):
- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64

As clang should be used with this target, I've removed tests added on https://github.com/rust-lang/cc-rs/pull/704 that require gcc.
