### PR TITLE
Use `dep:` syntax to avoid implicit features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = { version = "1.19", optional = true }
 libc = { version = "0.2.62", default-features = false, optional = true }
 
 [features]
-parallel = ["libc", "jobserver", "once_cell"]
+parallel = ["dep:libc", "dep:jobserver", "dep:once_cell"]
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
The only real externally visible feature should be `parallel` and not the implicit features for the optional dependencies.