### PR TITLE
Added tvos-sim support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,41 +95,42 @@ jobs:
     - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
     - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
-  # This is separate from the matrix above because there is no prebuilt rust-std component for the target.
+  # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:
-    name: Test aarch64-apple-tvos
-    runs-on: macos-latest
+    name: Test build-std
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [nightly, macos, aarch64-macos]
+        include:
+          - build: aarch64-tvos
+            os: macos-latest
+            rust: nightly
+            target: aarch64-apple-tvos
+            no_run: --no-run
+          - build: aarch64-ios
+            os: macos-latest
+            rust: nightly
+            target: aarch64-apple-tvos-sim
+            no_run: --no-run
+          - build: x86_64-tvos
+            os: macos-latest
+            rust: nightly
+            target: x86_64-apple-tvos
+            no_run: --no-run
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
       run: |
         set -euxo pipefail
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup component add rust-src --toolchain nightly
-        rustup default nightly
+        rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal
+        rustup component add rust-src --toolchain ${{ matrix.rust }}
+        rustup default ${{ matrix.rust }}
       shell: bash
     - uses: Swatinem/rust-cache@v2
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos --release
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos --features parallel
-
-  # This is separate from the matrix above because there is no prebuilt rust-std component for the target.
-  check-tvos-sim:
-    name: Test aarch64-apple-tvos-sim
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust (rustup)
-      run: |
-        set -euxo pipefail
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup component add rust-src --toolchain nightly
-        rustup default nightly
-      shell: bash
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim --release
-    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim --features parallel
+    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   cuda:
     name: Test CUDA support

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,14 +101,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [nightly, macos, aarch64-macos]
+        build: [aarch64-tvos, aarch64-tvos-sim, x86_64-tvos]
         include:
           - build: aarch64-tvos
             os: macos-latest
             rust: nightly
             target: aarch64-apple-tvos
             no_run: --no-run
-          - build: aarch64-ios
+          - build: aarch64-tvos-sim
             os: macos-latest
             rust: nightly
             target: aarch64-apple-tvos-sim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,24 @@ jobs:
     - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos --release
     - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos --features parallel
 
+  # This is separate from the matrix above because there is no prebuilt rust-std component for the target.
+  check-tvos-sim:
+    name: Test aarch64-apple-tvos-sim
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust (rustup)
+      run: |
+        set -euxo pipefail
+        rustup toolchain install nightly --no-self-update --profile minimal
+        rustup component add rust-src --toolchain nightly
+        rustup default nightly
+      shell: bash
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim
+    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim --release
+    - run: cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos-sim --features parallel
+
   cuda:
     name: Test CUDA support
     runs-on: ubuntu-20.04

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1927,7 +1927,7 @@ impl Build {
                                 .into(),
                             );
                         }
-                    } else if target.contains("tvos-sim") {
+                    } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos")  {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1948,6 +1948,21 @@ impl Build {
                                 .into(),
                             );
                         }
+                    } else if target.contains("aarch64-apple-tvos") {
+                        if let Some(arch) =
+                            map_darwin_target_from_rust_to_compiler_architecture(target)
+                        {
+                            let sdk_details =
+                                apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Device(""));
+                            let deployment_target = self.apple_deployment_version(
+                                AppleOs::TvOs,
+                                None,
+                                &sdk_details.sdk,
+                            );
+                            cmd.args.push(
+                                format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
+                            );
+                        }
                     } else if target.starts_with("riscv64gc-") {
                         cmd.args.push(
                             format!("--target={}", target.replace("riscv64gc", "riscv64")).into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1929,7 +1929,7 @@ impl Build {
                                 .into(),
                             );
                         }
-                    } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos")  {
+                    } else if target.contains("tvos-sim") || target.contains("x86_64-apple-tvos") {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1927,7 +1927,7 @@ impl Build {
                                 .into(),
                             );
                         }
-                    } else if target.contains("x86_64-apple-tvos") {
+                    } else if target.contains("tvos-sim") {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
@@ -1944,21 +1944,6 @@ impl Build {
                                     arch, deployment_target
                                 )
                                 .into(),
-                            );
-                        }
-                    } else if target.contains("aarch64-apple-tvos") {
-                        if let Some(arch) =
-                            map_darwin_target_from_rust_to_compiler_architecture(target)
-                        {
-                            let sdk_details =
-                                apple_os_sdk_parts(AppleOs::TvOs, &AppleArchSpec::Device(""));
-                            let deployment_target = self.apple_deployment_version(
-                                AppleOs::TvOs,
-                                None,
-                                &sdk_details.sdk,
-                            );
-                            cmd.args.push(
-                                format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
                             );
                         }
                     } else if target.starts_with("riscv64gc-") {


### PR DESCRIPTION
This PR allows using cc-rs lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html) simulator builds

- The aarch64-apple-tvos-sim target was added so both tvos-sim and x86 versions are simulator versions.
- I removed the target.contains("aarch64-apple-tvos") as it seems to be redundant and iOS and watchOS implementations do not include it. The build was not effected with this removal.
- Added a new check-tvos-sim step to actions

how was this tested: 

- cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos{and -sim}
- cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos{and -sim} --release
- cargo test -Z build-std=std --no-run --workspace --target aarch64-apple-tvos{and -sim} --features parallel

