### PR TITLE
Deprecate cc::Build::static_flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,7 +766,7 @@ impl Build {
     /// ```
     #[deprecated(
         since = "1.0.99",
-        note = "cc itself always generates a archive. If you use cc::Tool::to_command(), then you shall manually add -static to command"
+        note = "cc itself always generates an archive. If you really need `-static`, use `cc::Tool::to_command()` and add it to the `Command` arguments."
     )]
     pub fn static_flag(&mut self, static_flag: bool) -> &mut Build {
         self.static_flag = Some(static_flag);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,6 +764,10 @@ impl Build {
     ///     .static_flag(true)
     ///     .compile("foo");
     /// ```
+    #[deprecated(
+        since = "1.0.99",
+        note = "cc itself always generates a archive. If you use cc::Tool::to_command(), then you shall manually add -static to command"
+    )]
     pub fn static_flag(&mut self, static_flag: bool) -> &mut Build {
         self.static_flag = Some(static_flag);
         self


### PR DESCRIPTION
cc only compiles file and does not do any linking at all, so `-static` doesn't make sense