### PR TITLE
Release cc 1.0.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.85"
+version = "1.0.86"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"


### PR DESCRIPTION
Regression (#945) has been resolved, #948 seems like a zig-cc issue.

Even if #948 is indeed an issue in cc, it affects a much smaller group of people (cross-compiling from Linux to MacOS).