### PR TITLE
Use RUSTC_WRAPPER if no other wrapper is provided

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2761,7 +2761,11 @@ impl Build {
         // interpretation at all, just pass it on through. This'll hopefully get
         // us to support spaces-in-paths.
         if Path::new(&*tool).exists() {
-            return Some((PathBuf::from(&*tool), None, Vec::new()));
+            return Some((
+                PathBuf::from(&*tool),
+                Self::rustc_wrapper_fallback(),
+                Vec::new(),
+            ));
         }
 
         // Ok now we want to handle a couple of scenarios. We'll assume from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2382,6 +2382,7 @@ impl Build {
         enum ArchSpec {
             Device(&'static str),
             Simulator(&'static str),
+            #[allow(dead_code)]
             Catalyst(&'static str),
         }
 


### PR DESCRIPTION
Previously, the `rustc_wrapper_fallback` was only called if the tool
 was **not** a full path.
With this patch, the `RUSTC_WRAPPER` is always used, even if the tool provided is an exact path.
Providing a wrapper manually is still possible and overrides the `RUSTC_WRAPPER`.

If the path to the tool includes spaces it is otherwise impossible to provide a compiler cache like sccache through the CXX or CC environment variables, as the arguments will be split up incorrectly.

See also: https://github.com/corrosion-rs/corrosion/pull/474