### PR TITLE
Rm unnecessary println in try_get_compiler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1761,8 +1761,6 @@ impl Build {
 
         if !no_defaults {
             self.add_default_flags(&mut cmd, &target, &opt_level)?;
-        } else {
-            println!("Info: default compiler flags are disabled");
         }
 
         if let Some(ref std) = self.std {


### PR DESCRIPTION
when no default flag is specificed