### PR TITLE
fix: Add apple tvos support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,24 @@ jobs:
     - run: cargo test ${{ matrix.no_run }} --manifest-path cc-test/Cargo.toml --target ${{ matrix.target }} --features parallel
     - run: cargo test ${{ matrix.no_run }} --manifest-path cc-test/Cargo.toml --target ${{ matrix.target }} --release
 
+  check-tvos:
+    name: Test aarch64-apple-tvos
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust (rustup)
+      run: |
+        set -euxo pipefail
+        rustup toolchain install nightly --no-self-update --profile minimal
+        rustup component add rust-src --toolchain nightly
+        rustup default nightly
+      shell: bash
+    - run: cargo test -Z build-std=std --no-run --target aarch64-apple-tvos
+    - run: cargo test -Z build-std=std --no-run --features parallel --target aarch64-apple-tvos
+    - run: cargo test -Z build-std=std --no-run --manifest-path cc-test/Cargo.toml --target aarch64-apple-tvos
+    - run: cargo test -Z build-std=std --no-run --manifest-path cc-test/Cargo.toml --target aarch64-apple-tvos --features parallel
+    - run: cargo test -Z build-std=std --no-run --manifest-path cc-test/Cargo.toml --target aarch64-apple-tvos --release
+
   cuda:
     name: Test CUDA support
     runs-on: ubuntu-20.04

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,6 +1840,16 @@ impl Build {
                                 .into(),
                             );
                         }
+                    } else if target.contains("aarch64-apple-tvos") {
+                        if let Some(arch) =
+                            map_darwin_target_from_rust_to_compiler_architecture(target)
+                        {
+                            let deployment_target =
+                                self.apple_deployment_version(AppleOs::TvOs, target, None);
+                            cmd.args.push(
+                                format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
+                            );
+                        }
                     } else if target.starts_with("riscv64gc-") {
                         cmd.args.push(
                             format!("--target={}", target.replace("riscv64gc", "riscv64")).into(),
@@ -2576,6 +2586,8 @@ impl Build {
                 } else if target.contains("apple-ios") {
                     clang.to_string()
                 } else if target.contains("apple-watchos") {
+                    clang.to_string()
+                } else if target.contains("apple-tvos") {
                     clang.to_string()
                 } else if target.contains("android") {
                     autodetect_android_compiler(&target, &host, gnu, clang)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -61,6 +61,12 @@ impl Test {
         t
     }
 
+    pub fn clang() -> Test {
+        let t = Test::new();
+        t.shim("clang").shim("clang++").shim("ar");
+        t
+    }
+
     pub fn shim(&self, name: &str) -> &Test {
         let name = if name.ends_with(env::consts::EXE_SUFFIX) {
             name.to_string()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -510,9 +510,9 @@ fn gnu_apple_darwin() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn apple_tvos() {
+fn clang_apple_tvos() {
     for target in &["aarch64-apple-tvos"] {
-        let test = Test::gnu();
+        let test = Test::clang();
         test.gcc()
             .target(&target)
             .host(&target)
@@ -525,9 +525,9 @@ fn apple_tvos() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn apple_tvsimulator() {
+fn clang_apple_tvsimulator() {
     for target in &["x86_64-apple-tvos"] {
-        let test = Test::gnu();
+        let test = Test::clang();
         test.gcc()
             .target(&target)
             .host(&target)


### PR DESCRIPTION
This PR allows using cc-rs lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

    Apple tvOS on aarch64
    Apple tvOS Simulator on x86_64

~~As clang should be used with this target, I've removed tests added on https://github.com/rust-lang/cc-rs/pull/704 that require gcc.~~ Restored tests.