### PR TITLE
Improve gcc detection

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -97,7 +97,10 @@ impl Tool {
             };
             if stdout.contains("clang") {
                 ToolFamily::Clang
-            } else if stdout.contains("GCC") {
+            } else if stdout.contains("GCC")
+                || stdout.contains("gcc")
+                || stdout.contains("Free Software Foundation")
+            {
                 ToolFamily::Gnu
             } else {
                 // --version doesn't include clang for GCC


### PR DESCRIPTION
`cc --version` / `gcc --version` doesn't necessarily contains `GCC` in output, for example, on Ubuntu 22.04:

```bash
$ cc --version
cc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```