### PR TITLE
Fix detect_compiler_family.c not being created

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -125,8 +125,8 @@ impl Tool {
                 NamedTempfile::new(&out_dir, "detect_compiler_family.c").map_err(|err| Error {
                     kind: ErrorKind::IOError,
                     message: format!(
-                        "failed to create detect_compiler_family.c temp file in '{:?}': {}",
-                        out_dir, err
+                        "failed to create detect_compiler_family.c temp file in '{}': {}",
+                        out_dir.display(), err
                     )
                     .into(),
                 })?;

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -110,12 +110,26 @@ impl Tool {
             cargo_output: &CargoOutput,
             out_dir: Option<&Path>,
         ) -> Result<ToolFamily, Error> {
-            let tmp = NamedTempfile::new(
-                &out_dir
-                    .map(Cow::Borrowed)
-                    .unwrap_or_else(|| Cow::Owned(env::temp_dir())),
-                "detect_compiler_family.c",
-            )?;
+            let out_dir = out_dir
+                .map(Cow::Borrowed)
+                .unwrap_or_else(|| Cow::Owned(env::temp_dir()));
+
+            // Ensure all the parent directories exist otherwise temp file creation
+            // will fail
+            std::fs::create_dir_all(&out_dir).map_err(|err| Error {
+                kind: ErrorKind::IOError,
+                message: format!("failed to create OUT_DIR '{:?}': {}", out_dir, err).into(),
+            })?;
+
+            let tmp =
+                NamedTempfile::new(&out_dir, "detect_compiler_family.c").map_err(|err| Error {
+                    kind: ErrorKind::IOError,
+                    message: format!(
+                        "failed to create detect_compiler_family.c temp file in '{:?}': {}",
+                        out_dir, err
+                    )
+                    .into(),
+                })?;
             tmp.file()
                 .write_all(include_bytes!("detect_compiler_family.c"))?;
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -118,7 +118,7 @@ impl Tool {
             // will fail
             std::fs::create_dir_all(&out_dir).map_err(|err| Error {
                 kind: ErrorKind::IOError,
-                message: format!("failed to create OUT_DIR '{:?}': {}", out_dir, err).into(),
+                message: format!("failed to create OUT_DIR '{}': {}", out_dir.display(), err).into(),
             })?;
 
             let tmp =

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -118,7 +118,8 @@ impl Tool {
             // will fail
             std::fs::create_dir_all(&out_dir).map_err(|err| Error {
                 kind: ErrorKind::IOError,
-                message: format!("failed to create OUT_DIR '{}': {}", out_dir.display(), err).into(),
+                message: format!("failed to create OUT_DIR '{}': {}", out_dir.display(), err)
+                    .into(),
             })?;
 
             let tmp =
@@ -126,7 +127,8 @@ impl Tool {
                     kind: ErrorKind::IOError,
                     message: format!(
                         "failed to create detect_compiler_family.c temp file in '{}': {}",
-                        out_dir.display(), err
+                        out_dir.display(),
+                        err
                     )
                     .into(),
                 })?;


### PR DESCRIPTION
This fixes an issue where the detect_compiler_family.c temp file would not be created, thus falling back to defaults, printing a warning, eg `warning: libz-sys@1.1.18: Compiler family detection failed due to error: IOError: No such file or directory (os error 2)`. I noticed this when debugging a `cargo package` command, as I believe that is an edge case due to how it differs from a normal cargo build.