### PR TITLE
Use llvm-ar, llvm-ranlib for Android NDK

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3107,8 +3107,9 @@ impl Build {
             None => {
                 if target.contains("android") {
                     name = format!("llvm-{}", tool);
-                    if !Command::new(&name).arg("--version").output().is_ok() {
-                        name = format!("{}-{}", target.replace("armv7", "arm"), tool);
+                    match Command::new(&name).arg("--version").status() {
+                        Ok(status) if status.success() => (),
+                        _ => name = format!("{}-{}", target.replace("armv7", "arm"), tool),
                     }
                     self.cmd(&name)
                 } else if target.contains("msvc") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3106,10 +3106,8 @@ impl Build {
             Some(t) => t,
             None => {
                 if target.contains("android") {
-                    let compiler = self.get_base_compiler()?;
-                    if compiler.family == ToolFamily::Clang {
-                        name = format!("llvm-{}", tool);
-                    } else {
+                    name = format!("llvm-{}", tool);
+                    if !Command::new(&name).arg("--version").output().is_ok() {
                         name = format!("{}-{}", target.replace("armv7", "arm"), tool);
                     }
                     self.cmd(&name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3106,7 +3106,12 @@ impl Build {
             Some(t) => t,
             None => {
                 if target.contains("android") {
-                    name = format!("{}-{}", target.replace("armv7", "arm"), tool);
+                    let compiler = self.get_base_compiler()?;
+                    if compiler.family == ToolFamily::Clang {
+                        name = format!("llvm-{}", tool);
+                    } else {
+                        name = format!("{}-{}", target.replace("armv7", "arm"), tool);
+                    }
                     self.cmd(&name)
                 } else if target.contains("msvc") {
                     // NOTE: There isn't really a ranlib on msvc, so arguably we should return


### PR DESCRIPTION
For newer Android NDK, `target-triple-ar|ranlib` has been replaced to `llvm-ar|ranlib`. Which could be an issue when compiling libs like https://github.com/sfackler/rust-openssl .

This PR tries to use `llvm-ar|ranlib` when the compiler family is `Clang`.