### PR TITLE
Fix jobserver: Last `--jobserver-auth` wins

### DIFF
--- a/src/parallel/job_token/unix.rs
+++ b/src/parallel/job_token/unix.rs
@@ -1,14 +1,11 @@
 use std::{
-    ffi::{OsStr, OsString},
+    ffi::OsStr,
     fs::{self, File},
     io::{self, Read, Write},
     mem::ManuallyDrop,
     os::{
         raw::c_int,
-        unix::{
-            ffi::{OsStrExt, OsStringExt},
-            prelude::*,
-        },
+        unix::{ffi::OsStrExt, prelude::*},
     },
     path::Path,
 };
@@ -19,21 +16,11 @@ pub(super) struct JobServerClient {
 }
 
 impl JobServerClient {
-    pub(super) unsafe fn open(var: OsString) -> Option<Self> {
-        let bytes = var.into_vec();
-
-        let s = bytes
-            .split(u8::is_ascii_whitespace)
-            .filter_map(|arg| {
-                arg.strip_prefix(b"--jobserver-fds=")
-                    .or_else(|| arg.strip_prefix(b"--jobserver-auth="))
-            })
-            .find(|bytes| !bytes.is_empty())?;
-
-        if let Some(fifo) = s.strip_prefix(b"fifo:") {
+    pub(super) unsafe fn open(var: &[u8]) -> Option<Self> {
+        if let Some(fifo) = var.strip_prefix(b"fifo:") {
             Self::from_fifo(Path::new(OsStr::from_bytes(fifo)))
         } else {
-            Self::from_pipe(OsStr::from_bytes(s).to_str()?)
+            Self::from_pipe(OsStr::from_bytes(var).to_str()?)
         }
     }
 


### PR DESCRIPTION
`--jobserver-auth=` is the only documented makeflags. `--jobserver-fds=` is actually an internal only makeflags, so we should always prefer `--jobserver-auth=`.

Also, according to doc of makeflags, if there are multiple `--jobserver-auth=` the last one is used

ref: rust-lang/jobserver-rs#67