### PR TITLE
Use specified include directories prior to CFLAGS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1773,15 +1773,15 @@ impl Build {
             cmd.push_cc_arg(format!("-std{}{}", separator, std).into());
         }
 
+        for directory in self.include_directories.iter() {
+            cmd.args.push("-I".into());
+            cmd.args.push(directory.as_os_str().into());
+        }
+
         if let Ok(flags) = self.envflags(if self.cpp { "CXXFLAGS" } else { "CFLAGS" }) {
             for arg in flags {
                 cmd.push_cc_arg(arg.into());
             }
-        }
-
-        for directory in self.include_directories.iter() {
-            cmd.args.push("-I".into());
-            cmd.args.push(directory.as_os_str().into());
         }
 
         // If warnings and/or extra_warnings haven't been explicitly set,


### PR DESCRIPTION
## Issues
See: 
* #1020
* #376

## Problem
The header files in the directories provided via `CFLAGS` can conflict with the specific headers needed for the project being built.  The include files specified by the project should take precedence over those provided via `CFLAGS`.

## Proposed change
A simple re-ordering of the arguments to add the specified include directories prior to those in `CFLAGS`.