### PR TITLE
Fix use of cc with make <4.3: Clear O_NONBLOCK after compilaton

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1395,7 +1395,7 @@ impl Build {
         }
 
         // Limit our parallelism globally with a jobserver.
-        let tokens = parallel::job_token::JobTokenServer::new();
+        let tokens = parallel::job_token::ActiveJobTokenServer::new()?;
 
         // When compiling objects in parallel we do a few dirty tricks to speed
         // things up:

--- a/src/parallel/job_token/mod.rs
+++ b/src/parallel/job_token/mod.rs
@@ -21,7 +21,7 @@ impl Drop for JobToken {
     }
 }
 
-pub(crate) enum JobTokenServer {
+enum JobTokenServer {
     Inherited(inherited_jobserver::JobServer),
     InProcess(inprocess_jobserver::JobServer),
 }
@@ -35,7 +35,7 @@ impl JobTokenServer {
     ///    present), we will create a global in-process only jobserver
     ///    that has to be static so that it will be shared by all cc
     ///    compilation.
-    pub(crate) fn new() -> &'static Self {
+    fn new() -> &'static Self {
         static INIT: Once = Once::new();
         static mut JOBSERVER: MaybeUninit<JobTokenServer> = MaybeUninit::uninit();
 
@@ -50,11 +50,35 @@ impl JobTokenServer {
             &*JOBSERVER.as_ptr()
         }
     }
+}
+
+pub(crate) struct ActiveJobTokenServer(&'static JobTokenServer);
+
+impl ActiveJobTokenServer {
+    pub(crate) fn new() -> Result<Self, Error> {
+        let jobserver = JobTokenServer::new();
+
+        #[cfg(unix)]
+        if let JobTokenServer::Inherited(inherited_jobserver) = &jobserver {
+            inherited_jobserver.enter_active()?;
+        }
+
+        Ok(Self(jobserver))
+    }
 
     pub(crate) fn try_acquire(&self) -> Result<Option<JobToken>, Error> {
-        match self {
-            Self::Inherited(jobserver) => jobserver.try_acquire(),
-            Self::InProcess(jobserver) => Ok(jobserver.try_acquire()),
+        match &self.0 {
+            JobTokenServer::Inherited(jobserver) => jobserver.try_acquire(),
+            JobTokenServer::InProcess(jobserver) => Ok(jobserver.try_acquire()),
+        }
+    }
+}
+
+impl Drop for ActiveJobTokenServer {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let JobTokenServer::Inherited(inherited_jobserver) = &self.0 {
+            inherited_jobserver.exit_active();
         }
     }
 }
@@ -64,9 +88,12 @@ mod inherited_jobserver {
 
     use std::{
         env::var_os,
-        sync::atomic::{
-            AtomicBool,
-            Ordering::{AcqRel, Acquire},
+        sync::{
+            atomic::{
+                AtomicBool,
+                Ordering::{AcqRel, Acquire},
+            },
+            Mutex, MutexGuard, PoisonError,
         },
     };
 
@@ -80,6 +107,10 @@ mod inherited_jobserver {
         /// the end of the process.
         global_implicit_token: AtomicBool,
         inner: sys::JobServerClient,
+        /// number of active clients is required to know when it is safe to clear non-blocking
+        /// flags
+        #[cfg(unix)]
+        active_clients_cnt: Mutex<usize>,
     }
 
     impl JobServer {
@@ -117,7 +148,38 @@ mod inherited_jobserver {
             .map(|inner| Self {
                 inner,
                 global_implicit_token: AtomicBool::new(true),
+                #[cfg(unix)]
+                active_clients_cnt: Mutex::new(0),
             })
+        }
+
+        #[cfg(unix)]
+        fn get_locked_active_cnt(&self) -> MutexGuard<'_, usize> {
+            self.active_clients_cnt
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+        }
+
+        #[cfg(unix)]
+        pub(super) fn enter_active(&self) -> Result<(), Error> {
+            let mut active_cnt = self.get_locked_active_cnt();
+            if *active_cnt == 0 {
+                self.inner.prepare_for_acquires()?;
+            }
+
+            *active_cnt += 1;
+
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        pub(super) fn exit_active(&self) {
+            let mut active_cnt = self.get_locked_active_cnt();
+            *active_cnt -= 1;
+
+            if *active_cnt == 0 {
+                self.inner.done_acquires();
+            }
         }
 
         pub(super) fn try_acquire(&self) -> Result<Option<JobToken>, Error> {

--- a/src/parallel/job_token/mod.rs
+++ b/src/parallel/job_token/mod.rs
@@ -88,14 +88,14 @@ mod inherited_jobserver {
 
     use std::{
         env::var_os,
-        sync::{
-            atomic::{
-                AtomicBool,
-                Ordering::{AcqRel, Acquire},
-            },
-            Mutex, MutexGuard, PoisonError,
+        sync::atomic::{
+            AtomicBool,
+            Ordering::{AcqRel, Acquire},
         },
     };
+
+    #[cfg(unix)]
+    use std::sync::{Mutex, MutexGuard, PoisonError};
 
     pub(crate) struct JobServer {
         /// Implicit token for this process which is obtained and will be

--- a/src/parallel/job_token/unix.rs
+++ b/src/parallel/job_token/unix.rs
@@ -74,6 +74,14 @@ impl JobServerClient {
                 Some(libc::O_RDONLY) | Some(libc::O_RDWR),
                 Some(libc::O_WRONLY) | Some(libc::O_RDWR),
             ) => {
+                // Optimization: Try converting it to a fifo by using /dev/fd
+                #[cfg(target_os = "linux")]
+                if let Some(jobserver) =
+                    Self::from_fifo(Path::new(&format!("/dev/fd/{}", read.as_raw_fd())))
+                {
+                    return Some(jobserver);
+                }
+
                 let read = read.try_clone().ok()?;
                 let write = write.try_clone().ok()?;
 

--- a/src/parallel/job_token/unix.rs
+++ b/src/parallel/job_token/unix.rs
@@ -75,7 +75,6 @@ impl JobServerClient {
                 Some(libc::O_WRONLY) | Some(libc::O_RDWR),
             ) => {
                 // Optimization: Try converting it to a fifo by using /dev/fd
-                #[cfg(target_os = "linux")]
                 if let Some(jobserver) =
                     Self::from_fifo(Path::new(&format!("/dev/fd/{}", read.as_raw_fd())))
                 {


### PR DESCRIPTION
Fixed #962

make <4.3 cannot handle jobserver pipe with `O_NONBLOCK` set.