### PR TITLE
Fix clippy warnings on Windows

### DIFF
--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -169,7 +169,7 @@ fn main() {
 #[track_caller]
 fn run_forked_capture_output(out: &Path, action: &str) {
     let program = env::current_exe().unwrap();
-    let output = Command::new(&program).arg(action).output().unwrap();
+    let output = Command::new(program).arg(action).output().unwrap();
     assert!(output.status.success(), "output: {:#?}", output);
     // we've captured the output and now we write it to a dedicated directory in the
     // build output so our tests can access the output.

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -12,7 +12,7 @@ fn generate_riscv_arch_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
         .iter()
         .filter_map(|(target, target_spec)| {
             let arch = target.split_once('-').unwrap().0;
-            (arch.contains("riscv") && arch != &target_spec.arch)
+            (arch.contains("riscv") && arch != target_spec.arch)
                 .then_some((arch, &*target_spec.arch))
         })
         .collect::<Vec<_>>();

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -397,7 +397,7 @@ pub(crate) struct CmdAddOutputFileArgs {
 
 pub(crate) fn command_add_output_file(cmd: &mut Command, dst: &Path, args: CmdAddOutputFileArgs) {
     if args.is_assembler_msvc
-        || !(!args.msvc || args.clang || args.gnu || args.cuda || args.is_asm && args.is_arm)
+        || !(!args.msvc || args.clang || args.gnu || args.cuda || (args.is_asm && args.is_arm))
     {
         let mut s = OsString::from("-Fo");
         s.push(dst);

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -397,7 +397,7 @@ pub(crate) struct CmdAddOutputFileArgs {
 
 pub(crate) fn command_add_output_file(cmd: &mut Command, dst: &Path, args: CmdAddOutputFileArgs) {
     if args.is_assembler_msvc
-        || (args.msvc && !args.clang && !args.gnu && !args.cuda && !(args.is_asm && args.is_arm))
+        || !(!args.msvc || args.clang || args.gnu || args.cuda || args.is_asm && args.is_arm)
     {
         let mut s = OsString::from("-Fo");
         s.push(dst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1956,8 +1956,8 @@ impl Build {
         // Target flags
         match cmd.family {
             ToolFamily::Clang { .. } => {
-                if !cmd.has_internal_target_arg
-                    && !(target.contains("android")
+                if !(cmd.has_internal_target_arg
+                    || target.contains("android")
                         && android_clang_compiler_uses_target_arg_internally(&cmd.path))
                 {
                     let (arch, rest) = target.split_once('-').ok_or_else(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2590,10 +2590,7 @@ impl Build {
         } else {
             AppleOs::Ios
         };
-        let is_mac = match os {
-            AppleOs::MacOs => true,
-            _ => false,
-        };
+        let is_mac = matches!(os, AppleOs::MacOs);
 
         let arch_str = target.split('-').nth(0).ok_or_else(|| {
             Error::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1948,8 +1948,8 @@ impl Build {
         match cmd.family {
             ToolFamily::Clang { .. } => {
                 if !(cmd.has_internal_target_arg
-                    || target.contains("android")
-                        && android_clang_compiler_uses_target_arg_internally(&cmd.path))
+                    || (target.contains("android")
+                        && android_clang_compiler_uses_target_arg_internally(&cmd.path)))
                 {
                     let (arch, rest) = target.split_once('-').ok_or_else(|| {
                         Error::new(
@@ -3353,127 +3353,129 @@ impl Build {
         // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"
         let cc_env = self.getenv("CROSS_COMPILE");
         let cross_compile = cc_env.as_ref().map(|s| s.trim_end_matches('-').to_owned());
-        cross_compile.or(linker_prefix).or(match target {
-            // Note: there is no `aarch64-pc-windows-gnu` target, only `-gnullvm`
-            "aarch64-pc-windows-gnullvm" => Some("aarch64-w64-mingw32"),
-            "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
-            "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
-            "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
-            "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
-            "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-            "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-            "armv5te-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-            "armv5te-unknown-linux-musleabi" => Some("arm-linux-gnueabi"),
-            "arm-frc-linux-gnueabi" => Some("arm-frc-linux-gnueabi"),
-            "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-            "arm-unknown-linux-musleabi" => Some("arm-linux-musleabi"),
-            "arm-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-            "arm-unknown-netbsd-eabi" => Some("arm--netbsdelf-eabi"),
-            "armv6-unknown-netbsd-eabihf" => Some("armv6--netbsdelf-eabihf"),
-            "armv7-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-            "armv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-            "armv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-            "armv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-            "armv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-            "thumbv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-            "thumbv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-            "thumbv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-            "thumbv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-            "armv7-unknown-netbsd-eabihf" => Some("armv7--netbsdelf-eabihf"),
-            "hexagon-unknown-linux-musl" => Some("hexagon-linux-musl"),
-            "i586-unknown-linux-musl" => Some("musl"),
-            "i686-pc-windows-gnu" => Some("i686-w64-mingw32"),
-            "i686-uwp-windows-gnu" => Some("i686-w64-mingw32"),
-            "i686-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
-                "i686-linux-gnu",
-                "x86_64-linux-gnu", // transparently support gcc-multilib
-            ]), // explicit None if not found, so caller knows to fall back
-            "i686-unknown-linux-musl" => Some("musl"),
-            "i686-unknown-netbsd" => Some("i486--netbsdelf"),
-            "loongarch64-unknown-linux-gnu" => Some("loongarch64-linux-gnu"),
-            "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),
-            "mips-unknown-linux-musl" => Some("mips-linux-musl"),
-            "mipsel-unknown-linux-gnu" => Some("mipsel-linux-gnu"),
-            "mipsel-unknown-linux-musl" => Some("mipsel-linux-musl"),
-            "mips64-unknown-linux-gnuabi64" => Some("mips64-linux-gnuabi64"),
-            "mips64el-unknown-linux-gnuabi64" => Some("mips64el-linux-gnuabi64"),
-            "mipsisa32r6-unknown-linux-gnu" => Some("mipsisa32r6-linux-gnu"),
-            "mipsisa32r6el-unknown-linux-gnu" => Some("mipsisa32r6el-linux-gnu"),
-            "mipsisa64r6-unknown-linux-gnuabi64" => Some("mipsisa64r6-linux-gnuabi64"),
-            "mipsisa64r6el-unknown-linux-gnuabi64" => Some("mipsisa64r6el-linux-gnuabi64"),
-            "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
-            "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
-            "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
-            "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
-            "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
-            "riscv32i-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                "riscv32-unknown-elf",
-                "riscv64-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
-            "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                "riscv32-unknown-elf",
-                "riscv64-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv32imac-unknown-xous-elf" => self.find_working_gnu_prefix(&[
-                "riscv32-unknown-elf",
-                "riscv64-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv32imc-esp-espidf" => Some("riscv32-esp-elf"),
-            "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                "riscv32-unknown-elf",
-                "riscv64-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv64gc-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                "riscv64-unknown-elf",
-                "riscv32-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv64imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                "riscv64-unknown-elf",
-                "riscv32-unknown-elf",
-                "riscv-none-embed",
-            ]),
-            "riscv64gc-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
-            "riscv32gc-unknown-linux-gnu" => Some("riscv32-linux-gnu"),
-            "riscv64gc-unknown-linux-musl" => Some("riscv64-linux-musl"),
-            "riscv32gc-unknown-linux-musl" => Some("riscv32-linux-musl"),
-            "riscv64gc-unknown-netbsd" => Some("riscv64--netbsd"),
-            "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
-            "sparc-unknown-linux-gnu" => Some("sparc-linux-gnu"),
-            "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
-            "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
-            "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),
-            "armv7a-none-eabi" => Some("arm-none-eabi"),
-            "armv7a-none-eabihf" => Some("arm-none-eabi"),
-            "armebv7r-none-eabi" => Some("arm-none-eabi"),
-            "armebv7r-none-eabihf" => Some("arm-none-eabi"),
-            "armv7r-none-eabi" => Some("arm-none-eabi"),
-            "armv7r-none-eabihf" => Some("arm-none-eabi"),
-            "armv8r-none-eabihf" => Some("arm-none-eabi"),
-            "thumbv6m-none-eabi" => Some("arm-none-eabi"),
-            "thumbv7em-none-eabi" => Some("arm-none-eabi"),
-            "thumbv7em-none-eabihf" => Some("arm-none-eabi"),
-            "thumbv7m-none-eabi" => Some("arm-none-eabi"),
-            "thumbv8m.base-none-eabi" => Some("arm-none-eabi"),
-            "thumbv8m.main-none-eabi" => Some("arm-none-eabi"),
-            "thumbv8m.main-none-eabihf" => Some("arm-none-eabi"),
-            "x86_64-pc-windows-gnu" => Some("x86_64-w64-mingw32"),
-            "x86_64-pc-windows-gnullvm" => Some("x86_64-w64-mingw32"),
-            "x86_64-uwp-windows-gnu" => Some("x86_64-w64-mingw32"),
-            "x86_64-rumprun-netbsd" => Some("x86_64-rumprun-netbsd"),
-            "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
-                "x86_64-linux-gnu", // rustfmt wrap
-            ]), // explicit None if not found, so caller knows to fall back
-            "x86_64-unknown-linux-musl" => Some("musl"),
-            "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
-            _ => None,
-        }
-        .map(|x| x.to_owned()))
+        cross_compile.or(linker_prefix).or_else(|| {
+            match target {
+                // Note: there is no `aarch64-pc-windows-gnu` target, only `-gnullvm`
+                "aarch64-pc-windows-gnullvm" => Some("aarch64-w64-mingw32"),
+                "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
+                "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+                "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+                "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
+                "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                "armv5te-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                "armv5te-unknown-linux-musleabi" => Some("arm-linux-gnueabi"),
+                "arm-frc-linux-gnueabi" => Some("arm-frc-linux-gnueabi"),
+                "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                "arm-unknown-linux-musleabi" => Some("arm-linux-musleabi"),
+                "arm-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                "arm-unknown-netbsd-eabi" => Some("arm--netbsdelf-eabi"),
+                "armv6-unknown-netbsd-eabihf" => Some("armv6--netbsdelf-eabihf"),
+                "armv7-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                "armv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                "armv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                "armv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                "armv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                "thumbv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                "thumbv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                "thumbv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                "thumbv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                "armv7-unknown-netbsd-eabihf" => Some("armv7--netbsdelf-eabihf"),
+                "hexagon-unknown-linux-musl" => Some("hexagon-linux-musl"),
+                "i586-unknown-linux-musl" => Some("musl"),
+                "i686-pc-windows-gnu" => Some("i686-w64-mingw32"),
+                "i686-uwp-windows-gnu" => Some("i686-w64-mingw32"),
+                "i686-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
+                    "i686-linux-gnu",
+                    "x86_64-linux-gnu", // transparently support gcc-multilib
+                ]), // explicit None if not found, so caller knows to fall back
+                "i686-unknown-linux-musl" => Some("musl"),
+                "i686-unknown-netbsd" => Some("i486--netbsdelf"),
+                "loongarch64-unknown-linux-gnu" => Some("loongarch64-linux-gnu"),
+                "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),
+                "mips-unknown-linux-musl" => Some("mips-linux-musl"),
+                "mipsel-unknown-linux-gnu" => Some("mipsel-linux-gnu"),
+                "mipsel-unknown-linux-musl" => Some("mipsel-linux-musl"),
+                "mips64-unknown-linux-gnuabi64" => Some("mips64-linux-gnuabi64"),
+                "mips64el-unknown-linux-gnuabi64" => Some("mips64el-linux-gnuabi64"),
+                "mipsisa32r6-unknown-linux-gnu" => Some("mipsisa32r6-linux-gnu"),
+                "mipsisa32r6el-unknown-linux-gnu" => Some("mipsisa32r6el-linux-gnu"),
+                "mipsisa64r6-unknown-linux-gnuabi64" => Some("mipsisa64r6-linux-gnuabi64"),
+                "mipsisa64r6el-unknown-linux-gnuabi64" => Some("mipsisa64r6el-linux-gnuabi64"),
+                "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
+                "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
+                "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
+                "riscv32i-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                    "riscv32-unknown-elf",
+                    "riscv64-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
+                "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                    "riscv32-unknown-elf",
+                    "riscv64-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv32imac-unknown-xous-elf" => self.find_working_gnu_prefix(&[
+                    "riscv32-unknown-elf",
+                    "riscv64-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv32imc-esp-espidf" => Some("riscv32-esp-elf"),
+                "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                    "riscv32-unknown-elf",
+                    "riscv64-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv64gc-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                    "riscv64-unknown-elf",
+                    "riscv32-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv64imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                    "riscv64-unknown-elf",
+                    "riscv32-unknown-elf",
+                    "riscv-none-embed",
+                ]),
+                "riscv64gc-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
+                "riscv32gc-unknown-linux-gnu" => Some("riscv32-linux-gnu"),
+                "riscv64gc-unknown-linux-musl" => Some("riscv64-linux-musl"),
+                "riscv32gc-unknown-linux-musl" => Some("riscv32-linux-musl"),
+                "riscv64gc-unknown-netbsd" => Some("riscv64--netbsd"),
+                "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
+                "sparc-unknown-linux-gnu" => Some("sparc-linux-gnu"),
+                "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
+                "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
+                "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),
+                "armv7a-none-eabi" => Some("arm-none-eabi"),
+                "armv7a-none-eabihf" => Some("arm-none-eabi"),
+                "armebv7r-none-eabi" => Some("arm-none-eabi"),
+                "armebv7r-none-eabihf" => Some("arm-none-eabi"),
+                "armv7r-none-eabi" => Some("arm-none-eabi"),
+                "armv7r-none-eabihf" => Some("arm-none-eabi"),
+                "armv8r-none-eabihf" => Some("arm-none-eabi"),
+                "thumbv6m-none-eabi" => Some("arm-none-eabi"),
+                "thumbv7em-none-eabi" => Some("arm-none-eabi"),
+                "thumbv7em-none-eabihf" => Some("arm-none-eabi"),
+                "thumbv7m-none-eabi" => Some("arm-none-eabi"),
+                "thumbv8m.base-none-eabi" => Some("arm-none-eabi"),
+                "thumbv8m.main-none-eabi" => Some("arm-none-eabi"),
+                "thumbv8m.main-none-eabihf" => Some("arm-none-eabi"),
+                "x86_64-pc-windows-gnu" => Some("x86_64-w64-mingw32"),
+                "x86_64-pc-windows-gnullvm" => Some("x86_64-w64-mingw32"),
+                "x86_64-uwp-windows-gnu" => Some("x86_64-w64-mingw32"),
+                "x86_64-rumprun-netbsd" => Some("x86_64-rumprun-netbsd"),
+                "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
+                    "x86_64-linux-gnu", // rustfmt wrap
+                ]), // explicit None if not found, so caller knows to fall back
+                "x86_64-unknown-linux-musl" => Some("musl"),
+                "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
+                _ => None,
+            }
+            .map(|x| x.to_owned())
+        })
     }
 
     /// Some platforms have multiple, compatible, canonical prefixes. Look through

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,10 @@
 //!
 //! ```rust,no_run
 //! // build.rs
-//!
-//! fn main() {
-//!     cc::Build::new()
-//!         .file("foo.c")
-//!         .file("bar.c")
-//!         .compile("foo");
-//! }
+//! cc::Build::new()
+//!     .file("foo.c")
+//!     .file("bar.c")
+//!     .compile("foo");
 //! ```
 //!
 //! And that's it! Running `cargo build` should take care of the rest and your Rust
@@ -159,12 +156,10 @@
 //! `Build`:
 //!
 //! ```rust,no_run
-//! fn main() {
-//!     cc::Build::new()
-//!         .cpp(true) // Switch to C++ library compilation.
-//!         .file("foo.cpp")
-//!         .compile("foo");
-//! }
+//! cc::Build::new()
+//!     .cpp(true) // Switch to C++ library compilation.
+//!     .file("foo.cpp")
+//!     .compile("foo");
 //! ```
 //!
 //! For C++ libraries, the `CXX` and `CXXFLAGS` environment variables are used instead of `CC` and `CFLAGS`.
@@ -173,13 +168,11 @@
 //!
 //! 1. by using the `cpp_link_stdlib` method on `Build`:
 //! ```rust,no_run
-//! fn main() {
-//!     cc::Build::new()
-//!         .cpp(true)
-//!         .file("foo.cpp")
-//!         .cpp_link_stdlib("stdc++") // use libstdc++
-//!         .compile("foo");
-//! }
+//! cc::Build::new()
+//!     .cpp(true)
+//!     .file("foo.cpp")
+//!     .cpp_link_stdlib("stdc++") // use libstdc++
+//!     .compile("foo");
 //! ```
 //! 2. by setting the `CXXSTDLIB` environment variable.
 //!
@@ -193,26 +186,24 @@
 //! on `Build`:
 //!
 //! ```rust,no_run
-//! fn main() {
-//!     cc::Build::new()
-//!         // Switch to CUDA C++ library compilation using NVCC.
-//!         .cuda(true)
-//!         .cudart("static")
-//!         // Generate code for Maxwell (GTX 970, 980, 980 Ti, Titan X).
-//!         .flag("-gencode").flag("arch=compute_52,code=sm_52")
-//!         // Generate code for Maxwell (Jetson TX1).
-//!         .flag("-gencode").flag("arch=compute_53,code=sm_53")
-//!         // Generate code for Pascal (GTX 1070, 1080, 1080 Ti, Titan Xp).
-//!         .flag("-gencode").flag("arch=compute_61,code=sm_61")
-//!         // Generate code for Pascal (Tesla P100).
-//!         .flag("-gencode").flag("arch=compute_60,code=sm_60")
-//!         // Generate code for Pascal (Jetson TX2).
-//!         .flag("-gencode").flag("arch=compute_62,code=sm_62")
-//!         // Generate code in parallel
-//!         .flag("-t0")
-//!         .file("bar.cu")
-//!         .compile("bar");
-//! }
+//! cc::Build::new()
+//!     // Switch to CUDA C++ library compilation using NVCC.
+//!     .cuda(true)
+//!     .cudart("static")
+//!     // Generate code for Maxwell (GTX 970, 980, 980 Ti, Titan X).
+//!     .flag("-gencode").flag("arch=compute_52,code=sm_52")
+//!     // Generate code for Maxwell (Jetson TX1).
+//!     .flag("-gencode").flag("arch=compute_53,code=sm_53")
+//!     // Generate code for Pascal (GTX 1070, 1080, 1080 Ti, Titan Xp).
+//!     .flag("-gencode").flag("arch=compute_61,code=sm_61")
+//!     // Generate code for Pascal (Tesla P100).
+//!     .flag("-gencode").flag("arch=compute_60,code=sm_60")
+//!     // Generate code for Pascal (Jetson TX2).
+//!     .flag("-gencode").flag("arch=compute_62,code=sm_62")
+//!     // Generate code in parallel
+//!     .flag("-t0")
+//!     .file("bar.cu")
+//!     .compile("bar");
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/cc/1.0")]

--- a/src/parallel/job_token.rs
+++ b/src/parallel/job_token.rs
@@ -186,7 +186,7 @@ mod inherited_jobserver {
                         // Fallback to creating a help thread with blocking acquire
                         let helper_thread = self
                             .helper_thread
-                            .get_or_try_init(|| HelperThread::new(&self.jobserver))?;
+                            .get_or_try_init(|| HelperThread::new(self.jobserver))?;
 
                         match helper_thread.rx.try_recv() {
                             Ok(res) => {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -392,10 +392,7 @@ impl Tool {
 
     /// Whether the tool is MSVC-like.
     pub fn is_like_msvc(&self) -> bool {
-        match self.family {
-            ToolFamily::Msvc { .. } => true,
-            _ => false,
-        }
+        matches!(self.family, ToolFamily::Msvc { .. })
     }
 }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -96,7 +96,7 @@ impl Tool {
     ) -> Self {
         fn is_zig_cc(path: &Path, cargo_output: &CargoOutput) -> bool {
             run_output(
-                Command::new(&path).arg("--version"),
+                Command::new(path).arg("--version"),
                 path,
                 // tool detection issues should always be shown as warnings
                 cargo_output,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -142,14 +142,13 @@ pub fn find_vs_version() -> Result<VsVers, String> {
             } else if impl_::has_msbuild_version("12.0") {
                 Ok(VsVers::Vs12)
             } else {
-                Err(format!(
-                    "\n\n\
+                Err("\n\n\
                      couldn't determine visual studio generator\n\
                      if VisualStudio is installed, however, consider \
                      running the appropriate vcvars script before building \
                      this crate\n\
                      "
-                ))
+                .to_string())
             }
         }
     }
@@ -302,9 +301,7 @@ mod impl_ {
     /// Attempt to find the tool using environment variables set by vcvars.
     pub(super) fn find_msvc_environment(tool: &str, target: TargetArch<'_>) -> Option<Tool> {
         // Early return if the environment doesn't contain a VC install.
-        if env::var_os("VCINSTALLDIR").is_none() {
-            return None;
-        }
+        env::var_os("VCINSTALLDIR")?;
         let vs_install_dir = env::var_os("VSINSTALLDIR")?.into();
 
         // If the vscmd target differs from the requested target then
@@ -423,7 +420,7 @@ mod impl_ {
         };
 
         let vswhere_output = Command::new(vswhere_path)
-            .args(&[
+            .args([
                 "-latest",
                 "-products",
                 "*",
@@ -712,7 +709,7 @@ mod impl_ {
     }
 
     fn add_env(tool: &mut Tool, env: &str, paths: Vec<PathBuf>) {
-        let prev = env::var_os(env).unwrap_or(OsString::new());
+        let prev = env::var_os(env).unwrap_or_default();
         let prev = env::split_paths(&prev);
         let new = paths.into_iter().chain(prev);
         tool.env
@@ -815,8 +812,7 @@ mod impl_ {
         let dir = dirs
             .into_iter()
             .rev()
-            .filter(|dir| dir.join("um").join("x64").join("kernel32.lib").is_file())
-            .next()?;
+            .find(|dir| dir.join("um").join("x64").join("kernel32.lib").is_file())?;
         let version = dir.components().last().unwrap();
         let version = version.as_os_str().to_str().unwrap().to_string();
         Some((root.into(), version))
@@ -928,7 +924,7 @@ mod impl_ {
         for subkey in key.iter().filter_map(|k| k.ok()) {
             let val = subkey
                 .to_str()
-                .and_then(|s| s.trim_start_matches("v").replace('.', "").parse().ok());
+                .and_then(|s| s.trim_start_matches('v').replace('.', "").parse().ok());
             let val = match val {
                 Some(s) => s,
                 None => continue,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -337,9 +337,9 @@ mod impl_ {
         };
         Box::new(instances.into_iter().filter_map(move |instance| {
             let installation_name = instance.installation_name()?;
-            if installation_name.starts_with(&format!("VisualStudio/{}.", version)) {
-                Some(instance.installation_path()?)
-            } else if installation_name.starts_with(&format!("VisualStudioPreview/{}.", version)) {
+            if installation_name.starts_with(&format!("VisualStudio/{}.", version))
+                || installation_name.starts_with(&format!("VisualStudioPreview/{}.", version))
+            {
                 Some(instance.installation_path()?)
             } else {
                 None

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -302,7 +302,7 @@ mod impl_ {
     pub(super) fn find_msvc_environment(tool: &str, target: TargetArch<'_>) -> Option<Tool> {
         // Early return if the environment doesn't contain a VC install.
         env::var_os("VCINSTALLDIR")?;
-        let vs_install_dir = env::var_os("VSINSTALLDIR")?.into();
+        let vs_install_dir: PathBuf = env::var_os("VSINSTALLDIR")?.into();
 
         // If the vscmd target differs from the requested target then
         // attempt to get the tool using the VS install directory.
@@ -503,7 +503,7 @@ mod impl_ {
     fn tool_from_vs15plus_instance(
         tool: &str,
         target: TargetArch<'_>,
-        instance_path: &PathBuf,
+        instance_path: &Path,
     ) -> Option<Tool> {
         let (root_path, bin_path, host_dylib_path, lib_path, alt_lib_path, include_path) =
             vs15plus_vc_paths(target, instance_path)?;

--- a/src/windows/vs_instances.rs
+++ b/src/windows/vs_instances.rs
@@ -73,7 +73,7 @@ impl TryFrom<&Vec<u8>> for VswhereInstance {
     fn try_from(output: &Vec<u8>) -> Result<Self, Self::Error> {
         let map: HashMap<_, _> = output
             .lines()
-            .filter_map(Result::ok)
+            .map_while(Result::ok)
             .filter_map(|s| {
                 let mut splitn = s.splitn(2, ": ");
                 Some((splitn.next()?.to_owned(), splitn.next()?.to_owned()))

--- a/tests/cc_env.rs
+++ b/tests/cc_env.rs
@@ -55,22 +55,16 @@ fn ccache_env_flags() {
         compiler.cc_env(),
         OsString::from("ccache lol-this-is-not-a-compiler")
     );
-    assert!(
-        compiler
-            .cflags_env()
-            .into_string()
-            .unwrap()
-            .contains("ccache")
-            == false
-    );
-    assert!(
-        compiler
-            .cflags_env()
-            .into_string()
-            .unwrap()
-            .contains(" lol-this-is-not-a-compiler")
-            == false
-    );
+    assert!(!compiler
+        .cflags_env()
+        .into_string()
+        .unwrap()
+        .contains("ccache"));
+    assert!(!compiler
+        .cflags_env()
+        .into_string()
+        .unwrap()
+        .contains(" lol-this-is-not-a-compiler"));
 
     env::set_var("CC", "");
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -7,7 +7,6 @@ use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use cc;
 use tempfile::{Builder, TempDir};
 
 pub struct Test {
@@ -86,12 +85,10 @@ impl Test {
         let mut cfg = cc::Build::new();
         let target = if self.msvc {
             "x86_64-pc-windows-msvc"
+        } else if cfg!(target_os = "macos") {
+            "x86_64-apple-darwin"
         } else {
-            if cfg!(target_os = "macos") {
-                "x86_64-apple-darwin"
-            } else {
-                "x86_64-unknown-linux-gnu"
-            }
+            "x86_64-unknown-linux-gnu"
         };
 
         cfg.target(target)


### PR DESCRIPTION
This is likely best reviewed commit-by-commit. The first commit simply uses `cargo clippy --fix` to automatically fix warnings so there almost certainly aren't any behavioural changes. The other commits are manual fixes but should be fine too. The most tricky one is probably 397dd22 because it's rearranging boolean expressions.