### PR TITLE
use full import path in tool module

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
 };
 
-use crate::{run_output, CargoOutput};
+use crate::command_helpers::{run_output, CargoOutput};
 
 /// Configuration used to represent an invocation of a C compiler.
 ///


### PR DESCRIPTION
instead of relying on `use command_helpers::*;` in lib.rs