### PR TITLE
Fix default deployment target behavior for Apple targets

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -17,7 +17,7 @@ pub struct Test {
 }
 
 pub struct Execution {
-    args: Vec<String>,
+    pub args: Vec<String>,
 }
 
 impl Test {


### PR DESCRIPTION
In hindsight defaulting to rustc's default deployment targets when no explicit ones were provided wasn't a great call. Those versions are older then what most people target and interact badly with third-party C libraries and Apple's SDKs that expect *usually* higher versions instead. So this goes ahead and reverts to `cc`'s older behavior of using the target's current platform SDK `DefaultDeploymentTarget` when no explicit version is given to `cc`. 

This afaict is functionally identical to passing nothing and letting `clang` figure out the default except this keeps the code cleaner because optionals don't need handled everywhere :)

Fixes https://github.com/rust-lang/cc-rs/issues/902