### PR TITLE
CI: Add automatic publish on tag creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    tags:        
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Publish to crates.io
+      run: |
+        cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Requires a new secret `CARGO_REGISTRY_TOKEN` to be added to github action secrets of this repository.

It would only need permission to publsh new versions of cc on crates.io , using scoped token.