### PR TITLE
fix llvm-ar as archiver for msvc targets; fix clang-cl detection; fix assembler output flag detection; add clang/clang-cl windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: $Env:AR="llvm-ar" ; $Env:CC="clang" ; $Env:CXX="clang++" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
+            env: AR=llvm-ar CC=clang CXX=clang++ RUSTFLAGS=-Clinker=lld-link
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
@@ -99,6 +99,8 @@ jobs:
     - name: add clang to path
       run: $Env:PATH += ";C:\msys64\mingw64\bin"
       if: matrix.build == 'windows-clang'
+    - run : echo ${{ matrix.env }} >> $GITHUB_ENV
+      shell: bash
     - uses: Swatinem/rust-cache@v2
     - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
     - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,12 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: AR=llvm-ar CC=clang CXX=clang++ RUSTFLAGS=-Clinker=lld-link
+            env: $Env:AR="llvm-ar" ; $Env:CC="clang" ; $Env:CXX="clang++" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
           - build: windows-clang-cl
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: AR=llvm-ar CC=clang-cl CXX=clang-cl RUSTFLAGS=-Clinker=lld-link
+            env: $Env:AR="llvm-ar" ; $Env:CC="clang-cl" ; $Env:CXX="clang-cl" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
@@ -104,14 +104,10 @@ jobs:
     - name: add clang to path
       run: $Env:PATH += ";C:\msys64\mingw64\bin"
       if: startsWith(matrix.build, 'windows-clang')
-    - run : echo ${{ matrix.env }} | xargs -I{} -n1 -- bash -c "echo {} >> $GITHUB_ENV"
-      shell: bash
-    - run: env
-      shell: bash
     - uses: Swatinem/rust-cache@v2
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,8 @@ jobs:
       if: startsWith(matrix.build, 'windows-clang')
     - run : echo ${{ matrix.env }} | xargs -I{} -n1 -- bash -c "echo {} >> $GITHUB_ENV"
       shell: bash
+    - run: env
+      shell: bash
     - uses: Swatinem/rust-cache@v2
     - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
     - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: AR=llvm-ar CC=clang CXX=clang++ RUSTFLAGS=-Clinker=lld-link
+            env: $Env:AR="llvm-ar" ; $Env:CC="clang" ; $Env:CXX="clang++" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, linux32, macos, aarch64-macos, aarch64-ios, win32, win64, mingw32, mingw64, windows-2019]
+        build:
+          [
+            stable,
+            beta,
+            nightly,
+            linux32,
+            macos,
+            aarch64-macos,
+            aarch64-ios,
+            win32,
+            win64,
+            mingw32,
+            mingw64,
+            windows-2019,
+          ]
         include:
           - build: stable
             os: ubuntu-latest
@@ -76,38 +90,46 @@ jobs:
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: $Env:AR="llvm-ar" ; $Env:CC="clang" ; $Env:CXX="clang++" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
+            CC: clang
+            CXX: clang++
           - build: windows-clang-cl
             os: windows-2019
             rust: stable
             target: x86_64-pc-windows-msvc
-            env: $Env:AR="llvm-ar" ; $Env:CC="clang-cl" ; $Env:CXX="clang-cl" ; $Env:RUSTFLAGS="-Clinker=lld-link" ;
+            CC: clang-cl
+            CXX: clang-cl
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust (rustup)
-      run: |
-        set -euxo pipefail
-        rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal --target ${{ matrix.target }}
-        rustup default ${{ matrix.rust }}
-      shell: bash
-    - name: Install g++-multilib
-      run: |
-        set -e
-        # Remove the ubuntu-toolchain-r/test PPA, which is added by default.
-        # Some packages were removed, and this is causing the g++multilib
-        # install to fail. Similar issue:
-        # https://github.com/scikit-learn/scikit-learn/issues/13928.
-        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
-        sudo apt-get install g++-multilib
-      if: matrix.build == 'linux32'
-    - name: add clang to path
-      run: $Env:PATH += ";C:\msys64\mingw64\bin"
-      if: startsWith(matrix.build, 'windows-clang')
-    - uses: Swatinem/rust-cache@v2
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+      - uses: actions/checkout@v4
+      - name: Install Rust (rustup)
+        run: |
+          set -euxo pipefail
+          rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal --target ${{ matrix.target }}
+          rustup default ${{ matrix.rust }}
+        shell: bash
+      - name: Install g++-multilib
+        run: |
+          set -e
+          # Remove the ubuntu-toolchain-r/test PPA, which is added by default.
+          # Some packages were removed, and this is causing the g++multilib
+          # install to fail. Similar issue:
+          # https://github.com/scikit-learn/scikit-learn/issues/13928.
+          sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install g++-multilib
+        if: matrix.build == 'linux32'
+      - name: add clang to path
+        if: startsWith(matrix.build, 'windows-clang')
+        run: |
+          echo "C:\msys64\mingw64\bin" >> "$GITHUB_PATH"
+          echo -e "AR=llvm-ar\nRUSTFLAGS=-Clinker=lld-link\nCC=${CC}\nCXX=${CXX}" >> "$GITHUB_ENV"
+        shell: bash
+        env:
+          CC: ${{ matrix.CC }}
+          CXX: ${{ matrix.CXX }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:
@@ -133,37 +155,37 @@ jobs:
             target: x86_64-apple-tvos
             no_run: --no-run
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust (rustup)
-      run: |
-        set -euxo pipefail
-        rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal
-        rustup component add rust-src --toolchain ${{ matrix.rust }}
-        rustup default ${{ matrix.rust }}
-      shell: bash
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-    - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+      - uses: actions/checkout@v4
+      - name: Install Rust (rustup)
+        run: |
+          set -euxo pipefail
+          rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal
+          rustup component add rust-src --toolchain ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+        shell: bash
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   cuda:
     name: Test CUDA support
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v4
-    - name: Install cuda-minimal-build-11-8
-      shell: bash
-      run: |
-        # https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
-        sudo apt-get update
-        sudo apt-get -y install cuda-minimal-build-11-8
-    - uses: Swatinem/rust-cache@v2
-    - name: Test 'cudart' feature
-      shell: bash
-      run: |
-        PATH="/usr/local/cuda/bin:$PATH" cargo test --manifest-path dev-tools/cc-test/Cargo.toml --features test_cuda
+      - uses: actions/checkout@v4
+      - name: Install cuda-minimal-build-11-8
+        shell: bash
+        run: |
+          # https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+          sudo dpkg -i cuda-keyring_1.0-1_all.deb
+          sudo apt-get update
+          sudo apt-get -y install cuda-minimal-build-11-8
+      - uses: Swatinem/rust-cache@v2
+      - name: Test 'cudart' feature
+        shell: bash
+        run: |
+          PATH="/usr/local/cuda/bin:$PATH" cargo test --manifest-path dev-tools/cc-test/Cargo.toml --features test_cuda
 
   msrv:
     name: MSRV
@@ -173,42 +195,42 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        rustup toolchain install 1.53.0 --no-self-update --profile minimal
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup default 1.53.0
-      shell: bash
-    - name: Create Cargo.lock with minimal version
-      run: cargo +nightly update -Zminimal-versions
-    - name: Cache downloaded crates since 1.53 is really slow in fetching
-      uses: Swatinem/rust-cache@v2
-    - run: cargo check --lib -p cc --locked
-    - run: cargo check --lib -p cc --locked --all-features
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup toolchain install 1.53.0 --no-self-update --profile minimal
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup default 1.53.0
+        shell: bash
+      - name: Create Cargo.lock with minimal version
+        run: cargo +nightly update -Zminimal-versions
+      - name: Cache downloaded crates since 1.53 is really slow in fetching
+        uses: Swatinem/rust-cache@v2
+      - run: cargo check --lib -p cc --locked
+      - run: cargo check --lib -p cc --locked --all-features
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
-        rustup default stable
-      shell: bash
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo clippy
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
+          rustup default stable
+        shell: bash
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
-        rustup default stable
-      shell: bash
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo fmt -- --check
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
+          rustup default stable
+        shell: bash
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt -- --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,11 @@ jobs:
             os: windows-2019
             rust: stable-x86_64
             target: x86_64-pc-windows-msvc
+          - build: windows-clang
+            os: windows-2019
+            rust: stable
+            target: x86_64-pc-windows-msvc
+            env: AR=llvm-ar CC=clang CXX=clang++ RUSTFLAGS=-Clinker=lld-link
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)
@@ -92,9 +97,9 @@ jobs:
         sudo apt-get install g++-multilib
       if: matrix.build == 'linux32'
     - uses: Swatinem/rust-cache@v2
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install g++-multilib
       if: matrix.build == 'linux32'
+    - name: add clang to path
+      run: $Env:PATH += ";C:\msys64\mingw64\bin"
+      if: matrix.build == 'windows-clang'
     - uses: Swatinem/rust-cache@v2
     - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
     - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,9 +126,6 @@ jobs:
         env:
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}
-      - name: setup dev environment
-        uses: ilammy/msvc-dev-cmd@v1
-        if: startsWith(matrix.build, 'windows-clang')
       - uses: Swatinem/rust-cache@v2
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,9 @@ jobs:
         env:
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}
+      - name: setup dev environment
+        uses: ilammy/msvc-dev-cmd@v1
+        if: startsWith(matrix.build, 'windows-clang')
       - uses: Swatinem/rust-cache@v2
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,9 +107,9 @@ jobs:
     - run : echo ${{ matrix.env }} >> $GITHUB_ENV
       shell: bash
     - uses: Swatinem/rust-cache@v2
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-    - run: ${{ matrix.env }} cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
+    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
+    - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,8 +103,8 @@ jobs:
       if: matrix.build == 'linux32'
     - name: add clang to path
       run: $Env:PATH += ";C:\msys64\mingw64\bin"
-      if: matrix.build == 'windows-clang'
-    - run : echo ${{ matrix.env }} >> $GITHUB_ENV
+      if: startsWith(matrix.build, 'windows-clang')
+    - run : echo ${{ matrix.env }} | xargs -I{} -n1 -- bash -c "echo {} >> $GITHUB_ENV"
       shell: bash
     - uses: Swatinem/rust-cache@v2
     - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,11 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
             env: AR=llvm-ar CC=clang CXX=clang++ RUSTFLAGS=-Clinker=lld-link
+          - build: windows-clang-cl
+            os: windows-2019
+            rust: stable
+            target: x86_64-pc-windows-msvc
+            env: AR=llvm-ar CC=clang-cl CXX=clang-cl RUSTFLAGS=-Clinker=lld-link
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust (rustup)

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -92,7 +92,7 @@ fn main() {
         } else if compiler.is_like_clang() {
             "CLANG"
         } else {
-            unimplemented!("Unknown compiler that targets msvc but isn't clang-link or msvc-like")
+            unimplemented!("Unknown compiler that targets msvc but isn't clang-like or msvc-like")
         };
 
         let out = out.join("tmp");

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -112,7 +112,7 @@ fn main() {
         fs::create_dir(&out).unwrap();
 
         // windows registry won't find clang in path
-        if compiler.is_like_msvc() {
+        if !compiler.path().to_string_lossy().starts_with("clang-") {
             env::remove_var("PATH");
         }
         env::remove_var("VCINSTALLDIR");

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -112,7 +112,7 @@ fn main() {
         fs::create_dir(&out).unwrap();
 
         // windows registry won't find clang in path
-        if !compiler.path().to_string_lossy().starts_with("clang-") {
+        if !compiler.path().to_string_lossy().starts_with("clang") {
             env::remove_var("PATH");
         }
         env::remove_var("VCINSTALLDIR");

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -31,7 +31,8 @@ fn main() {
     }
 
     let mut build = cc::Build::new();
-    build.file("src/foo.c")
+    build
+        .file("src/foo.c")
         .flag_if_supported("-Wall")
         .flag_if_supported("-Wfoo-bar-this-flag-does-not-exist")
         .define("FOO", None)

--- a/dev-tools/cc-test/src/NMakefile
+++ b/dev-tools/cc-test/src/NMakefile
@@ -1,14 +1,20 @@
 all: $(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.exe
 
+!IF "$(CC_FRONTEND)" == "MSVC"
+EXTRA_CFLAGS=-nologo
+CFLAG_OUTPUT=-Fo:
+!ELSE
+CFLAG_OUTPUT=-o
+!ENDIF
+
 $(OUT_DIR)/msvc.lib: $(OUT_DIR)/msvc.o
 	lib -nologo -out:$(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.o
-	rc -h
 
 $(OUT_DIR)/msvc.o: src/msvc.c
-	$(CC) -nologo -c -Fo:$@ src/msvc.c -MD
+	$(CC) $(EXTRA_CFLAGS) -c $(CFLAG_OUTPUT)$@ src/msvc.c -MD
 
 $(OUT_DIR)/msvc.exe: $(OUT_DIR)/msvc2.o
-	$(CC) -nologo -Fo:$@ $(OUT_DIR)/msvc2.o
+	$(CC) $(EXTRA_CFLAGS) $(CFLAG_OUTPUT)$@ $(OUT_DIR)/msvc2.o
 
 $(OUT_DIR)/msvc2.o: src/msvc.c
-	$(CC) -nologo -c -Fo:$@ src/msvc.c -DMAIN -MD
+	$(CC) $(EXTRA_CFLAGS) -c $(CFLAG_OUTPUT)$@ src/msvc.c -DMAIN -MD

--- a/dev-tools/cc-test/src/NMakefile
+++ b/dev-tools/cc-test/src/NMakefile
@@ -2,7 +2,7 @@ all: $(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.exe
 
 !IF "$(CC_FRONTEND)" == "MSVC"
 EXTRA_CFLAGS=-nologo
-CFLAG_OUTPUT=-Fo:
+CFLAG_OUTPUT=-Fo
 !ELSE
 CFLAG_OUTPUT=-o
 !ENDIF

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -385,17 +385,20 @@ for help)"
     }
 }
 
-pub(crate) fn command_add_output_file(
-    cmd: &mut Command,
-    dst: &Path,
-    cuda: bool,
-    msvc: bool,
-    clang: bool,
-    gnu: bool,
-    is_asm: bool,
-    is_arm: bool,
-) {
-    if msvc && !clang && !gnu && !cuda && !(is_asm && is_arm) {
+pub(crate) struct CmdAddOutputFileArgs {
+    pub(crate) cuda: bool,
+    pub(crate) is_assembler_msvc: bool,
+    pub(crate) msvc: bool,
+    pub(crate) clang: bool,
+    pub(crate) gnu: bool,
+    pub(crate) is_asm: bool,
+    pub(crate) is_arm: bool,
+}
+
+pub(crate) fn command_add_output_file(cmd: &mut Command, dst: &Path, args: CmdAddOutputFileArgs) {
+    if args.is_assembler_msvc
+        || (args.msvc && !args.clang && !args.gnu && !args.cuda && !(args.is_asm && args.is_arm))
+    {
         let mut s = OsString::from("-Fo");
         s.push(dst);
         cmd.arg(s);

--- a/src/detect_compiler_family.c
+++ b/src/detect_compiler_family.c
@@ -5,7 +5,3 @@
 #ifdef __GNUC__
 #pragma message "gcc"
 #endif
-
-#ifdef _MSC_VER
-#pragma message "msvc"
-#endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/cc/1.0")]
-#![cfg_attr(test, deny(warnings))]
+// #![cfg_attr(test, deny(warnings))]
 #![allow(deprecated)]
 #![deny(missing_docs)]
 
@@ -1601,7 +1601,7 @@ impl Build {
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
         if is_assembler_msvc || compiler.is_like_msvc() {
-            let mut out_arg = OsString::from("/Fo");
+            let mut out_arg = OsString::from("-Fo");
             out_arg.push(&obj.dst);
             cmd.arg(out_arg);
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2412,7 +2412,7 @@ impl Build {
 
         let target = self.get_target()?;
         let (mut ar, cmd, _any_flags) = self.get_ar()?;
-        if target.contains("msvc") && !cmd.to_string_lossy().contains("llvm-") {
+        if target.contains("msvc") {
             // The Rust compiler will look for libfoo.a and foo.lib, but the
             // MSVC linker will also be passed foo.lib, so be sure that both
             // exist for now.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1579,8 +1579,6 @@ impl Build {
         let target = self.get_target()?;
         let msvc = target.contains("msvc");
         let compiler = self.try_get_compiler()?;
-        let clang = compiler.is_like_clang();
-        let gnu = compiler.family == ToolFamily::Gnu;
 
         let is_assembler_msvc = msvc && asm_ext == Some(AsmFileExt::DotAsm);
         let (mut cmd, name) = if is_assembler_msvc {
@@ -1602,9 +1600,12 @@ impl Build {
             )
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(
-            &mut cmd, &obj.dst, self.cuda, msvc, clang, gnu, is_asm, is_arm,
-        );
+        if is_assembler_msvc {
+            cmd.arg("/Fo");
+        } else {
+            cmd.arg("-o");
+        }
+        cmd.arg(&obj.dst);
         // armasm and armasm64 don't requrie -c option
         if !is_assembler_msvc || !is_arm {
             cmd.arg("-c");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1601,11 +1601,12 @@ impl Build {
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
         if is_assembler_msvc {
-            cmd.arg("/Fo");
+            let mut out_arg = PathBuf::from("/Fo");
+            out_arg.push(&obj.dst);
+            cmd.arg(out_arg);
         } else {
-            cmd.arg("-o");
+            cmd.arg("-o").arg(&obj.dst);
         }
-        cmd.arg(&obj.dst);
         // armasm and armasm64 don't requrie -c option
         if !is_assembler_msvc || !is_arm {
             cmd.arg("-c");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,7 +2399,7 @@ impl Build {
 
         let target = self.get_target()?;
         let (mut ar, cmd, _any_flags) = self.get_ar()?;
-        if target.contains("msvc") && !cmd.to_str().unwrap().contains("llvm-") {
+        if target.contains("msvc") && !cmd.to_string_lossy().contains("llvm-") {
             // The Rust compiler will look for libfoo.a and foo.lib, but the
             // MSVC linker will also be passed foo.lib, so be sure that both
             // exist for now.
@@ -2436,7 +2436,7 @@ impl Build {
         let target = self.get_target()?;
 
         let (mut cmd, program, any_flags) = self.get_ar()?;
-        if target.contains("msvc") && !program.to_str().unwrap().contains("llvm-") {
+        if target.contains("msvc") && !program.to_string_lossy().contains("llvm-") {
             // NOTE: -out: here is an I/O flag, and so must be included even if $ARFLAGS/ar_flag is
             // in use. -nologo on the other hand is just a regular flag, and one that we'll skip if
             // the caller has explicitly dictated the flags they want. See

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1600,7 +1600,7 @@ impl Build {
             )
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        if is_assembler_msvc {
+        if is_assembler_msvc || compiler.is_like_msvc() {
             let mut out_arg = OsString::from("/Fo");
             out_arg.push(&obj.dst);
             cmd.arg(out_arg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,7 +2399,7 @@ impl Build {
 
         let target = self.get_target()?;
         let (mut ar, cmd, _any_flags) = self.get_ar()?;
-        if target.contains("msvc") && ! ar.get_program().to_str().unwrap().contains("llvm-") {
+        if target.contains("msvc") && ! cmd.to_str().unwrap().contains("llvm-") {
             // The Rust compiler will look for libfoo.a and foo.lib, but the
             // MSVC linker will also be passed foo.lib, so be sure that both
             // exist for now.
@@ -2436,7 +2436,7 @@ impl Build {
         let target = self.get_target()?;
 
         let (mut cmd, program, any_flags) = self.get_ar()?;
-        if target.contains("msvc") && !cmd.get_program().to_str().unwrap().contains("llvm-") {
+        if target.contains("msvc") && !program.to_str().unwrap().contains("llvm-") {
             // NOTE: -out: here is an I/O flag, and so must be included even if $ARFLAGS/ar_flag is
             // in use. -nologo on the other hand is just a regular flag, and one that we'll skip if
             // the caller has explicitly dictated the flags they want. See
@@ -3122,12 +3122,13 @@ impl Build {
         Ok(self.get_base_archiver_variant("RANLIB", "ranlib")?.0)
     }
 
-    fn get_base_archiver_variant(&self, env: &str, tool: &str) -> Result<(Command, String), Error> {
+    fn get_base_archiver_variant(&self, env: &str, tool: &str) -> Result<(Command, PathBuf), Error> {
         let target = self.get_target()?;
-        let mut name = String::new();
+        let mut name = PathBuf::new();
         let tool_opt: Option<Command> = self
             .env_tool(env)
             .map(|(tool, _wrapper, args)| {
+                name = tool.clone();
                 let mut cmd = self.cmd(tool);
                 cmd.args(args);
                 cmd
@@ -3137,11 +3138,11 @@ impl Build {
                     // Windows use bat files so we have to be a bit more specific
                     if cfg!(windows) {
                         let mut cmd = self.cmd("cmd");
-                        name = format!("em{}.bat", tool);
+                        name = format!("em{}.bat", tool).into();
                         cmd.arg("/c").arg(&name);
                         Some(cmd)
                     } else {
-                        name = format!("em{}", tool);
+                        name = format!("em{}", tool).into();
                         Some(self.cmd(&name))
                     }
                 } else if target.starts_with("wasm32") {
@@ -3152,7 +3153,7 @@ impl Build {
                     // of "llvm-ar"...
                     let compiler = self.get_base_compiler().ok()?;
                     if compiler.is_like_clang() {
-                        name = format!("llvm-{}", tool);
+                        name = format!("llvm-{}", tool).into();
                         search_programs(&mut self.cmd(&compiler.path), &name, &self.cargo_output)
                             .map(|name| self.cmd(name))
                     } else {
@@ -3168,10 +3169,10 @@ impl Build {
             Some(t) => t,
             None => {
                 if target.contains("android") {
-                    name = format!("llvm-{}", tool);
+                    name = format!("llvm-{}", tool).into();
                     match Command::new(&name).arg("--version").status() {
                         Ok(status) if status.success() => (),
-                        _ => name = format!("{}-{}", target.replace("armv7", "arm"), tool),
+                        _ => name = format!("{}-{}", target.replace("armv7", "arm"), tool).into(),
                     }
                     self.cmd(&name)
                 } else if target.contains("msvc") {
@@ -3198,7 +3199,7 @@ impl Build {
                     }
 
                     if lib.is_empty() {
-                        name = String::from("lib.exe");
+                        name = PathBuf::from("lib.exe");
                         let mut cmd = match windows_registry::find(&target, "lib.exe") {
                             Some(t) => t,
                             None => self.cmd("lib.exe"),
@@ -3208,7 +3209,7 @@ impl Build {
                         }
                         cmd
                     } else {
-                        name = lib;
+                        name = lib.into();
                         self.cmd(&name)
                     }
                 } else if target.contains("illumos") {
@@ -3216,7 +3217,7 @@ impl Build {
                     // but the OS comes bundled with a GNU-compatible variant.
                     //
                     // Use the GNU-variant to match other Unix systems.
-                    name = format!("g{}", tool);
+                    name = format!("g{}", tool).into();
                     self.cmd(&name)
                 } else if self.get_host()? != target {
                     match self.prefix_for_target(&target) {
@@ -3236,16 +3237,16 @@ impl Build {
                                     break;
                                 }
                             }
-                            name = chosen;
+                            name = chosen.into();
                             self.cmd(&name)
                         }
                         None => {
-                            name = default;
+                            name = default.into();
                             self.cmd(&name)
                         }
                     }
                 } else {
-                    name = default;
+                    name = default.into();
                     self.cmd(&name)
                 }
             }
@@ -3937,7 +3938,7 @@ fn which(tool: &Path, path_entries: Option<OsString>) -> Option<PathBuf> {
 }
 
 // search for |prog| on 'programs' path in '|cc| -print-search-dirs' output
-fn search_programs(cc: &mut Command, prog: &str, cargo_output: &CargoOutput) -> Option<PathBuf> {
+fn search_programs(cc: &mut Command, prog: &Path, cargo_output: &CargoOutput) -> Option<PathBuf> {
     let search_dirs = run_output(
         cc.arg("-print-search-dirs"),
         "cc",
@@ -3950,7 +3951,7 @@ fn search_programs(cc: &mut Command, prog: &str, cargo_output: &CargoOutput) -> 
     let search_dirs = std::str::from_utf8(&search_dirs).ok()?;
     for dirs in search_dirs.split(|c| c == '\r' || c == '\n') {
         if let Some(path) = dirs.strip_prefix("programs: =") {
-            return which(Path::new(prog), Some(OsString::from(path)));
+            return which(prog, Some(OsString::from(path)));
         }
     }
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1601,7 +1601,7 @@ impl Build {
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
         if is_assembler_msvc {
-            let mut out_arg = PathBuf::from("/Fo");
+            let mut out_arg = OsString::from("/Fo");
             out_arg.push(&obj.dst);
             cmd.arg(out_arg);
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2411,7 +2411,6 @@ impl Build {
         }
 
         let target = self.get_target()?;
-        let (mut ar, cmd, _any_flags) = self.get_ar()?;
         if target.contains("msvc") {
             // The Rust compiler will look for libfoo.a and foo.lib, but the
             // MSVC linker will also be passed foo.lib, so be sure that both
@@ -2435,6 +2434,7 @@ impl Build {
             // Non-msvc targets (those using `ar`) need a separate step to add
             // the symbol table to archives since our construction command of
             // `cq` doesn't add it for us.
+            let (mut ar, cmd, _any_flags) = self.get_ar()?;
 
             // NOTE: We add `s` even if flags were passed using $ARFLAGS/ar_flag, because `s`
             // here represents a _mode_, not an arbitrary flag. Further discussion of this choice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,12 +637,15 @@ impl Build {
         command_add_output_file(
             &mut cmd,
             &obj,
-            self.cuda,
-            target.contains("msvc"),
-            clang,
-            gnu,
-            false,
-            is_arm,
+            CmdAddOutputFileArgs {
+                cuda: self.cuda,
+                is_assembler_msvc: false,
+                msvc: compiler.is_like_msvc(),
+                clang,
+                gnu,
+                is_asm: false,
+                is_arm,
+            },
         );
 
         // Checking for compiler flags does not require linking
@@ -1605,12 +1608,15 @@ impl Build {
         command_add_output_file(
             &mut cmd,
             &obj.dst,
-            self.cuda,
-            is_assembler_msvc || compiler.is_like_msvc(),
-            clang,
-            gnu,
-            is_asm,
-            is_arm,
+            CmdAddOutputFileArgs {
+                cuda: self.cuda,
+                is_assembler_msvc,
+                msvc: compiler.is_like_msvc(),
+                clang,
+                gnu,
+                is_asm,
+                is_arm,
+            },
         );
         // armasm and armasm64 don't requrie -c option
         if !is_assembler_msvc || !is_arm {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/cc/1.0")]
-// #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(test, deny(warnings))]
 #![allow(deprecated)]
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,7 +2399,7 @@ impl Build {
 
         let target = self.get_target()?;
         let (mut ar, cmd, _any_flags) = self.get_ar()?;
-        if target.contains("msvc") && ! cmd.to_str().unwrap().contains("llvm-") {
+        if target.contains("msvc") && !cmd.to_str().unwrap().contains("llvm-") {
             // The Rust compiler will look for libfoo.a and foo.lib, but the
             // MSVC linker will also be passed foo.lib, so be sure that both
             // exist for now.
@@ -2482,7 +2482,11 @@ impl Build {
             // NOTE: We add cq here regardless of whether $ARFLAGS/ar_flag have been used because
             // it dictates the _mode_ ar runs in, which the setter of $ARFLAGS/ar_flag can't
             // dictate. See https://github.com/rust-lang/cc-rs/pull/763 for further discussion.
-            run(cmd.arg("cq").arg(dst).args(objs), &program, &self.cargo_output)?;
+            run(
+                cmd.arg("cq").arg(dst).args(objs),
+                &program,
+                &self.cargo_output,
+            )?;
         }
 
         Ok(())
@@ -3122,7 +3126,11 @@ impl Build {
         Ok(self.get_base_archiver_variant("RANLIB", "ranlib")?.0)
     }
 
-    fn get_base_archiver_variant(&self, env: &str, tool: &str) -> Result<(Command, PathBuf), Error> {
+    fn get_base_archiver_variant(
+        &self,
+        env: &str,
+        tool: &str,
+    ) -> Result<(Command, PathBuf), Error> {
         let target = self.get_target()?;
         let mut name = PathBuf::new();
         let tool_opt: Option<Command> = self

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -5,12 +5,13 @@ use std::{
     ffi::{OsStr, OsString},
     io::Write,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     sync::Mutex,
 };
 
 use crate::{
     command_helpers::{run_output, CargoOutput},
+    run,
     tempfile::NamedTempfile,
     Error, ErrorKind,
 };
@@ -135,11 +136,20 @@ impl Tool {
 
             cargo_output.print_debug(&stdout);
 
+            // https://gitlab.kitware.com/cmake/cmake/-/blob/69a2eeb9dff5b60f2f1e5b425002a0fd45b7cadb/Modules/CMakeDetermineCompilerId.cmake#L267-271
+            let accepts_cl_style_flags =
+                run(Command::new(path).arg("-?").stdout(Stdio::null()), path, &{
+                    // the errors are not errors!
+                    let mut cargo_output = cargo_output.clone();
+                    cargo_output.warnings = cargo_output.debug;
+                    cargo_output
+                })
+                .is_ok();
+
             let clang = stdout.contains(r#""clang""#);
-            let msvc = stdout.contains(r#""msvc""#);
             let gcc = stdout.contains(r#""gcc""#);
 
-            match (clang, msvc, gcc) {
+            match (clang, accepts_cl_style_flags, gcc) {
                 (clang_cl, true, _) => Ok(ToolFamily::Msvc { clang_cl }),
                 (true, false, _) => Ok(ToolFamily::Clang {
                     zig_cc: is_zig_cc(path, cargo_output),

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -34,6 +34,11 @@ impl Test {
         // lesser of the two evils.
         env::remove_var("RUSTC_WRAPPER");
 
+        // cc-rs prefers these env vars to the wrappers. We set these in some tests, so unset them so the wrappers get used
+        env::remove_var("CC");
+        env::remove_var("CXX");
+        env::remove_var("AR");
+
         let mut gcc = env::current_exe().unwrap();
         gcc.pop();
         if gcc.ends_with("deps") {


### PR DESCRIPTION
This PR contains several clang on windows improvements:

1. properly detect clang vs clang-cl by invoking with `-?`, instead of checking for `_MSC_VER`. This is what cmake does, and `_MSC_VER` is always defined for msvc ABI targets, regardless of the frontend variant used
2. Fix detection of which output assembler flag to use. It used to use complex logic, including if the C compiler is clang, which was incorrect. Use the flag based on if it's using the msvc assembler
3. Add clang-cl/clang CI for windows
4. Detect usage of llvm-ar and pass GNU style flags to it

Original description:

this is somewhat a nasty hack here, but it does work. when (cross) compiling for msvc and you use llvm-ar as the archiver, then you need to use gnu-style flags.

currently it attemps to run llvm-ar like:

```
running: "/usr/bin/llvm-ar" "-out:/workspaces/ars/build_windows_clang_x86_64_relnoopt/./cargo/build/x86_64-pc-windows-msvc/release/build/link-cplusplus-b04e59fc086748c2/out/liblink-cplusplus.a" "-nologo" "/workspaces/ars/build_windows_clang_x86_64_relnoopt/./cargo/build/x86_64-pc-windows-msvc/release/build/link-cplusplus-b04e59fc086748c2/out/0466faf07398e270-dummy.o"
```

which doesn't work, as llvm-ar takes in GNU-style ar flags.

i'm definitely open to a more robust way to get the archiver "Family" (maybe something similar to how we detect compiler family? idk) if that would be better

I also moved some APIs to to use Path as it avoided a string->path conversion. Let me know if that's not of interest.

With this and the other PR, I can now cross-compile to windows using clang from linux :)

EDIT: also fixes the path to the archiver not being set on when env_tool finds it
