### PR TITLE
Add `/System/iOSSupport` to header/library search paths on Mac Catalyst

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2582,14 +2582,42 @@ impl Build {
                 "Detecting {:?} SDK path for {}",
                 os, sdk_details.sdk
             ));
-            let sdk_path = if let Some(sdkroot) = env::var_os("SDKROOT") {
-                sdkroot
-            } else {
-                self.apple_sdk_root(&sdk_details.sdk)?
-            };
+            let sdk_path = self.apple_sdk_root(&sdk_details.sdk)?;
 
             cmd.args.push("-isysroot".into());
             cmd.args.push(sdk_path);
+        }
+
+        if let AppleArchSpec::Catalyst(_) = arch {
+            // Mac Catalyst uses the macOS SDK, but to compile against and
+            // link to iOS-specific frameworks, we should have the support
+            // library stubs in the include and library search path.
+            let sdk_path = self.apple_sdk_root(&sdk_details.sdk)?;
+            let ios_support = PathBuf::from(sdk_path).join("/System/iOSSupport");
+
+            cmd.args.extend([
+                // Header search path
+                OsString::from("-isystem"),
+                ios_support.join("/usr/include").into(),
+                // Framework header search path
+                OsString::from("-iframework"),
+                ios_support.join("/System/Library/Frameworks").into(),
+                // Library search path
+                {
+                    let mut s = OsString::from("-L");
+                    s.push(&ios_support.join("/usr/lib"));
+                    s
+                },
+                // Framework linker search path
+                {
+                    // Technically, we _could_ avoid emitting `-F`, as
+                    // `-iframework` implies it, but let's keep it in for
+                    // clarity.
+                    let mut s = OsString::from("-F");
+                    s.push(&ios_support.join("/System/Library/Frameworks"));
+                    s
+                },
+            ]);
         }
 
         Ok(())
@@ -3488,6 +3516,10 @@ impl Build {
     }
 
     fn apple_sdk_root(&self, sdk: &str) -> Result<OsString, Error> {
+        if let Some(sdkroot) = env::var_os("SDKROOT") {
+            return Ok(sdkroot);
+        }
+
         let mut cache = self
             .apple_sdk_root_cache
             .lock()


### PR DESCRIPTION
This allows using `#import <UIKit/UIKit.h>` in C code processed by `cc`.

See https://github.com/rust-lang/rust/pull/121430 for more context. In `cc`, we need a few more flags than `rustc`, as we also want to add header search paths.

CC @BlackHoleFox.