### PR TITLE
Fix: Accept non utf-8 characters in compiler and archiver

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::hash_map,
-    convert::AsRef,
     ffi::OsString,
     fmt::Display,
     fs,

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -337,7 +337,7 @@ pub(crate) fn run_output(
     Ok(stdout)
 }
 
-fn spawn_inner(
+pub(crate) fn spawn(
     cmd: &mut Command,
     program: &Path,
     cargo_output: &CargoOutput,
@@ -386,14 +386,6 @@ for help)"
     }
 }
 
-pub(crate) fn spawn(
-    cmd: &mut Command,
-    program: impl AsRef<Path>,
-    cargo_output: &CargoOutput,
-) -> Result<Child, Error> {
-    spawn_inner(cmd, program.as_ref(), cargo_output)
-}
-
 pub(crate) fn command_add_output_file(
     cmd: &mut Command,
     dst: &Path,
@@ -416,13 +408,11 @@ pub(crate) fn command_add_output_file(
 #[cfg(feature = "parallel")]
 pub(crate) fn try_wait_on_child(
     cmd: &Command,
-    program: impl AsRef<Path>,
+    program: &Path,
     child: &mut Child,
     stdout: &mut dyn io::Write,
     stderr_forwarder: &mut StderrForwarder,
 ) -> Result<Option<()>, Error> {
-    let program = program.as_ref();
-
     stderr_forwarder.forward_available();
 
     match child.try_wait() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1657,9 +1657,7 @@ impl Build {
         let name = compiler
             .path
             .file_name()
-            .ok_or_else(|| Error::new(ErrorKind::IOError, "Failed to get compiler path."))?
-            .to_string_lossy()
-            .into_owned();
+            .ok_or_else(|| Error::new(ErrorKind::IOError, "Failed to get compiler path."))?;
 
         Ok(run_output(&mut cmd, &name, &self.cargo_output)?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3030,7 +3030,7 @@ impl Build {
         }
     }
 
-    fn get_ar(&self) -> Result<(Command, String, bool), Error> {
+    fn get_ar(&self) -> Result<(Command, PathBuf, bool), Error> {
         self.try_get_archiver_and_flags()
     }
 
@@ -3063,7 +3063,7 @@ impl Build {
         Ok(self.try_get_archiver_and_flags()?.0)
     }
 
-    fn try_get_archiver_and_flags(&self) -> Result<(Command, String, bool), Error> {
+    fn try_get_archiver_and_flags(&self) -> Result<(Command, PathBuf, bool), Error> {
         let (mut cmd, name) = self.get_base_archiver()?;
         let mut any_flags = false;
         if let Ok(flags) = self.envflags("ARFLAGS") {
@@ -3077,12 +3077,14 @@ impl Build {
         Ok((cmd, name, any_flags))
     }
 
-    fn get_base_archiver(&self) -> Result<(Command, String), Error> {
+    fn get_base_archiver(&self) -> Result<(Command, PathBuf), Error> {
         if let Some(ref a) = self.archiver {
-            return Ok((self.cmd(&**a), a.to_string_lossy().into_owned()));
+            let archiver = &**a;
+            return Ok((self.cmd(archiver), archiver.into()));
         }
 
         self.get_base_archiver_variant("AR", "ar")
+            .map(|(cmd, archiver)| (cmd, archiver.into()))
     }
 
     /// Get the ranlib that's in use for this configuration.

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -81,7 +81,7 @@ impl Tool {
 
             let stdout = match run_output(
                 &mut cmd,
-                &path.to_string_lossy(),
+                path,
                 // tool detection issues should always be shown as warnings
                 cargo_output,
             )


### PR DESCRIPTION
While the compiler automatically detected by cc always is a valid `str`, it is possible for user to override them using environment variable `CC`, `CXX` and `AR`, which could contain non utf-8 characters.

Before this PR is applied, cc uses `to_string_lossy()` to convert it to a valid `str` which might cause the creation of process to fail.