### PR TITLE
feat:  Query rustc for clang target triples instead of hardcoding them

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,8 +170,8 @@ jobs:
       run: cargo +nightly update -Zminimal-versions
     - name: Cache downloaded crates since 1.53 is really slow in fetching
       uses: Swatinem/rust-cache@v2
-    - run: cargo check --lib -p cc
-    - run: cargo check --lib -p cc --all-features
+    - run: cargo check --lib -p cc --locked
+    - run: cargo check --lib -p cc --locked --all-features
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3"
 
 [workspace]
 members = [
-    "dev-tools/cc-test", "dev-tools/gen-target-info",
+    "dev-tools/cc-test",
+    "dev-tools/gen-target-info",
     "dev-tools/gen-windows-sys-binding",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,6 @@ tempfile = "3"
 
 [workspace]
 members = [
-    "dev-tools/cc-test",
+    "dev-tools/cc-test", "dev-tools/gen-target-info",
     "dev-tools/gen-windows-sys-binding",
 ]

--- a/dev-tools/gen-target-info/Cargo.toml
+++ b/dev-tools/gen-target-info/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gen-target-info"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/dev-tools/gen-target-info/Cargo.toml
+++ b/dev-tools/gen-target-info/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gen-target-info"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = { version = "1.0.163", features = ["derive"] }
+serde-tuple-vec-map = "1.0.1"
+serde_json = "1.0.107"

--- a/dev-tools/gen-target-info/src/lib.rs
+++ b/dev-tools/gen-target-info/src/lib.rs
@@ -1,0 +1,8 @@
+mod target_specs;
+pub use target_specs::*;
+
+mod read;
+pub use read::get_target_specs_from_json;
+
+mod write;
+pub use write::*;

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -1,4 +1,4 @@
-use gen_target_info::{get_target_specs_from_json, write_string_mapping_to_file};
+use gen_target_info::{get_target_specs_from_json, write_target_tuple_mapping};
 use std::{fs::File, io::Write as _};
 
 fn main() {
@@ -22,7 +22,7 @@ fn main() {
         .collect::<Vec<_>>();
     riscv_target_mapping.sort_unstable_by_key(|(arch, _)| &**arch);
     riscv_target_mapping.dedup();
-    write_string_mapping_to_file(&mut f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
+    write_target_tuple_mapping(&mut f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
 
     // Flush the data onto disk
     f.flush().unwrap();

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -1,0 +1,29 @@
+use gen_target_info::{get_target_specs_from_json, write_string_mapping_to_file};
+use std::{fs::File, io::Write as _};
+
+fn main() {
+    let target_specs = get_target_specs_from_json();
+
+    // Open file to write to
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    let path = format!("{manifest_dir}/../../src/target_info.rs");
+    let mut f = File::create(path).expect("failed to create src/target_info.rs");
+
+    // Wrute riscv target mapping
+    let mut riscv_target_mapping = target_specs
+        .0
+        .iter()
+        .filter_map(|(target, target_spec)| {
+            let arch = target.split_once('-').unwrap().0;
+            (arch.contains("riscv") && arch != &target_spec.arch)
+                .then_some((arch, &*target_spec.arch))
+        })
+        .collect::<Vec<_>>();
+    riscv_target_mapping.sort_unstable_by_key(|(arch, _)| &**arch);
+    riscv_target_mapping.dedup();
+    write_string_mapping_to_file(&mut f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
+
+    // Flush the data onto disk
+    f.flush().unwrap();
+}

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -1,16 +1,7 @@
-use gen_target_info::{get_target_specs_from_json, write_target_tuple_mapping};
+use gen_target_info::{get_target_specs_from_json, write_target_tuple_mapping, RustcTargetSpecs};
 use std::{fs::File, io::Write as _};
 
-fn main() {
-    let target_specs = get_target_specs_from_json();
-
-    // Open file to write to
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-
-    let path = format!("{manifest_dir}/../../src/target_info.rs");
-    let mut f = File::create(path).expect("failed to create src/target_info.rs");
-
-    // Wrute riscv target mapping
+fn generate_riscv_arch_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
     let mut riscv_target_mapping = target_specs
         .0
         .iter()
@@ -22,7 +13,20 @@ fn main() {
         .collect::<Vec<_>>();
     riscv_target_mapping.sort_unstable_by_key(|(arch, _)| &**arch);
     riscv_target_mapping.dedup();
-    write_target_tuple_mapping(&mut f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
+    write_target_tuple_mapping(f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
+}
+
+fn main() {
+    let target_specs = get_target_specs_from_json();
+
+    // Open file to write to
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    let path = format!("{manifest_dir}/../../src/target_info.rs");
+    let mut f = File::create(path).expect("failed to create src/target_info.rs");
+
+    // Start generating
+    generate_riscv_arch_mapping(&mut f, &target_specs);
 
     // Flush the data onto disk
     f.flush().unwrap();

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -1,6 +1,11 @@
 use gen_target_info::{get_target_specs_from_json, write_target_tuple_mapping, RustcTargetSpecs};
 use std::{fs::File, io::Write as _};
 
+const PRELUDE: &str = r#"//! This file is generated code. Please edit the generator
+//! in dev-tools/gen-target-info if you need to make changes.
+
+"#;
+
 fn generate_riscv_arch_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
     let mut riscv_target_mapping = target_specs
         .0
@@ -24,6 +29,8 @@ fn main() {
 
     let path = format!("{manifest_dir}/../../src/target_info.rs");
     let mut f = File::create(path).expect("failed to create src/target_info.rs");
+
+    f.write_all(PRELUDE.as_bytes()).unwrap();
 
     // Start generating
     generate_riscv_arch_mapping(&mut f, &target_specs);

--- a/dev-tools/gen-target-info/src/read.rs
+++ b/dev-tools/gen-target-info/src/read.rs
@@ -15,7 +15,7 @@ pub fn get_target_specs_from_json() -> RustcTargetSpecs {
     let process::Output { status, stdout, .. } = cmd.output().unwrap();
 
     if !status.success() {
-        panic!("{cmd:?} failed with non-zero exit status: {status}")
+        panic!("{:?} failed with non-zero exit status: {}", cmd, status)
     }
 
     serde_json::from_slice(&stdout).unwrap()

--- a/dev-tools/gen-target-info/src/read.rs
+++ b/dev-tools/gen-target-info/src/read.rs
@@ -1,0 +1,22 @@
+use std::process;
+
+use crate::RustcTargetSpecs;
+
+pub fn get_target_specs_from_json() -> RustcTargetSpecs {
+    let mut cmd = process::Command::new("rustc");
+    cmd.args([
+        "+nightly",
+        "-Zunstable-options",
+        "--print",
+        "all-target-specs-json",
+    ])
+    .stdout(process::Stdio::piped());
+
+    let process::Output { status, stdout, .. } = cmd.output().unwrap();
+
+    if !status.success() {
+        panic!("{cmd:?} failed with non-zero exit status: {status}")
+    }
+
+    serde_json::from_slice(&stdout).unwrap()
+}

--- a/dev-tools/gen-target-info/src/target_specs.rs
+++ b/dev-tools/gen-target-info/src/target_specs.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct PreLinkArgs(
+    /// First field in the linker name,
+    /// second field is the args.
+    #[serde(with = "tuple_vec_map")]
+    pub Vec<(String, Vec<String>)>,
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all(deserialize = "kebab-case"))]
+pub struct TargetSpec {
+    pub arch: String,
+    pub llvm_target: String,
+    /// link env to remove, mostly for apple
+    pub link_env_remove: Option<Vec<String>>,
+    /// link env to set, mostly for apple, e.g. `ZERO_AR_DATE=1`
+    pub link_env: Option<Vec<String>>,
+    pub os: Option<String>,
+    /// `apple`, `pc`
+    pub vendor: Option<String>,
+    pub pre_link_args: Option<PreLinkArgs>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct RustcTargetSpecs(
+    /// First field in the tuple is the rustc target
+    #[serde(with = "tuple_vec_map")]
+    pub Vec<(String, TargetSpec)>,
+);

--- a/dev-tools/gen-target-info/src/write.rs
+++ b/dev-tools/gen-target-info/src/write.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Write as _, fs, io::Write as _};
 
 pub fn write_string_mapping_to_file(f: &mut fs::File, variable_name: &str, data: &[(&str, &str)]) {
-    let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[");
+    let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[\n");
 
     for (f1, f2) in data {
-        write!(&mut content, r#"("{f1}", "{f2}"),"#).unwrap();
+        write!(&mut content, r#"    ("{f1}", "{f2}"),\n"#).unwrap();
     }
 
     content.push_str("];\n");

--- a/dev-tools/gen-target-info/src/write.rs
+++ b/dev-tools/gen-target-info/src/write.rs
@@ -4,7 +4,8 @@ pub fn write_string_mapping_to_file(f: &mut fs::File, variable_name: &str, data:
     let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[\n");
 
     for (f1, f2) in data {
-        write!(&mut content, r#"    ("{f1}", "{f2}"),\n"#).unwrap();
+        write!(&mut content, r#"    ("{f1}", "{f2}"),"#).unwrap();
+        content.push('\n');
     }
 
     content.push_str("];\n");

--- a/dev-tools/gen-target-info/src/write.rs
+++ b/dev-tools/gen-target-info/src/write.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write as _, fs, io::Write as _};
 
-pub fn write_string_mapping_to_file(f: &mut fs::File, variable_name: &str, data: &[(&str, &str)]) {
+pub fn write_target_tuple_mapping(f: &mut fs::File, variable_name: &str, data: &[(&str, &str)]) {
     let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[\n");
 
     for (f1, f2) in data {

--- a/dev-tools/gen-target-info/src/write.rs
+++ b/dev-tools/gen-target-info/src/write.rs
@@ -1,0 +1,13 @@
+use std::{fmt::Write as _, fs, io::Write as _};
+
+pub fn write_string_mapping_to_file(f: &mut fs::File, variable_name: &str, data: &[(&str, &str)]) {
+    let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[");
+
+    for (f1, f2) in data {
+        write!(&mut content, r#"("{f1}", "{f2}"),"#).unwrap();
+    }
+
+    content.push_str("];\n");
+
+    f.write_all(content.as_bytes()).unwrap();
+}

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,2 +1,10 @@
 pub const RISCV_ARCH_MAPPING: &[(&str, &str)] = &[
-    ("riscv32gc", "riscv32"),\n    ("riscv32i", "riscv32"),\n    ("riscv32im", "riscv32"),\n    ("riscv32imac", "riscv32"),\n    ("riscv32imafc", "riscv32"),\n    ("riscv32imc", "riscv32"),\n    ("riscv64gc", "riscv64"),\n    ("riscv64imac", "riscv64"),\n];
+    ("riscv32gc", "riscv32"),
+    ("riscv32i", "riscv32"),
+    ("riscv32im", "riscv32"),
+    ("riscv32imac", "riscv32"),
+    ("riscv32imafc", "riscv32"),
+    ("riscv32imc", "riscv32"),
+    ("riscv64gc", "riscv64"),
+    ("riscv64imac", "riscv64"),
+];

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,0 +1,1 @@
+pub const RISCV_ARCH_MAPPING: &[(&str, &str)] = &[("riscv32gc", "riscv32"),("riscv32i", "riscv32"),("riscv32im", "riscv32"),("riscv32imac", "riscv32"),("riscv32imafc", "riscv32"),("riscv32imc", "riscv32"),("riscv64gc", "riscv64"),("riscv64imac", "riscv64"),];

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,1 +1,2 @@
-pub const RISCV_ARCH_MAPPING: &[(&str, &str)] = &[("riscv32gc", "riscv32"),("riscv32i", "riscv32"),("riscv32im", "riscv32"),("riscv32imac", "riscv32"),("riscv32imafc", "riscv32"),("riscv32imc", "riscv32"),("riscv64gc", "riscv64"),("riscv64imac", "riscv64"),];
+pub const RISCV_ARCH_MAPPING: &[(&str, &str)] = &[
+    ("riscv32gc", "riscv32"),\n    ("riscv32i", "riscv32"),\n    ("riscv32im", "riscv32"),\n    ("riscv32imac", "riscv32"),\n    ("riscv32imafc", "riscv32"),\n    ("riscv32imc", "riscv32"),\n    ("riscv64gc", "riscv64"),\n    ("riscv64imac", "riscv64"),\n];

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,3 +1,6 @@
+//! This file is generated code. Please edit the generator
+//! in dev-tools/gen-target-info if you need to make changes.
+
 pub const RISCV_ARCH_MAPPING: &[(&str, &str)] = &[
     ("riscv32gc", "riscv32"),
     ("riscv32i", "riscv32"),


### PR DESCRIPTION
Fixed #994

Add new workspace crate `gen-target-info` for generating `src/target_info.rs`, and use it to simplify riscv target arch mapping logic in `Build::add_default_flags`