### PR TITLE
add comment why tvOS CI job is separate from the matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,7 @@ jobs:
     - run: cargo test ${{ matrix.no_run }} --manifest-path cc-test/Cargo.toml --target ${{ matrix.target }} --features parallel
     - run: cargo test ${{ matrix.no_run }} --manifest-path cc-test/Cargo.toml --target ${{ matrix.target }} --release
 
+  # This is separate from the matrix above because there is no prebuilt rust-std component for the target.
   check-tvos:
     name: Test aarch64-apple-tvos
     runs-on: macos-latest


### PR DESCRIPTION
I wasted some time trying to figure out how to get this to work in the matrix until I saw that it is [intentionally separate](https://github.com/rust-lang/cc-rs/pull/881#discussion_r1377491719).