### PR TITLE
Fix regression: remove `--target` when targeting Android on non-Windows platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1894,7 +1894,10 @@ impl Build {
         // Target flags
         match cmd.family {
             ToolFamily::Clang => {
-                if !(target.contains("android") && cmd.has_internal_target_arg) {
+                if !cmd.has_internal_target_arg
+                    && !(target.contains("android")
+                        && android_clang_compiler_uses_target_arg_internally(&cmd.path))
+                {
                     if target.contains("darwin") {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)


### PR DESCRIPTION
The `--target` argument should not be passed to Clang when targeting Android, as the Android NDK contains wrappers for Clang that automatically set the target.

However, <https://github.com/rust-lang/cc-rs/commit/53564e00498156c9be00361c4b039952cbf7ff59> introduced a regression where `--target` was being passed on non-Windows platforms, which broke the `compile-ui` tests for the Rust compiler when building for `arm-android`: <https://github.com/rust-lang/rust/pull/121854#issuecomment-1973518078>

This fix restores the original logic AND respects the new `has_internal_target_arg` flag (regardless if we're targeting Android or not).

I've verified that the `arm-android` build succeeds with this change: <https://github.com/rust-lang/rust/actions/runs/8146073082/job/22263762750?pr=121874>

Fixes #990