### PR TITLE
Pass -Wno-unused-command-line-argument to clang in `is_flag_supported`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,11 @@ impl Build {
         if compiler.family.verbose_stderr() {
             compiler.remove_arg("-v".into());
         }
+        if compiler.family == ToolFamily::Clang {
+            // Avoid reporting that the arg is unsupported just because the
+            // compiler complains that it wasn't used.
+            compiler.push_cc_arg("-Wno-unused-command-line-argument".into());
+        }
 
         let mut cmd = compiler.to_command();
         let is_arm = target.contains("aarch64") || target.contains("arm");


### PR DESCRIPTION
Fixes #730

I don't know when this warning was added but it seems at least 10 years old from a quick search, so hopefully we don't need to check clang version first.

I'm not sure if clang-cl needs this either.