### PR TITLE
Fix WASI compilation for C++

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1912,6 +1912,10 @@ impl Build {
                         cmd.push_cc_arg("-fno-plt".into());
                     }
                 }
+                if target.contains("wasm32") {
+                    // WASI does not support exceptions yet.
+                    cmd.push_cc_arg("-fno-exceptions".into());
+                }
             }
         }
 
@@ -2861,7 +2865,11 @@ impl Build {
                     || target == "wasm32-unknown-wasi"
                     || target == "wasm32-unknown-unknown"
                 {
-                    "clang".to_string()
+                    if self.cpp {
+                        "clang++".to_string()
+                    } else {
+                        "clang".to_string()
+                    }
                 } else if target.contains("vxworks") {
                     if self.cpp {
                         "wr-c++".to_string()
@@ -3099,6 +3107,7 @@ impl Build {
                         | target.contains("openbsd")
                         | target.contains("aix")
                         | target.contains("linux-ohos")
+                        | target.contains("wasm32")
                     {
                         Ok(Some("c++".to_string()))
                     } else if target.contains("android") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,7 +1318,7 @@ impl Build {
                 let wasi_sysroot = self.wasi_sysroot()?;
                 self.cargo_output.print_metadata(&format_args!(
                     "cargo:rustc-flags=-L {}/lib/wasm32-wasi -lstatic=c++ -lstatic=c++abi",
-                    wasi_sysroot.display()
+                    wasi_sysroot
                 ));
             }
         }
@@ -1926,7 +1926,7 @@ impl Build {
                     cmd.push_cc_arg("-fno-exceptions".into());
                     // Link clang sysroot
                     let wasi_sysroot = self.wasi_sysroot()?;
-                    cmd.push_cc_arg(format!("--sysroot={}", wasi_sysroot.display()).into());
+                    cmd.push_cc_arg(format!("--sysroot={}", wasi_sysroot).into());
                 }
             }
         }
@@ -3873,10 +3873,9 @@ impl Build {
         }
     }
 
-    fn wasi_sysroot(&self) -> Result<PathBuf, Error> {
+    fn wasi_sysroot(&self) -> Result<Arc<str>, Error> {
         if let Some(wasi_sysroot_path) = self.getenv("WASI_SYSROOT") {
-            let path = PathBuf::from(wasi_sysroot_path.as_ref());
-            Ok(path)
+            Ok(wasi_sysroot_path)
         } else {
             Err(Error::new(
                 ErrorKind::EnvVarNotFound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1912,9 +1912,18 @@ impl Build {
                         cmd.push_cc_arg("-fno-plt".into());
                     }
                 }
-                if target.contains("wasm32") {
+                if target.contains("wasm32-wasi") {
                     // WASI does not support exceptions yet.
                     cmd.push_cc_arg("-fno-exceptions".into());
+                    let wasi_sdk = std::env::var("WASI_SDK").expect("Could not find WASI_SDK. Download it from github & setup environment variable WASI_SDK targetting the folder.");
+                    let wasi_sysroot = format!("{}/share/wasi-sysroot/", wasi_sdk);
+                    // If compiling for c++, link libc++ & libc++abi
+                    if self.cpp {
+                        self.cargo_output.print_metadata(&format_args!(
+                            "cargo:rustc-flags=-L {}/lib/wasm32-wasi -lstatic=c++ -lstatic=c++abi",
+                            wasi_sysroot
+                        ));
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3872,13 +3872,12 @@ impl Build {
                 .unwrap_or_else(|| "1.0".into()),
         }
     }
-    
+
     fn wasi_sysroot(&self) -> Result<String, Error> {
         if let Some(wasi_sysroot_path) = std::env::var_os("WASI_SYSROOT") {
             let path = PathBuf::from(wasi_sysroot_path);
             Ok(String::from(path.to_string_lossy()))
-        }
-        else {
+        } else {
             Err(Error::new(
                 ErrorKind::EnvVarNotFound,
                 "Environment variable WASI_SYSROOT not defined. Download sysroot from github & setup environment variable WASI_SYSROOT targetting the folder.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,7 +1920,7 @@ impl Build {
                         cmd.push_cc_arg("-fno-plt".into());
                     }
                 }
-                if target.contains("-wasi") {
+                if target == "wasm32-wasi" {
                     // WASI does not support exceptions yet.
                     // https://github.com/WebAssembly/exception-handling
                     cmd.push_cc_arg("-fno-exceptions".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,7 +1318,7 @@ impl Build {
                 let wasi_sysroot = self.wasi_sysroot()?;
                 self.cargo_output.print_metadata(&format_args!(
                     "cargo:rustc-flags=-L {}/lib/wasm32-wasi -lstatic=c++ -lstatic=c++abi",
-                    wasi_sysroot
+                    wasi_sysroot.display()
                 ));
             }
         }
@@ -1926,7 +1926,7 @@ impl Build {
                     cmd.push_cc_arg("-fno-exceptions".into());
                     // Link clang sysroot
                     let wasi_sysroot = self.wasi_sysroot()?;
-                    cmd.push_cc_arg(format!("--sysroot={}", wasi_sysroot).into());
+                    cmd.push_cc_arg(format!("--sysroot={}", wasi_sysroot.display()).into());
                 }
             }
         }
@@ -3119,7 +3119,7 @@ impl Build {
                         | target.contains("openbsd")
                         | target.contains("aix")
                         | target.contains("linux-ohos")
-                        | target.contains("wasm32")
+                        | target.contains("-wasi")
                     {
                         Ok(Some("c++".to_string()))
                     } else if target.contains("android") {
@@ -3873,10 +3873,10 @@ impl Build {
         }
     }
 
-    fn wasi_sysroot(&self) -> Result<String, Error> {
-        if let Some(wasi_sysroot_path) = std::env::var_os("WASI_SYSROOT") {
-            let path = PathBuf::from(wasi_sysroot_path);
-            Ok(String::from(path.to_string_lossy()))
+    fn wasi_sysroot(&self) -> Result<PathBuf, Error> {
+        if let Some(wasi_sysroot_path) = self.getenv("WASI_SYSROOT") {
+            let path = PathBuf::from(wasi_sysroot_path.as_ref());
+            Ok(path)
         } else {
             Err(Error::new(
                 ErrorKind::EnvVarNotFound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,7 +1920,7 @@ impl Build {
                         cmd.push_cc_arg("-fno-plt".into());
                     }
                 }
-                if target == "wasm32-wasi" {
+                if target == "wasm32-wasip1" {
                     // WASI does not support exceptions yet.
                     // https://github.com/WebAssembly/exception-handling
                     cmd.push_cc_arg("-fno-exceptions".into());


### PR DESCRIPTION
It seems that currently cc-rs cannot build c++ to WASI correctly, it is using clang instead of clang++, not declaring some unsupported features such as no-exceptions (WASI does not support exceptions), and not linking libc++ aswell that is coming from WASI SDK.
With this PR, I am hoping this could fix this and avoid some extra code such as .compiler("clang++") to fix it