### PR TITLE
Add tests that execute `{TVOS,XROS}_DEPLOYMENT_VERSION` detecion logic.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,9 +130,9 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         if: startsWith(matrix.build, 'windows-clang')
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} -- --nocapture
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release -- --nocapture
+      - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel -- --nocapture
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-tvos:

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -638,6 +638,24 @@ fn clang_apple_tvsimulator() {
 }
 
 #[cfg(target_os = "macos")]
+fn clang_apple_detect_deployment_target(target: &str) {
+    let test = Test::clang();
+    test.gcc().target(target).file("foo.c").compile("foo");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn clang_apple_tvos_detect_deployment_target() {
+    clang_apple_detect_deployment_target("aarch64-apple-tvos");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn clang_apple_visionos_detect_deployment_target() {
+    clang_apple_detect_deployment_target("aarch64-apple-visionos");
+}
+
+#[cfg(target_os = "macos")]
 #[test]
 fn clang_apple_visionos() {
     // Only run this test if visionOS is available on the host machine

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -637,19 +637,19 @@ fn clang_apple_tvsimulator() {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_arch="aarch64", target_os = "macos"))]
 fn clang_apple_detect_deployment_target(target: &str) {
     let test = Test::clang();
     test.gcc().target(target).file("foo.c").compile("foo");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_arch="aarch64", target_os = "macos"))]
 #[test]
 fn clang_apple_tvos_detect_deployment_target() {
     clang_apple_detect_deployment_target("aarch64-apple-tvos");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_arch="aarch64", target_os = "macos"))]
 #[test]
 fn clang_apple_visionos_detect_deployment_target() {
     clang_apple_detect_deployment_target("aarch64-apple-visionos");


### PR DESCRIPTION
This causes the version detection to be skipped and thus it isn't being tested. Remove it so that we test the version detection.