### PR TITLE
Fix xcrun sdk version arg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3616,7 +3616,7 @@ impl Build {
 
             let version = run_output(
                 self.cmd("xcrun")
-                    .arg("--show-sdk-platform-version")
+                    .arg("--show-sdk-version")
                     .arg("--sdk")
                     .arg(sdk),
                 "xcrun",


### PR DESCRIPTION
We should use `xcrun --show-sdk-version ...` to obtain targeted apple os version instead of `--show-sdk-platform-version`, as shown in my screenshot.
![屏幕快照 2024-03-12 下午7 07 06](https://github.com/rust-lang/cc-rs/assets/56025753/dfe43239-f506-4895-8ddb-9b1c85b187a8)

Closes #1001, closes #963 