### PR TITLE
Don't use the value of SDKROOT if it doesn't match the target.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3656,7 +3656,7 @@ impl Build {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = env::var_os("SDKROOT") {
             let p = PathBuf::from(sdkroot);
-            let sdkroot = sdkroot.to_string_lossy();
+            let sdkroot = p.to_string_lossy();
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.
                 "appletvos"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3654,7 +3654,7 @@ impl Build {
 
     fn apple_sdk_root(&self, sdk: &str) -> Result<OsString, Error> {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
-        if let Ok(sdkroot) = env::var("SDKROOT") {
+        if let Some(sdkroot) = env::var_os("SDKROOT") {
             let p = Path::new(&sdkroot);
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3656,6 +3656,7 @@ impl Build {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = env::var_os("SDKROOT") {
             let p = Path::new(&sdkroot);
+            let sdkroot = sdkroot.to_string_lossy();
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.
                 "appletvos"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3655,7 +3655,7 @@ impl Build {
     fn apple_sdk_root(&self, sdk: &str) -> Result<OsString, Error> {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = env::var_os("SDKROOT") {
-            let p = Path::new(&sdkroot);
+            let p = PathBuf::from(sdkroot);
             let sdkroot = sdkroot.to_string_lossy();
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.
@@ -3688,7 +3688,7 @@ impl Build {
                 }
                 // Ignore `SDKROOT` if it's not a valid path.
                 _ if !p.is_absolute() || p == Path::new("/") || !p.exists() => {}
-                _ => return Ok(sdkroot.into()),
+                _ => return Ok(p.into()),
             }
         }
 


### PR DESCRIPTION
The SDKROOT environment variable can be problematic on Mac. In cases where you are compiling for multiple targets, SDKROOT cannot be right for all of them. Furthermore, the system Python interpreter sets SDKROOT to the MacOSX SDK if not already set.

So, if you are using a Python script to run a build, and you need to build for multiple targets, the logic in the cc crate doesn't work. This is precisely what is happening with rustc itself, and so we can't upgrade the version of the cc crate used by the bootstrap code.

(Unsetting SDKROOT doesn't work either because the custom clang build that rustc uses for CI depends on it being set)