### PR TITLE
Support compiling on wasm targets

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -130,6 +130,8 @@ impl StderrForwarder {
                             self.bytes_available_failed = true;
                             MIN_BUFFER_CAPACITY
                         }
+                        #[cfg(target_family = "wasm")]
+                        Err(_) => unimplemented!(),
                         Ok(bytes_available) => MIN_BUFFER_CAPACITY.max(bytes_available),
                     }
                 } else {

--- a/src/parallel/stderr.rs
+++ b/src/parallel/stderr.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, process::ChildStderr};
 
 use crate::{Error, ErrorKind};
 
-#[cfg(all(not(unix), not(windows)))]
+#[cfg(all(not(unix), not(windows), not(target_family = "wasm"))]
 compile_error!("Only unix and windows support non-blocking pipes! For other OSes, disable the parallel feature.");
 
 #[cfg(unix)]

--- a/src/parallel/stderr.rs
+++ b/src/parallel/stderr.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, process::ChildStderr};
 
 use crate::{Error, ErrorKind};
 
-#[cfg(all(not(unix), not(windows), not(target_family = "wasm"))]
+#[cfg(all(not(unix), not(windows), not(target_family = "wasm")))]
 compile_error!("Only unix and windows support non-blocking pipes! For other OSes, disable the parallel feature.");
 
 #[cfg(unix)]

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[cfg(not(any(unix, target_os = "wasi", windows)))]
+#[cfg(not(any(unix, target_family = "wasm", windows)))]
 compile_error!("Your system is not supported since cc cannot create named tempfile");
 
 fn rand() -> u64 {


### PR DESCRIPTION
In this PR, I added `target_family = "wasm"` to the `compile_error!` exceptions list in a few modules. 

For more context, in a wasm game engine SDK I maintain ([`turbo`](https://crates.io/crates/turbo-genesis-sdk)), I'm pulling in a crate ([`solana-sdk`](https://crates.io/crates/solana-sdk)). However, `cc-rs` is deeply buried in dependencies of dependencies of that crate. This wouldn't be a terrible problem since `cc-rs` (especially the parallel feature stuff) is far from any code path that runs in wasm and optimization can get rid of a unused code, however, the `compile_error!` macro prevents `cc-rs` prevents builds from ever completing in the first place.

So the only option in my case (where `cc-rs` is buried deep in the dependency tree and I'm targeting wasm) currently is to fork and patch. This gets brittle fairly quickly since other dependencies can have version conflicts and force me to create more branches with version bumps and other minor tweaks over time.

I'm hoping we can land this patch and carve out exceptions for wasm with `compile_error!` moving forward 🙏🏽