### PR TITLE
Also shim llvm-ar in the clang_android test on non-Windows

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -642,7 +642,8 @@ fn clang_android() {
     {
         let test = Test::new();
         test.shim("arm-linux-androideabi-clang")
-            .shim("arm-linux-androideabi-ar");
+            .shim("arm-linux-androideabi-ar")
+            .shim("llvm-ar");
         test.gcc().target(target).file("foo.c").compile("foo");
         test.cmd(0).must_not_have("--target=arm-linux-androideabi");
     }


### PR DESCRIPTION
In CI we detect and use `arm-linux-androideabi-ar` but some folks locally are seeing the test use `llvm-ar` - this is likely a difference in dependencies on the system (e.g., Android NDK installed or not) so we'll shim both.

Fixes #1012