### PR TITLE
fix: emscripten build on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2812,11 +2812,9 @@ impl Build {
                     let tool = if self.cpp { "em++" } else { "emcc" };
                     // Windows uses bat file so we have to be a bit more specific
                     if cfg!(windows) {
-                        let mut t = Tool::new(
+                        let mut t = Tool::with_family(
                             PathBuf::from("cmd"),
-                            &self.cached_compiler_family,
-                            &self.cargo_output,
-                            out_dir,
+                            ToolFamily::Clang { zig_cc: false },
                         );
                         t.args.push("/c".into());
                         t.args.push(format!("{}.bat", tool).into());


### PR DESCRIPTION
Since family detection is performed for `cmd.exe`, it recognizes `msvc` instead of `clang` and passes the wrong compilation options (`-nologo`).