### PR TITLE
Add support for riscv32imac-esp-espidf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3048,6 +3048,7 @@ impl Build {
                 "riscv64-unknown-elf",
                 "riscv-none-embed",
             ]),
+            "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
             "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
                 "riscv32-unknown-elf",
                 "riscv64-unknown-elf",


### PR DESCRIPTION
esp32c6 and esp32h2 use the riscv32imac-esp-espidf target