### PR TITLE
Output msvc.exe in the output directory

### DIFF
--- a/dev-tools/cc-test/src/NMakefile
+++ b/dev-tools/cc-test/src/NMakefile
@@ -14,7 +14,7 @@ $(OUT_DIR)/msvc.o: src/msvc.c
 	$(CC) $(EXTRA_CFLAGS) -c $(CFLAG_OUTPUT)$@ src/msvc.c -MD
 
 $(OUT_DIR)/msvc.exe: $(OUT_DIR)/msvc2.o
-	$(CC) $(EXTRA_CFLAGS) $(CFLAG_OUTPUT)$@ $(OUT_DIR)/msvc2.o
+	$(CC) $(EXTRA_CFLAGS) $(CFLAG_OUTPUT)$@ $(OUT_DIR)/msvc2.o -Fe:$(OUT_DIR)/msvc.exe
 
 $(OUT_DIR)/msvc2.o: src/msvc.c
 	$(CC) $(EXTRA_CFLAGS) -c $(CFLAG_OUTPUT)$@ src/msvc.c -DMAIN -MD


### PR DESCRIPTION
Previously, `msvc2.exe` was being written to `dev-tools/cc-test/msvc2.exe`. I don't think that was intended and it is a bit annoying. This uses [`-Fe`](https://learn.microsoft.com/en-us/cpp/build/reference/fe-name-exe-file?view=msvc-170) to set the output path, which should work with both `cl` (msvc) and `clang-cl` (clang).