### PR TITLE
Link against libc++ on *-linux-ohos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2835,6 +2835,7 @@ impl Build {
                         | target.contains("freebsd")
                         | target.contains("openbsd")
                         | target.contains("aix")
+                        | target.contains("linux-ohos")
                     {
                         Ok(Some("c++".to_string()))
                     } else if target.contains("android") {


### PR DESCRIPTION
I can confirm that openharmony is utilizing the runtime in llvm-project, e.g. libc++.

Refer:
- https://doc.rust-lang.org/beta/rustc/platform-support/openharmony.html
- https://github.com/llvm/llvm-project/blob/0cdaadf15aaa6609f93e3508417b47baa3891996/clang/lib/Driver/ToolChains/OHOS.h#L33