### PR TITLE
Disable optimization for jobserver pipe

### DIFF
--- a/src/parallel/job_token/unix.rs
+++ b/src/parallel/job_token/unix.rs
@@ -74,13 +74,6 @@ impl JobServerClient {
                 Some(libc::O_RDONLY) | Some(libc::O_RDWR),
                 Some(libc::O_WRONLY) | Some(libc::O_RDWR),
             ) => {
-                // Optimization: Try converting it to a fifo by using /dev/fd
-                if let Some(jobserver) =
-                    Self::from_fifo(Path::new(&format!("/dev/fd/{}", read.as_raw_fd())))
-                {
-                    return Some(jobserver);
-                }
-
                 let read = read.try_clone().ok()?;
                 let write = write.try_clone().ok()?;
 


### PR DESCRIPTION
It could be the reason why the failure still happens in https://github.com/sfackler/rust-openssl/issues/2184#issuecomment-1962453714