### PR TITLE
Don't assume GCC toolchain supports the same dwarf format rust uses

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -422,12 +422,12 @@ impl ToolFamily {
             ToolFamily::Msvc { .. } => {
                 cmd.push_cc_arg("-Z7".into());
             }
+            ToolFamily::Clang { .. } if dwarf_version.is_some() => {
+                cmd.push_cc_arg(format!("-gdwarf-{}", dwarf_version.unwrap()).into());
+            }
+            // Don't assume gcc supports the same dwarf version rust/llvm does (#1075)
             ToolFamily::Gnu | ToolFamily::Clang { .. } => {
-                cmd.push_cc_arg(
-                    dwarf_version
-                        .map_or_else(|| "-g".into(), |v| format!("-gdwarf-{}", v))
-                        .into(),
-                );
+                cmd.push_cc_arg("-g".into());
             }
         }
     }


### PR DESCRIPTION
While it may be a fairly safe assumption that we can use the same dwarf version rust uses (0fff25a) if we're compiling with clang, it might not be a valid assumption for the Gnu toolchain.

I tried to pull the logic up to `add_default_flags()`, but that would require running `is_flag_supported()` in the call to `add_default_flags()` which, while possible, might not be the expected or desired behavior. The alternate implementation would look like this, but I think this PR as submitted is probably the better way to go.

<details>
<pre lang="diff">
diff --git a/src/lib.rs b/src/lib.rs
index 9b2816f..69b7e28 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1921,7 +1921,15 @@ impl Build {
                 cmd.args.push("-G".into());
             }
             let family = cmd.family;
-            family.add_debug_flags(cmd, self.get_dwarf_version());
+            let (flag, opt_flag) = family.get_debug_flags(self.get_dwarf_version());
+            if let Some(flag) = flag {
+                cmd.args.push(flag.into());
+            }
+            if let Some(flag) = opt_flag {
+                if self.is_flag_supported(&flag).unwrap_or(false) {
+                    cmd.args.push(flag.into());
+                }
+            }
         }
 <br>
         if self.get_force_frame_pointer() {
diff --git a/src/tool.rs b/src/tool.rs
index ea0f36f..ff6f517 100644
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -416,19 +416,21 @@ pub enum ToolFamily {
 }
 <br>
 impl ToolFamily {
-    /// What the flag to request debug info for this family of tools look like
-    pub(crate) fn add_debug_flags(&self, cmd: &mut Tool, dwarf_version: Option<u32>) {
+    /// What the flag to request debug info for this family of tools look like.
+    ///
+    /// Return value is a tuple of `(Option<Flag>, Option<FlagIfSupported>)` where `Flag` may
+    /// be set unconditionally but `FlagIfSupported` should be tested for support first.
+    pub(crate) fn get_debug_flags(
+        &self,
+        dwarf_version: Option<u32>,
+    ) -> (Option<String>, Option<String>) {
         match *self {
-            ToolFamily::Msvc { .. } => {
-                cmd.push_cc_arg("-Z7".into());
-            }
-            ToolFamily::Gnu | ToolFamily::Clang { .. } => {
-                cmd.push_cc_arg(
-                    dwarf_version
-                        .map_or_else(|| "-g".into(), |v| format!("-gdwarf-{}", v))
-                        .into(),
-                );
-            }
+            ToolFamily::Msvc { .. } => (Some("-Z7".into()), None),
+            ToolFamily::Clang { .. } => match dwarf_version {
+                Some(v) => (Some(format!("-gdwarf-{v}")), None),
+                None => (Some("-g".into()), None),
+            },
+            ToolFamily::Gnu => (Some("-g".into()), Some(format!("-g").into())),
         }
     }
</pre>
</details>

Closes #1075.