### PR TITLE
Fix regression in compiler family detection

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -135,9 +135,9 @@ impl Tool {
 
             cargo_output.print_debug(&stdout);
 
-            let clang = stdout.contains("clang");
-            let msvc = stdout.contains("msvc");
-            let gcc = stdout.contains("gcc");
+            let clang = stdout.contains(r#""clang""#);
+            let msvc = stdout.contains(r#""msvc""#);
+            let gcc = stdout.contains(r#""gcc""#);
 
             match (clang, msvc, gcc) {
                 (clang_cl, true, _) => Ok(ToolFamily::Msvc { clang_cl }),


### PR DESCRIPTION
f36d6a7ed06033c38021ef65e2b7f1da38932024 introduced a regression where if your output directory had any of the special strings in it it would erronously find the string.

For example, my output dir is /workspaces/ars/build_windows_clang_x86_64_relnoopt/./cargo/build/x86_64-pc-windows-msvc/release/

But i'm using clang (and not clang-cl), so it finds `msvc` in the output and decides this is clang-cl.

Adding the quotes still feels messy--but I'm not sure if there is a bettery way--you can't just search for the pragma comment as at least clang seems to insert the parenthesis. We could use a regular expression of something like `#\s*pragma\s*message\s*\(?\s*"clang"\s*\)?` but that's kinda icky as well.
