### PR TITLE
do not publish tests or gcc-shim with crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ code.
 keywords = ["build-dependencies"]
 readme = "README.md"
 categories = ["development-tools::build-utils"]
-exclude = ["/.github"]
+# The binary target is only used by tests.
+exclude = ["/.github", "tests", "src/bin"]
 edition = "2018"
 rust-version = "1.53"
 


### PR DESCRIPTION
Only necessary files are published with this:
```
cc-rs on  exclude_tests [$] is 📦 v1.0.84 via 🦀 v1.75.0 on ☁  (auto) 
❯ cargo package --list
.cargo_vcs_info.json
.gitignore
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE-APACHE
LICENSE-MIT
README.md
src/com.rs
src/command_helpers.rs
src/lib.rs
src/os_pipe/mod.rs
src/os_pipe/unix.rs
src/os_pipe/windows.rs
src/parallel/async_executor.rs
src/parallel/job_token/mod.rs
src/parallel/job_token/unix.rs
src/parallel/job_token/windows.rs
src/parallel/mod.rs
src/registry.rs
src/setup_config.rs
src/tool.rs
src/vs_instances.rs
src/winapi.rs
src/windows_registry.rs
src/windows_sys.rs
```