### PR TITLE
Add a public file iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,9 +758,9 @@ impl Build {
         self
     }
 
-    /// Get an iterator of the files which will be compiled
-    pub fn iter_files(&self) -> impl Iterator<Item = &Path> {
-        self.files.iter().map(|path| path.as_ref())
+    /// Get the files which will be compiled
+    pub fn get_files(&self) -> impl Iterator<Item = &Path> {
+        self.files.iter().map(AsRef::as_ref)
     }
 
     /// Set C++ support.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,6 +758,11 @@ impl Build {
         self
     }
 
+    /// Get an iterator of the files which will be compiled
+    pub fn iter_files(&self) -> impl Iterator<Item = &Path> {
+        self.files.iter().map(|path| path.as_ref())
+    }
+
     /// Set C++ support.
     ///
     /// The other `cpp_*` options will only become active if this is set to


### PR DESCRIPTION
Hi, I am adding a public interface for iterating the files to be compiled.
My use case is to generate `compile_commands.json` outside. This configuration is needed by various language servers/IDEs and contains the mapping between source files and their compile commands. We can already get the compile commands using `get_compiler`, but the files are not exposed through any public interface yet.
I've made this interface a little more general by not exposing `Arc<Path>` but give an iterator instead.

I am also wondering if adding a `compile_commands.json`-generator directly into `cc-rs` might be useful as this is a built-in feature for many build systems including cmake, bazel, makefile, ninja, and [some rust ones](https://crates.io/crates/builder_cpp/0.6.1) etc. It is better if one can generate one json combined from multiple `cc::Build` instances.