### PR TITLE
Allow opt-out the -ccbin flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ pub struct Build {
     cpp_set_stdlib: Option<Arc<str>>,
     cuda: bool,
     cudart: Option<Arc<str>>,
+    ccbin: bool,
     std: Option<Arc<str>>,
     target: Option<Arc<str>>,
     host: Option<Arc<str>>,
@@ -402,6 +403,7 @@ impl Build {
             cpp_set_stdlib: None,
             cuda: false,
             cudart: None,
+            ccbin: true,
             std: None,
             target: None,
             host: None,
@@ -846,6 +848,20 @@ impl Build {
     pub fn cudart(&mut self, cudart: &str) -> &mut Build {
         if self.cuda {
             self.cudart = Some(cudart.into());
+        }
+        self
+    }
+
+    /// Set CUDA host compiler.
+    ///
+    /// By default, a `-ccbin` flag will be passed to NVCC to specify the
+    /// underlying host compiler. The value of `-ccbin` is the same as the
+    /// chosen C++ compiler. This is not always desired, because NVCC might
+    /// not support that compiler. In this case, you can remove the `-ccbin`
+    /// flag so that NVCC will choose the host compiler by itself.
+    pub fn ccbin(&mut self, ccbin: bool) -> &mut Build {
+        if self.cuda {
+            self.ccbin = ccbin;
         }
         self
     }
@@ -2915,9 +2931,11 @@ impl Build {
                 &self.cargo_output,
                 out_dir,
             );
-            nvcc_tool
-                .args
-                .push(format!("-ccbin={}", tool.path.display()).into());
+            if self.ccbin {
+                nvcc_tool
+                    .args
+                    .push(format!("-ccbin={}", tool.path.display()).into());
+            }
             nvcc_tool.family = tool.family;
             nvcc_tool
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,9 +860,7 @@ impl Build {
     /// not support that compiler. In this case, you can remove the `-ccbin`
     /// flag so that NVCC will choose the host compiler by itself.
     pub fn ccbin(&mut self, ccbin: bool) -> &mut Build {
-        if self.cuda {
-            self.ccbin = ccbin;
-        }
+        self.ccbin = ccbin;
         self
     }
 


### PR DESCRIPTION
Closes #1084.

I'm not 100% sure how to design the API. My initial thought was `ccbin: Option<String>`. But given that we cannot specify C/C++ compiler through functions, it would be weird that we could do so for NVCC. We can still use `CXX` env anyway.

Also, I think enabling `ccbin` by default is weird. But I want to maintain backward compatibility.