### PR TITLE
Add `--` for files in `try_expand`  (like in #514)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1542,6 +1542,16 @@ impl Build {
             "Expand may only be called for a single file"
         );
 
+        let is_asm = self.files.iter().map(std::ops::Deref::deref).find_map(AsmFileExt::from_path).is_some();
+
+        if compiler.family == (ToolFamily::Msvc { clang_cl: true }) && !is_asm {
+            // #513: For `clang-cl`, separate flags/options from the input file.
+            // When cross-compiling macOS -> Windows, this avoids interpreting
+            // common `/Users/...` paths as the `/U` flag and triggering
+            // `-Wslash-u-filename` warning.
+            cmd.arg("--");
+        }
+
         cmd.args(self.files.iter().map(std::ops::Deref::deref));
 
         let name = compiler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1542,7 +1542,12 @@ impl Build {
             "Expand may only be called for a single file"
         );
 
-        let is_asm = self.files.iter().map(std::ops::Deref::deref).find_map(AsmFileExt::from_path).is_some();
+        let is_asm = self
+            .files
+            .iter()
+            .map(std::ops::Deref::deref)
+            .find_map(AsmFileExt::from_path)
+            .is_some();
 
         if compiler.family == (ToolFamily::Msvc { clang_cl: true }) && !is_asm {
             // #513: For `clang-cl`, separate flags/options from the input file.


### PR DESCRIPTION
Hi! 

This PR is very similar with #514 (issue: #513), but for `try_expand`

I've faced with that issue when i tried to cross-compile `macos -> win` crate with buildscript that uses `embed-resource` via cargo-xwin. 
For more context: rust-cross/cargo-xwin#86