### PR TITLE
Fix unconditional cargo metadata printing on flag support check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,6 +527,7 @@ impl Build {
         let host = self.get_host()?;
         let mut cfg = Build::new();
         cfg.flag(flag)
+            .cargo_metadata(self.cargo_metadata)
             .target(&target)
             .opt_level(0)
             .host(&host)


### PR DESCRIPTION
This PR fixes an issue that if the `Build` instance configured with disabled cargo metadata production this doesn't have an impact on the internally used `Build` instance and for every compiler flag check the cargo metadata is still produced and printed to the stdout.

It's expected that the bellow configuration on the client code shouldn't produce any cargo metadata output:
```rust
let mut cfg = cc::Build::new();
cfg.cargo_metadata(false);
```