### PR TITLE
Optimize `set_non_blocking`: Avoid dup mono

### DIFF
--- a/src/parallel/job_token/unix.rs
+++ b/src/parallel/job_token/unix.rs
@@ -3,10 +3,7 @@ use std::{
     fs::{self, File},
     io::{self, Read, Write},
     mem::ManuallyDrop,
-    os::{
-        raw::c_int,
-        unix::{ffi::OsStrExt, prelude::*},
-    },
+    os::{raw::c_int, unix::prelude::*},
     path::Path,
 };
 


### PR DESCRIPTION
`set_non_blocking` takes a generic parameter and it is used in two different places with different types.

Since it only uses the fd returned by `pipe.as_raw_fd()`, we could create an `_inner` function that takes the fd and do the job.