### PR TITLE
Use `Build::getenv` instead of `env::var*` in anywhere that makes sense

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    { path = "std::env::var_os", reason = "Please use Build::getenv" },
+    { path = "std::env::var", reason = "Please use Build::getenv" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,7 @@
 disallowed-methods = [
     { path = "std::env::var_os", reason = "Please use Build::getenv" },
     { path = "std::env::var", reason = "Please use Build::getenv" },
+    { path = "windows_registry::find", reason = "Please use find_tool_inner" },
+    { path = "windows_registry::find_tool", reason = "Please use find_tool_inner" },
+    { path = "windows_registry::find_vs_version", reason = "No" },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,4 @@
 disallowed-methods = [
     { path = "std::env::var_os", reason = "Please use Build::getenv" },
     { path = "std::env::var", reason = "Please use Build::getenv" },
-    { path = "windows_registry::find", reason = "Please use find_tool_inner" },
-    { path = "windows_registry::find_tool", reason = "Please use find_tool_inner" },
-    { path = "windows_registry::find_vs_version", reason = "No" },
 ]

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/bin/gcc-shim.rs
+++ b/src/bin/gcc-shim.rs
@@ -2,6 +2,7 @@
 //! It is not intended for users and is not published with the library code to crates.io.
 
 #![cfg_attr(test, allow(dead_code))]
+#![allow(clippy::disallowed_methods)]
 
 use std::env;
 use std::fs::File;

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -27,6 +27,7 @@ pub(crate) struct CargoOutput {
 
 impl CargoOutput {
     pub(crate) fn new() -> Self {
+        #[allow(clippy::disallowed_methods)]
         Self {
             metadata: true,
             warnings: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2742,7 +2742,7 @@ impl Build {
                 // Mac Catalyst uses the macOS SDK, but to compile against and
                 // link to iOS-specific frameworks, we should have the support
                 // library stubs in the include and library search path.
-                let ios_support = PathBuf::from(&sdk_path).join("System/iOSSupport");
+                let ios_support = Path:: new(&sdk_path).join("System/iOSSupport");
 
                 cmd.args.extend([
                     // Header search path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2435,7 +2435,9 @@ impl Build {
         } else {
             "ml.exe"
         };
-        let mut cmd = windows_registry::find(&target, tool).unwrap_or_else(|| self.cmd(tool));
+        let mut cmd = self
+            .windows_registry_find(&target, tool)
+            .unwrap_or_else(|| self.cmd(tool));
         cmd.arg("-nologo"); // undocumented, yet working with armasm[64]
         for directory in self.include_directories.iter() {
             cmd.arg("-I").arg(&**directory);
@@ -2815,7 +2817,7 @@ impl Build {
             traditional
         };
 
-        let cl_exe = windows_registry::find_tool(target, "cl.exe");
+        let cl_exe = self.windows_registry_find_tool(target, "cl.exe");
 
         let tool_opt: Option<Tool> = self
             .env_tool(env)
@@ -3333,7 +3335,7 @@ impl Build {
 
                     if lib.is_empty() {
                         name = PathBuf::from("lib.exe");
-                        let mut cmd = match windows_registry::find(&target, "lib.exe") {
+                        let mut cmd = match self.windows_registry_find(&target, "lib.exe") {
                             Some(t) => t,
                             None => self.cmd("lib.exe"),
                         };
@@ -3992,6 +3994,15 @@ impl Build {
             }
         }
         None
+    }
+
+    fn windows_registry_find(&self, target: &str, tool: &str) -> Option<Command> {
+        self.windows_registry_find_tool(target, tool)
+            .map(|c| c.to_command())
+    }
+
+    fn windows_registry_find_tool(&self, target: &str, tool: &str) -> Option<Tool> {
+        windows_registry::find_tool_inner(target, tool, |env| self.getenv(env))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3718,7 +3718,7 @@ impl Build {
     fn apple_sdk_root(&self, sdk: &str) -> Result<Arc<OsStr>, Error> {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = self.getenv("SDKROOT") {
-            let p = PathBuf::from(&sdkroot);
+            let p = Path::new(&sdkroot);
             let sdkroot_str = p.to_string_lossy();
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@
 #![doc(html_root_url = "https://docs.rs/cc/1.0")]
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
+#![deny(clippy::disallowed_methods)]
 
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4103,27 +4103,6 @@ fn android_clang_compiler_uses_target_arg_internally(clang_path: &Path) -> bool 
     false
 }
 
-#[test]
-fn test_android_clang_compiler_uses_target_arg_internally() {
-    for version in 16..21 {
-        assert!(android_clang_compiler_uses_target_arg_internally(
-            &PathBuf::from(format!("armv7a-linux-androideabi{}-clang", version))
-        ));
-        assert!(android_clang_compiler_uses_target_arg_internally(
-            &PathBuf::from(format!("armv7a-linux-androideabi{}-clang++", version))
-        ));
-    }
-    assert!(!android_clang_compiler_uses_target_arg_internally(
-        &PathBuf::from("clang-i686-linux-android")
-    ));
-    assert!(!android_clang_compiler_uses_target_arg_internally(
-        &PathBuf::from("clang")
-    ));
-    assert!(!android_clang_compiler_uses_target_arg_internally(
-        &PathBuf::from("clang++")
-    ));
-}
-
 fn autodetect_android_compiler(target: &str, host: &str, gnu: &str, clang: &str) -> String {
     let new_clang_key = match target {
         "aarch64-linux-android" => Some("aarch64"),
@@ -4214,5 +4193,31 @@ impl AsmFileExt {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_android_clang_compiler_uses_target_arg_internally() {
+        for version in 16..21 {
+            assert!(android_clang_compiler_uses_target_arg_internally(
+                &PathBuf::from(format!("armv7a-linux-androideabi{}-clang", version))
+            ));
+            assert!(android_clang_compiler_uses_target_arg_internally(
+                &PathBuf::from(format!("armv7a-linux-androideabi{}-clang++", version))
+            ));
+        }
+        assert!(!android_clang_compiler_uses_target_arg_internally(
+            &PathBuf::from("clang-i686-linux-android")
+        ));
+        assert!(!android_clang_compiler_uses_target_arg_internally(
+            &PathBuf::from("clang")
+        ));
+        assert!(!android_clang_compiler_uses_target_arg_internally(
+            &PathBuf::from("clang++")
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2742,7 +2742,7 @@ impl Build {
                 // Mac Catalyst uses the macOS SDK, but to compile against and
                 // link to iOS-specific frameworks, we should have the support
                 // library stubs in the include and library search path.
-                let ios_support = Path:: new(&sdk_path).join("System/iOSSupport");
+                let ios_support = Path::new(&sdk_path).join("System/iOSSupport");
 
                 cmd.args.extend([
                     // Header search path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3699,7 +3699,7 @@ impl Build {
             .getenv_with_target_prefixes(name)?
             .to_string_lossy()
             .split_ascii_whitespace()
-            .map(|slice| slice.to_string())
+            .map(ToString::to_string)
             .collect())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3386,142 +3386,143 @@ impl Build {
     }
 
     fn prefix_for_target(&self, target: &str) -> Option<Cow<'static, str>> {
-        // Put aside RUSTC_LINKER's prefix to be used as second choice, after CROSS_COMPILE
-        let linker_prefix = self.getenv("RUSTC_LINKER").and_then(|var| {
-            var.to_string_lossy()
-                .strip_suffix("-gcc")
-                .map(str::to_string)
-                .map(Cow::Owned)
-        });
         // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"
-        let cc_env = self.getenv("CROSS_COMPILE");
-        let cross_compile = cc_env
+        self.getenv("CROSS_COMPILE")
             .as_deref()
             .map(|s| s.to_string_lossy().trim_end_matches('-').to_owned())
-            .map(Cow::Owned);
-        cross_compile.or(linker_prefix).or_else(|| {
-            match target {
-                // Note: there is no `aarch64-pc-windows-gnu` target, only `-gnullvm`
-                "aarch64-pc-windows-gnullvm" => Some("aarch64-w64-mingw32"),
-                "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
-                "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
-                "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
-                "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
-                "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-                "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-                "armv5te-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-                "armv5te-unknown-linux-musleabi" => Some("arm-linux-gnueabi"),
-                "arm-frc-linux-gnueabi" => Some("arm-frc-linux-gnueabi"),
-                "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-                "arm-unknown-linux-musleabi" => Some("arm-linux-musleabi"),
-                "arm-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-                "arm-unknown-netbsd-eabi" => Some("arm--netbsdelf-eabi"),
-                "armv6-unknown-netbsd-eabihf" => Some("armv6--netbsdelf-eabihf"),
-                "armv7-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-                "armv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-                "armv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-                "armv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-                "armv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-                "thumbv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-                "thumbv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-                "thumbv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
-                "thumbv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
-                "armv7-unknown-netbsd-eabihf" => Some("armv7--netbsdelf-eabihf"),
-                "hexagon-unknown-linux-musl" => Some("hexagon-linux-musl"),
-                "i586-unknown-linux-musl" => Some("musl"),
-                "i686-pc-windows-gnu" => Some("i686-w64-mingw32"),
-                "i686-uwp-windows-gnu" => Some("i686-w64-mingw32"),
-                "i686-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
-                    "i686-linux-gnu",
-                    "x86_64-linux-gnu", // transparently support gcc-multilib
-                ]), // explicit None if not found, so caller knows to fall back
-                "i686-unknown-linux-musl" => Some("musl"),
-                "i686-unknown-netbsd" => Some("i486--netbsdelf"),
-                "loongarch64-unknown-linux-gnu" => Some("loongarch64-linux-gnu"),
-                "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),
-                "mips-unknown-linux-musl" => Some("mips-linux-musl"),
-                "mipsel-unknown-linux-gnu" => Some("mipsel-linux-gnu"),
-                "mipsel-unknown-linux-musl" => Some("mipsel-linux-musl"),
-                "mips64-unknown-linux-gnuabi64" => Some("mips64-linux-gnuabi64"),
-                "mips64el-unknown-linux-gnuabi64" => Some("mips64el-linux-gnuabi64"),
-                "mipsisa32r6-unknown-linux-gnu" => Some("mipsisa32r6-linux-gnu"),
-                "mipsisa32r6el-unknown-linux-gnu" => Some("mipsisa32r6el-linux-gnu"),
-                "mipsisa64r6-unknown-linux-gnuabi64" => Some("mipsisa64r6-linux-gnuabi64"),
-                "mipsisa64r6el-unknown-linux-gnuabi64" => Some("mipsisa64r6el-linux-gnuabi64"),
-                "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
-                "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
-                "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
-                "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
-                "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
-                "riscv32i-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                    "riscv32-unknown-elf",
-                    "riscv64-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
-                "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                    "riscv32-unknown-elf",
-                    "riscv64-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv32imac-unknown-xous-elf" => self.find_working_gnu_prefix(&[
-                    "riscv32-unknown-elf",
-                    "riscv64-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv32imc-esp-espidf" => Some("riscv32-esp-elf"),
-                "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                    "riscv32-unknown-elf",
-                    "riscv64-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv64gc-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                    "riscv64-unknown-elf",
-                    "riscv32-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv64imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
-                    "riscv64-unknown-elf",
-                    "riscv32-unknown-elf",
-                    "riscv-none-embed",
-                ]),
-                "riscv64gc-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
-                "riscv32gc-unknown-linux-gnu" => Some("riscv32-linux-gnu"),
-                "riscv64gc-unknown-linux-musl" => Some("riscv64-linux-musl"),
-                "riscv32gc-unknown-linux-musl" => Some("riscv32-linux-musl"),
-                "riscv64gc-unknown-netbsd" => Some("riscv64--netbsd"),
-                "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
-                "sparc-unknown-linux-gnu" => Some("sparc-linux-gnu"),
-                "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
-                "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
-                "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),
-                "armv7a-none-eabi" => Some("arm-none-eabi"),
-                "armv7a-none-eabihf" => Some("arm-none-eabi"),
-                "armebv7r-none-eabi" => Some("arm-none-eabi"),
-                "armebv7r-none-eabihf" => Some("arm-none-eabi"),
-                "armv7r-none-eabi" => Some("arm-none-eabi"),
-                "armv7r-none-eabihf" => Some("arm-none-eabi"),
-                "armv8r-none-eabihf" => Some("arm-none-eabi"),
-                "thumbv6m-none-eabi" => Some("arm-none-eabi"),
-                "thumbv7em-none-eabi" => Some("arm-none-eabi"),
-                "thumbv7em-none-eabihf" => Some("arm-none-eabi"),
-                "thumbv7m-none-eabi" => Some("arm-none-eabi"),
-                "thumbv8m.base-none-eabi" => Some("arm-none-eabi"),
-                "thumbv8m.main-none-eabi" => Some("arm-none-eabi"),
-                "thumbv8m.main-none-eabihf" => Some("arm-none-eabi"),
-                "x86_64-pc-windows-gnu" => Some("x86_64-w64-mingw32"),
-                "x86_64-pc-windows-gnullvm" => Some("x86_64-w64-mingw32"),
-                "x86_64-uwp-windows-gnu" => Some("x86_64-w64-mingw32"),
-                "x86_64-rumprun-netbsd" => Some("x86_64-rumprun-netbsd"),
-                "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
-                    "x86_64-linux-gnu", // rustfmt wrap
-                ]), // explicit None if not found, so caller knows to fall back
-                "x86_64-unknown-linux-musl" => Some("musl"),
-                "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
-                _ => None,
-            }
-            .map(Cow::Borrowed)
-        })
+            .map(Cow::Owned)
+            .or_else(|| {
+                // Put aside RUSTC_LINKER's prefix to be used as second choice, after CROSS_COMPILE
+                self.getenv("RUSTC_LINKER").and_then(|var| {
+                    var.to_string_lossy()
+                        .strip_suffix("-gcc")
+                        .map(str::to_string)
+                        .map(Cow::Owned)
+                })
+            })
+            .or_else(|| {
+                match target {
+                    // Note: there is no `aarch64-pc-windows-gnu` target, only `-gnullvm`
+                    "aarch64-pc-windows-gnullvm" => Some("aarch64-w64-mingw32"),
+                    "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
+                    "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+                    "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+                    "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
+                    "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                    "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                    "armv5te-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                    "armv5te-unknown-linux-musleabi" => Some("arm-linux-gnueabi"),
+                    "arm-frc-linux-gnueabi" => Some("arm-frc-linux-gnueabi"),
+                    "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "arm-unknown-linux-musleabi" => Some("arm-linux-musleabi"),
+                    "arm-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                    "arm-unknown-netbsd-eabi" => Some("arm--netbsdelf-eabi"),
+                    "armv6-unknown-netbsd-eabihf" => Some("armv6--netbsdelf-eabihf"),
+                    "armv7-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                    "armv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "armv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                    "armv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "armv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                    "thumbv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "thumbv7-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                    "thumbv7neon-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "thumbv7neon-unknown-linux-musleabihf" => Some("arm-linux-musleabihf"),
+                    "armv7-unknown-netbsd-eabihf" => Some("armv7--netbsdelf-eabihf"),
+                    "hexagon-unknown-linux-musl" => Some("hexagon-linux-musl"),
+                    "i586-unknown-linux-musl" => Some("musl"),
+                    "i686-pc-windows-gnu" => Some("i686-w64-mingw32"),
+                    "i686-uwp-windows-gnu" => Some("i686-w64-mingw32"),
+                    "i686-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
+                        "i686-linux-gnu",
+                        "x86_64-linux-gnu", // transparently support gcc-multilib
+                    ]), // explicit None if not found, so caller knows to fall back
+                    "i686-unknown-linux-musl" => Some("musl"),
+                    "i686-unknown-netbsd" => Some("i486--netbsdelf"),
+                    "loongarch64-unknown-linux-gnu" => Some("loongarch64-linux-gnu"),
+                    "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),
+                    "mips-unknown-linux-musl" => Some("mips-linux-musl"),
+                    "mipsel-unknown-linux-gnu" => Some("mipsel-linux-gnu"),
+                    "mipsel-unknown-linux-musl" => Some("mipsel-linux-musl"),
+                    "mips64-unknown-linux-gnuabi64" => Some("mips64-linux-gnuabi64"),
+                    "mips64el-unknown-linux-gnuabi64" => Some("mips64el-linux-gnuabi64"),
+                    "mipsisa32r6-unknown-linux-gnu" => Some("mipsisa32r6-linux-gnu"),
+                    "mipsisa32r6el-unknown-linux-gnu" => Some("mipsisa32r6el-linux-gnu"),
+                    "mipsisa64r6-unknown-linux-gnuabi64" => Some("mipsisa64r6-linux-gnuabi64"),
+                    "mipsisa64r6el-unknown-linux-gnuabi64" => Some("mipsisa64r6el-linux-gnuabi64"),
+                    "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                    "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
+                    "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
+                    "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                    "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
+                    "riscv32i-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
+                    "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv32imac-unknown-xous-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv32imc-esp-espidf" => Some("riscv32-esp-elf"),
+                    "riscv32imc-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv64gc-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv64-unknown-elf",
+                        "riscv32-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv64imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv64-unknown-elf",
+                        "riscv32-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv64gc-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
+                    "riscv32gc-unknown-linux-gnu" => Some("riscv32-linux-gnu"),
+                    "riscv64gc-unknown-linux-musl" => Some("riscv64-linux-musl"),
+                    "riscv32gc-unknown-linux-musl" => Some("riscv32-linux-musl"),
+                    "riscv64gc-unknown-netbsd" => Some("riscv64--netbsd"),
+                    "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
+                    "sparc-unknown-linux-gnu" => Some("sparc-linux-gnu"),
+                    "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
+                    "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
+                    "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),
+                    "armv7a-none-eabi" => Some("arm-none-eabi"),
+                    "armv7a-none-eabihf" => Some("arm-none-eabi"),
+                    "armebv7r-none-eabi" => Some("arm-none-eabi"),
+                    "armebv7r-none-eabihf" => Some("arm-none-eabi"),
+                    "armv7r-none-eabi" => Some("arm-none-eabi"),
+                    "armv7r-none-eabihf" => Some("arm-none-eabi"),
+                    "armv8r-none-eabihf" => Some("arm-none-eabi"),
+                    "thumbv6m-none-eabi" => Some("arm-none-eabi"),
+                    "thumbv7em-none-eabi" => Some("arm-none-eabi"),
+                    "thumbv7em-none-eabihf" => Some("arm-none-eabi"),
+                    "thumbv7m-none-eabi" => Some("arm-none-eabi"),
+                    "thumbv8m.base-none-eabi" => Some("arm-none-eabi"),
+                    "thumbv8m.main-none-eabi" => Some("arm-none-eabi"),
+                    "thumbv8m.main-none-eabihf" => Some("arm-none-eabi"),
+                    "x86_64-pc-windows-gnu" => Some("x86_64-w64-mingw32"),
+                    "x86_64-pc-windows-gnullvm" => Some("x86_64-w64-mingw32"),
+                    "x86_64-uwp-windows-gnu" => Some("x86_64-w64-mingw32"),
+                    "x86_64-rumprun-netbsd" => Some("x86_64-rumprun-netbsd"),
+                    "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
+                        "x86_64-linux-gnu", // rustfmt wrap
+                    ]), // explicit None if not found, so caller knows to fall back
+                    "x86_64-unknown-linux-musl" => Some("musl"),
+                    "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
+                    _ => None,
+                }
+                .map(Cow::Borrowed)
+            })
     }
 
     /// Some platforms have multiple, compatible, canonical prefixes. Look through
@@ -3553,16 +3554,6 @@ impl Build {
             // error that is shown to the user which should make it easier to search for
             // where it should be obtained.
             .or_else(|| prefixes.first().copied())
-    }
-
-    fn getenv_unwrap_str(&self, v: &str) -> Result<String, Error> {
-        let env = self.getenv_unwrap(v)?;
-        env.to_str().map(String::from).ok_or_else(|| {
-            Error::new(
-                ErrorKind::EnvVarNotFound,
-                format!("Environment variable {} is not valid utf-8.", v),
-            )
-        })
     }
 
     fn get_target(&self) -> Result<Cow<'_, str>, Error> {
@@ -3671,6 +3662,16 @@ impl Build {
                 format!("Environment variable {} not defined.", v),
             )),
         }
+    }
+
+    fn getenv_unwrap_str(&self, v: &str) -> Result<String, Error> {
+        let env = self.getenv_unwrap(v)?;
+        env.to_str().map(String::from).ok_or_else(|| {
+            Error::new(
+                ErrorKind::EnvVarNotFound,
+                format!("Environment variable {} is not valid utf-8.", v),
+            )
+        })
     }
 
     fn getenv_with_target_prefixes(&self, var_base: &str) -> Result<Arc<OsStr>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3719,36 +3719,29 @@ impl Build {
         // Code copied from rustc's compiler/rustc_codegen_ssa/src/back/link.rs.
         if let Some(sdkroot) = self.getenv("SDKROOT") {
             let p = Path::new(&sdkroot);
-            let sdkroot_str = p.to_string_lossy();
+            let does_sdkroot_contain = |strings: &[&str]| {
+                let sdkroot_str = p.to_string_lossy();
+                strings.iter().any(|s| sdkroot_str.contains(s))
+            };
             match sdk {
                 // Ignore `SDKROOT` if it's clearly set for the wrong platform.
                 "appletvos"
-                    if sdkroot_str.contains("TVSimulator.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["TVSimulator.platform", "MacOSX.platform"]) => {}
                 "appletvsimulator"
-                    if sdkroot_str.contains("TVOS.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["TVOS.platform", "MacOSX.platform"]) => {}
                 "iphoneos"
-                    if sdkroot_str.contains("iPhoneSimulator.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["iPhoneSimulator.platform", "MacOSX.platform"]) => {}
                 "iphonesimulator"
-                    if sdkroot_str.contains("iPhoneOS.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["iPhoneOS.platform", "MacOSX.platform"]) => {}
                 "macosx10.15"
-                    if sdkroot_str.contains("iPhoneOS.platform")
-                        || sdkroot_str.contains("iPhoneSimulator.platform") => {}
+                    if does_sdkroot_contain(&["iPhoneOS.platform", "iPhoneSimulator.platform"]) => {
+                }
                 "watchos"
-                    if sdkroot_str.contains("WatchSimulator.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["WatchSimulator.platform", "MacOSX.platform"]) => {}
                 "watchsimulator"
-                    if sdkroot_str.contains("WatchOS.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
-                "xros"
-                    if sdkroot_str.contains("XRSimulator.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
-                "xrsimulator"
-                    if sdkroot_str.contains("XROS.platform")
-                        || sdkroot_str.contains("MacOSX.platform") => {}
+                    if does_sdkroot_contain(&["WatchOS.platform", "MacOSX.platform"]) => {}
+                "xros" if does_sdkroot_contain(&["XRSimulator.platform", "MacOSX.platform"]) => {}
+                "xrsimulator" if does_sdkroot_contain(&["XROS.platform", "MacOSX.platform"]) => {}
                 // Ignore `SDKROOT` if it's not a valid path.
                 _ if !p.is_absolute() || p == Path::new("/") || !p.exists() => {}
                 _ => return Ok(sdkroot),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4002,7 +4002,15 @@ impl Build {
     }
 
     fn windows_registry_find_tool(&self, target: &str, tool: &str) -> Option<Tool> {
-        windows_registry::find_tool_inner(target, tool, |env| self.getenv(env))
+        struct BuildEnvGetter<'s>(&'s Build);
+
+        impl windows_registry::EnvGetter for BuildEnvGetter<'_> {
+            fn get_env(&self, name: &str) -> Option<windows_registry::Env> {
+                self.0.getenv(name).map(windows_registry::Env::Arced)
+            }
+        }
+
+        windows_registry::find_tool_inner(target, tool, &BuildEnvGetter(self))
     }
 }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -6,7 +6,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::Mutex,
+    sync::RwLock,
 };
 
 use crate::{
@@ -40,7 +40,7 @@ pub struct Tool {
 impl Tool {
     pub(crate) fn new(
         path: PathBuf,
-        cached_compiler_family: &Mutex<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -57,7 +57,7 @@ impl Tool {
     pub(crate) fn with_clang_driver(
         path: PathBuf,
         clang_driver: Option<&str>,
-        cached_compiler_family: &Mutex<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -90,7 +90,7 @@ impl Tool {
         path: PathBuf,
         clang_driver: Option<&str>,
         cuda: bool,
-        cached_compiler_family: &Mutex<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -186,13 +186,13 @@ impl Tool {
             }
         }
         let detect_family = |path: &Path| -> Result<ToolFamily, Error> {
-            if let Some(family) = cached_compiler_family.lock().unwrap().get(path) {
+            if let Some(family) = cached_compiler_family.read().unwrap().get(path) {
                 return Ok(*family);
             }
 
             let family = detect_family_inner(path, cargo_output, out_dir)?;
             cached_compiler_family
-                .lock()
+                .write()
                 .unwrap()
                 .insert(path.into(), family);
             Ok(family)

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -15,7 +15,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let len = self.slice.len();
-        for (index, os_str) in self.slice.into_iter().enumerate() {
+        for (index, os_str) in self.slice.iter().enumerate() {
             // TODO: Use OsStr::display once it is stablised,
             // Path and OsStr has the same `Display` impl
             write!(f, "{}", Path::new(os_str).display())?;

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -14,7 +14,14 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use std::{env, ffi::OsStr, process::Command};
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    ops::Deref,
+    path::PathBuf,
+    process::Command,
+    sync::Arc,
+};
 
 use crate::Tool;
 use crate::ToolFamily;
@@ -33,6 +40,50 @@ impl PartialEq<&str> for TargetArch<'_> {
 impl<'a> From<TargetArch<'a>> for &'a str {
     fn from(target: TargetArch<'a>) -> Self {
         target.0
+    }
+}
+
+pub(crate) enum Env {
+    Owned(OsString),
+    Arced(Arc<OsStr>),
+}
+
+impl AsRef<OsStr> for Env {
+    fn as_ref(&self) -> &OsStr {
+        self.deref()
+    }
+}
+
+impl Deref for Env {
+    type Target = OsStr;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Env::Owned(os_str) => os_str,
+            Env::Arced(os_str) => os_str,
+        }
+    }
+}
+
+impl From<Env> for PathBuf {
+    fn from(env: Env) -> Self {
+        match env {
+            Env::Owned(os_str) => PathBuf::from(os_str),
+            Env::Arced(os_str) => PathBuf::from(os_str.deref()),
+        }
+    }
+}
+
+pub(crate) trait EnvGetter {
+    fn get_env(&self, name: &'static str) -> Option<Env>;
+}
+
+struct StdEnvGetter;
+
+impl EnvGetter for StdEnvGetter {
+    #[allow(clippy::disallowed_methods)]
+    fn get_env(&self, name: &'static str) -> Option<Env> {
+        env::var_os(name).map(Env::Owned)
     }
 }
 
@@ -55,16 +106,15 @@ pub fn find(target: &str, tool: &str) -> Option<Command> {
 /// Similar to the `find` function above, this function will attempt the same
 /// operation (finding a MSVC tool in a local install) but instead returns a
 /// `Tool` which may be introspected.
-#[allow(clippy::disallowed_methods)]
 pub fn find_tool(target: &str, tool: &str) -> Option<Tool> {
-    find_tool_inner(target, tool, env::var_os)
+    find_tool_inner(target, tool, &StdEnvGetter)
 }
 
-pub(crate) fn find_tool_inner<F, R>(target: &str, tool: &str, get_env: F) -> Option<Tool>
-where
-    F: Fn(&'static str) -> Option<R>,
-    R: AsRef<OsStr> + 'static,
-{
+pub(crate) fn find_tool_inner(
+    target: &str,
+    tool: &str,
+    env_getter: &dyn EnvGetter,
+) -> Option<Tool> {
     // This logic is all tailored for MSVC, if we're not that then bail out
     // early.
     if !target.contains("msvc") {
@@ -77,13 +127,13 @@ where
     // Looks like msbuild isn't located in the same location as other tools like
     // cl.exe and lib.exe.
     if tool.contains("msbuild") {
-        return impl_::find_msbuild(target, &get_env);
+        return impl_::find_msbuild(target, env_getter);
     }
 
     // Looks like devenv isn't located in the same location as other tools like
     // cl.exe and lib.exe.
     if tool.contains("devenv") {
-        return impl_::find_devenv(target, &get_env);
+        return impl_::find_devenv(target, env_getter);
     }
 
     // Ok, if we're here, now comes the fun part of the probing. Default shells
@@ -93,10 +143,10 @@ where
     // environment variables like `LIB`, `INCLUDE`, and `PATH` to ensure that
     // the tool is actually usable.
 
-    impl_::find_msvc_environment(tool, target, &get_env)
-        .or_else(|| impl_::find_msvc_15plus(tool, target, &get_env))
-        .or_else(|| impl_::find_msvc_14(tool, target, &get_env))
-        .or_else(|| impl_::find_msvc_12(tool, target, get_env))
+    impl_::find_msvc_environment(tool, target, env_getter)
+        .or_else(|| impl_::find_msvc_15plus(tool, target, env_getter))
+        .or_else(|| impl_::find_msvc_14(tool, target, env_getter))
+        .or_else(|| impl_::find_msvc_12(tool, target, env_getter))
 }
 
 /// A version of Visual Studio
@@ -141,15 +191,15 @@ pub fn find_vs_version() -> Result<VsVers, String> {
         _ => {
             // Check for the presence of a specific registry key
             // that indicates visual studio is installed.
-            if impl_::has_msbuild_version("17.0", env::var_os) {
+            if impl_::has_msbuild_version("17.0", &StdEnvGetter) {
                 Ok(VsVers::Vs17)
-            } else if impl_::has_msbuild_version("16.0", env::var_os) {
+            } else if impl_::has_msbuild_version("16.0", &StdEnvGetter) {
                 Ok(VsVers::Vs16)
-            } else if impl_::has_msbuild_version("15.0", env::var_os) {
+            } else if impl_::has_msbuild_version("15.0", &StdEnvGetter) {
                 Ok(VsVers::Vs15)
-            } else if impl_::has_msbuild_version("14.0", env::var_os) {
+            } else if impl_::has_msbuild_version("14.0", &StdEnvGetter) {
                 Ok(VsVers::Vs14)
-            } else if impl_::has_msbuild_version("12.0", env::var_os) {
+            } else if impl_::has_msbuild_version("12.0", &StdEnvGetter) {
                 Ok(VsVers::Vs12)
             } else {
                 Err("\n\n\
@@ -177,7 +227,7 @@ mod impl_ {
     };
     use std::convert::TryFrom;
     use std::env;
-    use std::ffi::{OsStr, OsString};
+    use std::ffi::OsString;
     use std::fs::File;
     use std::io::Read;
     use std::iter;
@@ -188,7 +238,7 @@ mod impl_ {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Once;
 
-    use super::{TargetArch, MSVC_FAMILY};
+    use super::{EnvGetter, TargetArch, MSVC_FAMILY};
     use crate::Tool;
 
     struct MsvcTool {
@@ -271,11 +321,7 @@ mod impl_ {
             }
         }
 
-        fn into_tool<F, R>(self, get_env: F) -> Tool
-        where
-            F: Fn(&'static str) -> Option<R>,
-            R: AsRef<OsStr> + 'static,
-        {
+        fn into_tool(self, env_getter: &dyn EnvGetter) -> Tool {
             let MsvcTool {
                 tool,
                 libs,
@@ -283,21 +329,17 @@ mod impl_ {
                 include,
             } = self;
             let mut tool = Tool::with_family(tool, MSVC_FAMILY);
-            add_env(&mut tool, "LIB", libs, &get_env);
-            add_env(&mut tool, "PATH", path, &get_env);
-            add_env(&mut tool, "INCLUDE", include, get_env);
+            add_env(&mut tool, "LIB", libs, env_getter);
+            add_env(&mut tool, "PATH", path, env_getter);
+            add_env(&mut tool, "INCLUDE", include, env_getter);
             tool
         }
     }
 
     /// Checks to see if the `VSCMD_ARG_TGT_ARCH` environment variable matches the
     /// given target's arch. Returns `None` if the variable does not exist.
-    fn is_vscmd_target<F, R>(target: TargetArch<'_>, get_env: F) -> Option<bool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let vscmd_arch = get_env("VSCMD_ARG_TGT_ARCH")?;
+    fn is_vscmd_target(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<bool> {
+        let vscmd_arch = env_getter.get_env("VSCMD_ARG_TGT_ARCH")?;
         // Convert the Rust target arch to its VS arch equivalent.
         let arch = match target.into() {
             "x86_64" => "x64",
@@ -311,27 +353,24 @@ mod impl_ {
     }
 
     /// Attempt to find the tool using environment variables set by vcvars.
-    pub(super) fn find_msvc_environment<F, R>(
+    pub(super) fn find_msvc_environment(
         tool: &str,
         target: TargetArch<'_>,
-        get_env: F,
-    ) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
         // Early return if the environment doesn't contain a VC install.
-        get_env("VCINSTALLDIR")?;
-        let vs_install_dir: PathBuf = get_env("VSINSTALLDIR")?.as_ref().into();
+        env_getter.get_env("VCINSTALLDIR")?;
+        let vs_install_dir: PathBuf = env_getter.get_env("VSINSTALLDIR")?.into();
 
         // If the vscmd target differs from the requested target then
         // attempt to get the tool using the VS install directory.
-        if is_vscmd_target(target, &get_env) == Some(false) {
+        if is_vscmd_target(target, env_getter) == Some(false) {
             // We will only get here with versions 15+.
-            tool_from_vs15plus_instance(tool, target, &vs_install_dir, get_env)
+            tool_from_vs15plus_instance(tool, target, &vs_install_dir, env_getter)
         } else {
             // Fallback to simply using the current environment.
-            get_env("PATH")
+            env_getter
+                .get_env("PATH")
                 .and_then(|path| {
                     env::split_paths(&path)
                         .map(|p| p.join(tool))
@@ -341,25 +380,17 @@ mod impl_ {
         }
     }
 
-    fn find_msbuild_vs17<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        find_tool_in_vs16plus_path(r"MSBuild\Current\Bin\MSBuild.exe", target, "17", get_env)
+    fn find_msbuild_vs17(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
+        find_tool_in_vs16plus_path(r"MSBuild\Current\Bin\MSBuild.exe", target, "17", env_getter)
     }
 
     #[allow(bare_trait_objects)]
-    fn vs16plus_instances<F, R>(
+    fn vs16plus_instances(
         target: TargetArch<'_>,
         version: &'static str,
-        get_env: F,
-    ) -> Box<Iterator<Item = PathBuf>>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let instances = if let Some(instances) = vs15plus_instances(target, get_env) {
+        env_getter: &dyn EnvGetter,
+    ) -> Box<Iterator<Item = PathBuf>> {
+        let instances = if let Some(instances) = vs15plus_instances(target, env_getter) {
             instances
         } else {
             return Box::new(iter::empty());
@@ -376,17 +407,13 @@ mod impl_ {
         }))
     }
 
-    fn find_tool_in_vs16plus_path<F, R>(
+    fn find_tool_in_vs16plus_path(
         tool: &str,
         target: TargetArch<'_>,
         version: &'static str,
-        get_env: F,
-    ) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        vs16plus_instances(target, version, get_env)
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
+        vs16plus_instances(target, version, env_getter)
             .filter_map(|path| {
                 let path = path.join(tool);
                 if !path.is_file() {
@@ -404,12 +431,8 @@ mod impl_ {
             .next()
     }
 
-    fn find_msbuild_vs16<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        find_tool_in_vs16plus_path(r"MSBuild\Current\Bin\MSBuild.exe", target, "16", get_env)
+    fn find_msbuild_vs16(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
+        find_tool_in_vs16plus_path(r"MSBuild\Current\Bin\MSBuild.exe", target, "16", env_getter)
     }
 
     // In MSVC 15 (2017) MS once again changed the scheme for locating
@@ -424,12 +447,12 @@ mod impl_ {
     //
     // However, on ARM64 this method doesn't work because VS Installer fails to register COM component on ARM64.
     // Hence, as the last resort we try to use vswhere.exe to list available instances.
-    fn vs15plus_instances<F, R>(target: TargetArch<'_>, get_env: F) -> Option<VsInstances>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        vs15plus_instances_using_com().or_else(|| vs15plus_instances_using_vswhere(target, get_env))
+    fn vs15plus_instances(
+        target: TargetArch<'_>,
+        env_getter: &dyn EnvGetter,
+    ) -> Option<VsInstances> {
+        vs15plus_instances_using_com()
+            .or_else(|| vs15plus_instances_using_vswhere(target, env_getter))
     }
 
     fn vs15plus_instances_using_com() -> Option<VsInstances> {
@@ -441,16 +464,13 @@ mod impl_ {
         Some(VsInstances::ComBased(enum_setup_instances))
     }
 
-    fn vs15plus_instances_using_vswhere<F, R>(
+    fn vs15plus_instances_using_vswhere(
         target: TargetArch<'_>,
-        get_env: F,
-    ) -> Option<VsInstances>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let program_files_path =
-            get_env("ProgramFiles(x86)").or_else(|| get_env("ProgramFiles"))?;
+        env_getter: &dyn EnvGetter,
+    ) -> Option<VsInstances> {
+        let program_files_path = env_getter
+            .get_env("ProgramFiles(x86)")
+            .or_else(|| env_getter.get_env("ProgramFiles"))?;
 
         let program_files_path = Path::new(program_files_path.as_ref());
 
@@ -498,21 +518,17 @@ mod impl_ {
             .collect()
     }
 
-    pub(super) fn find_msvc_15plus<F, R>(
+    pub(super) fn find_msvc_15plus(
         tool: &str,
         target: TargetArch<'_>,
-        get_env: F,
-    ) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let iter = vs15plus_instances(target, &get_env)?;
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
+        let iter = vs15plus_instances(target, env_getter)?;
         iter.into_iter()
             .filter_map(|instance| {
                 let version = parse_version(&instance.installation_version()?)?;
                 let instance_path = instance.installation_path()?;
-                let tool = tool_from_vs15plus_instance(tool, target, &instance_path, &get_env)?;
+                let tool = tool_from_vs15plus_instance(tool, target, &instance_path, env_getter)?;
                 Some((version, tool))
             })
             .max_by(|(a_version, _), (b_version, _)| a_version.cmp(b_version))
@@ -526,12 +542,12 @@ mod impl_ {
     // we keep the registry method as a fallback option.
     //
     // [more reliable]: https://github.com/rust-lang/cc-rs/pull/331
-    fn find_tool_in_vs15_path<F, R>(tool: &str, target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let mut path = match vs15plus_instances(target, get_env) {
+    fn find_tool_in_vs15_path(
+        tool: &str,
+        target: TargetArch<'_>,
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
+        let mut path = match vs15plus_instances(target, env_getter) {
             Some(instances) => instances
                 .into_iter()
                 .filter_map(|instance| instance.installation_path())
@@ -561,18 +577,14 @@ mod impl_ {
         })
     }
 
-    fn tool_from_vs15plus_instance<F, R>(
+    fn tool_from_vs15plus_instance(
         tool: &str,
         target: TargetArch<'_>,
         instance_path: &Path,
-        get_env: F,
-    ) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
         let (root_path, bin_path, host_dylib_path, lib_path, alt_lib_path, include_path) =
-            vs15plus_vc_paths(target, instance_path, &get_env)?;
+            vs15plus_vc_paths(target, instance_path, env_getter)?;
         let tool_path = bin_path.join(tool);
         if !tool_path.exists() {
             return None;
@@ -592,20 +604,16 @@ mod impl_ {
             tool.include.push(atl_include_path);
         }
 
-        add_sdks(&mut tool, target, &get_env)?;
+        add_sdks(&mut tool, target, env_getter)?;
 
-        Some(tool.into_tool(get_env))
+        Some(tool.into_tool(env_getter))
     }
 
-    fn vs15plus_vc_paths<F, R>(
+    fn vs15plus_vc_paths(
         target: TargetArch<'_>,
         instance_path: &Path,
-        get_env: F,
-    ) -> Option<(PathBuf, PathBuf, PathBuf, PathBuf, Option<PathBuf>, PathBuf)>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+        env_getter: &dyn EnvGetter,
+    ) -> Option<(PathBuf, PathBuf, PathBuf, PathBuf, Option<PathBuf>, PathBuf)> {
         let version = vs15plus_vc_read_version(instance_path)?;
 
         let hosts = match host_arch() {
@@ -643,7 +651,7 @@ mod impl_ {
         // architecture, because it contains dlls like mspdb140.dll compiled for
         // the host architecture.
         let host_dylib_path = host_path.join(host.to_lowercase());
-        let lib_fragment = if use_spectre_mitigated_libs(get_env) {
+        let lib_fragment = if use_spectre_mitigated_libs(env_getter) {
             r"lib\spectre"
         } else {
             "lib"
@@ -698,12 +706,9 @@ mod impl_ {
         Some(version)
     }
 
-    fn use_spectre_mitigated_libs<F, R>(get_env: F) -> bool
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        get_env("VSCMD_ARG_VCVARS_SPECTRE")
+    fn use_spectre_mitigated_libs(env_getter: &dyn EnvGetter) -> bool {
+        env_getter
+            .get_env("VSCMD_ARG_VCVARS_SPECTRE")
             .map(|env| env.as_ref() == "spectre")
             .unwrap_or_default()
     }
@@ -720,22 +725,22 @@ mod impl_ {
 
     // For MSVC 14 we need to find the Universal CRT as well as either
     // the Windows 10 SDK or Windows 8.1 SDK.
-    pub(super) fn find_msvc_14<F, R>(tool: &str, target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    pub(super) fn find_msvc_14(
+        tool: &str,
+        target: TargetArch<'_>,
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
         let vcdir = get_vc_dir("14.0")?;
         let mut tool = get_tool(tool, &vcdir, target)?;
-        add_sdks(&mut tool, target, &get_env)?;
-        Some(tool.into_tool(get_env))
+        add_sdks(&mut tool, target, env_getter)?;
+        Some(tool.into_tool(env_getter))
     }
 
-    fn add_sdks<F, R>(tool: &mut MsvcTool, target: TargetArch<'_>, get_env: F) -> Option<()>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    fn add_sdks(
+        tool: &mut MsvcTool,
+        target: TargetArch<'_>,
+        env_getter: &dyn EnvGetter,
+    ) -> Option<()> {
         let sub = lib_subdir(target)?;
         let (ucrt, ucrt_version) = get_ucrt_dir()?;
 
@@ -755,7 +760,7 @@ mod impl_ {
         let ucrt_lib = ucrt.join("lib").join(&ucrt_version);
         tool.libs.push(ucrt_lib.join("ucrt").join(sub));
 
-        if let Some((sdk, version)) = get_sdk10_dir(get_env) {
+        if let Some((sdk, version)) = get_sdk10_dir(env_getter) {
             tool.path.push(sdk.join("bin").join(host));
             let sdk_lib = sdk.join("lib").join(&version);
             tool.libs.push(sdk_lib.join("um").join(sub));
@@ -778,11 +783,11 @@ mod impl_ {
     }
 
     // For MSVC 12 we need to find the Windows 8.1 SDK.
-    pub(super) fn find_msvc_12<F, R>(tool: &str, target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    pub(super) fn find_msvc_12(
+        tool: &str,
+        target: TargetArch<'_>,
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
         let vcdir = get_vc_dir("12.0")?;
         let mut tool = get_tool(tool, &vcdir, target)?;
         let sub = lib_subdir(target)?;
@@ -794,15 +799,16 @@ mod impl_ {
         tool.include.push(sdk_include.join("shared"));
         tool.include.push(sdk_include.join("um"));
         tool.include.push(sdk_include.join("winrt"));
-        Some(tool.into_tool(get_env))
+        Some(tool.into_tool(env_getter))
     }
 
-    fn add_env<F, R>(tool: &mut Tool, env: &'static str, paths: Vec<PathBuf>, get_env: F)
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        let prev = get_env(env);
+    fn add_env(
+        tool: &mut Tool,
+        env: &'static str,
+        paths: Vec<PathBuf>,
+        env_getter: &dyn EnvGetter,
+    ) {
+        let prev = env_getter.get_env(env);
         let prev = prev.as_ref().map(AsRef::as_ref).unwrap_or_default();
         let prev = env::split_paths(&prev);
         let new = paths.into_iter().chain(prev);
@@ -888,14 +894,11 @@ mod impl_ {
     // Before doing that, we check the "WindowsSdkDir" and "WindowsSDKVersion"
     // environment variables set by vcvars to use the environment sdk version
     // if one is already configured.
-    fn get_sdk10_dir<F, R>(get_env: F) -> Option<(PathBuf, String)>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    fn get_sdk10_dir(env_getter: &dyn EnvGetter) -> Option<(PathBuf, String)> {
         if let (Some(root), Some(version)) = (
-            get_env("WindowsSdkDir").as_ref(),
-            get_env("WindowsSDKVersion")
+            env_getter.get_env("WindowsSdkDir").as_ref(),
+            env_getter
+                .get_env("WindowsSDKVersion")
                 .as_ref()
                 .and_then(|version| version.as_ref().to_str()),
         ) {
@@ -1044,26 +1047,22 @@ mod impl_ {
         max_key
     }
 
-    pub(super) fn has_msbuild_version<F, R>(version: &str, get_env: F) -> bool
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    pub(super) fn has_msbuild_version(version: &str, env_getter: &dyn EnvGetter) -> bool {
         match version {
             "17.0" => {
-                find_msbuild_vs17(TargetArch("x86_64"), &get_env).is_some()
-                    || find_msbuild_vs17(TargetArch("i686"), &get_env).is_some()
-                    || find_msbuild_vs17(TargetArch("aarch64"), &get_env).is_some()
+                find_msbuild_vs17(TargetArch("x86_64"), env_getter).is_some()
+                    || find_msbuild_vs17(TargetArch("i686"), env_getter).is_some()
+                    || find_msbuild_vs17(TargetArch("aarch64"), env_getter).is_some()
             }
             "16.0" => {
-                find_msbuild_vs16(TargetArch("x86_64"), &get_env).is_some()
-                    || find_msbuild_vs16(TargetArch("i686"), &get_env).is_some()
-                    || find_msbuild_vs16(TargetArch("aarch64"), &get_env).is_some()
+                find_msbuild_vs16(TargetArch("x86_64"), env_getter).is_some()
+                    || find_msbuild_vs16(TargetArch("i686"), env_getter).is_some()
+                    || find_msbuild_vs16(TargetArch("aarch64"), env_getter).is_some()
             }
             "15.0" => {
-                find_msbuild_vs15(TargetArch("x86_64"), &get_env).is_some()
-                    || find_msbuild_vs15(TargetArch("i686"), &get_env).is_some()
-                    || find_msbuild_vs15(TargetArch("aarch64"), &get_env).is_some()
+                find_msbuild_vs15(TargetArch("x86_64"), env_getter).is_some()
+                    || find_msbuild_vs15(TargetArch("i686"), env_getter).is_some()
+                    || find_msbuild_vs15(TargetArch("aarch64"), env_getter).is_some()
             }
             "12.0" | "14.0" => LOCAL_MACHINE
                 .open(&OsString::from(format!(
@@ -1075,46 +1074,30 @@ mod impl_ {
         }
     }
 
-    pub(super) fn find_devenv<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        find_devenv_vs15(target, get_env)
+    pub(super) fn find_devenv(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
+        find_devenv_vs15(target, env_getter)
     }
 
-    fn find_devenv_vs15<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        find_tool_in_vs15_path(r"Common7\IDE\devenv.exe", target, get_env)
+    fn find_devenv_vs15(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
+        find_tool_in_vs15_path(r"Common7\IDE\devenv.exe", target, env_getter)
     }
 
     // see http://stackoverflow.com/questions/328017/path-to-msbuild
-    pub(super) fn find_msbuild<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+    pub(super) fn find_msbuild(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
         // VS 15 (2017) changed how to locate msbuild
-        if let Some(r) = find_msbuild_vs17(target, &get_env) {
+        if let Some(r) = find_msbuild_vs17(target, env_getter) {
             Some(r)
-        } else if let Some(r) = find_msbuild_vs16(target, &get_env) {
+        } else if let Some(r) = find_msbuild_vs16(target, env_getter) {
             return Some(r);
-        } else if let Some(r) = find_msbuild_vs15(target, get_env) {
+        } else if let Some(r) = find_msbuild_vs15(target, env_getter) {
             return Some(r);
         } else {
             find_old_msbuild(target)
         }
     }
 
-    fn find_msbuild_vs15<F, R>(target: TargetArch<'_>, get_env: F) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
-        find_tool_in_vs15_path(r"MSBuild\15.0\Bin\MSBuild.exe", target, get_env)
+    fn find_msbuild_vs15(target: TargetArch<'_>, env_getter: &dyn EnvGetter) -> Option<Tool> {
+        find_tool_in_vs15_path(r"MSBuild\15.0\Bin\MSBuild.exe", target, env_getter)
     }
 
     fn find_old_msbuild(target: TargetArch<'_>) -> Option<Tool> {
@@ -1140,12 +1123,9 @@ mod impl_ {
 /// Non-Windows Implementation.
 #[cfg(not(windows))]
 mod impl_ {
-    use std::{
-        env,
-        ffi::{OsStr, OsString},
-    };
+    use std::{env, ffi::OsStr};
 
-    use super::{TargetArch, MSVC_FAMILY};
+    use super::{EnvGetter, TargetArch, MSVC_FAMILY};
     use crate::Tool;
 
     /// Finding msbuild.exe tool under unix system is not currently supported.
@@ -1161,18 +1141,14 @@ mod impl_ {
     }
 
     /// Attempt to find the tool using environment variables set by vcvars.
-    pub(super) fn find_msvc_environment<F, R>(
+    pub(super) fn find_msvc_environment(
         tool: &str,
         _target: TargetArch<'_>,
-        get_env: F,
-    ) -> Option<Tool>
-    where
-        F: Fn(&'static str) -> Option<R>,
-        R: AsRef<OsStr> + 'static,
-    {
+        env_getter: &dyn EnvGetter,
+    ) -> Option<Tool> {
         // Early return if the environment doesn't contain a VC install.
-        let vc_install_dir = get_env("VCINSTALLDIR")?;
-        let vs_install_dir = get_env("VSINSTALLDIR")?;
+        let vc_install_dir = env_getter.get_env("VCINSTALLDIR")?;
+        let vs_install_dir = env_getter.get_env("VSINSTALLDIR")?;
 
         let get_tool = |install_dir: &OsStr| {
             env::split_paths(install_dir)
@@ -1187,7 +1163,8 @@ mod impl_ {
             .or_else(|| get_tool(vs_install_dir.as_ref()))
             // Take the path of tool for the current path environment.
             .or_else(|| {
-                get_env("PATH")
+                env_getter
+                    .get_env("PATH")
                     .as_ref()
                     .map(|path| path.as_ref())
                     .and_then(get_tool)
@@ -1209,10 +1186,7 @@ mod impl_ {
         None
     }
 
-    pub(super) fn has_msbuild_version(
-        version: &str,
-        _: fn(&'static str) -> Option<OsString>,
-    ) -> bool {
+    pub(super) fn has_msbuild_version<F>(version: &str, _: F) -> bool {
         match version {
             "17.0" => false,
             "16.0" => false,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -900,14 +900,14 @@ mod impl_ {
     // if one is already configured.
     fn get_sdk10_dir(env_getter: &dyn EnvGetter) -> Option<(PathBuf, String)> {
         if let (Some(root), Some(version)) = (
-            env_getter.get_env("WindowsSdkDir").as_ref(),
+            env_getter.get_env("WindowsSdkDir"),
             env_getter
                 .get_env("WindowsSDKVersion")
                 .as_ref()
                 .and_then(|version| version.as_ref().to_str()),
         ) {
             return Some((
-                Path::new(root).to_owned(),
+                PathBuf::from(root),
                 version.trim_end_matches('\\').to_string(),
             ));
         }

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -1131,14 +1131,14 @@ mod impl_ {
     /// Finding msbuild.exe tool under unix system is not currently supported.
     /// Maybe can check it using an environment variable looks like `MSBUILD_BIN`.
     #[inline(always)]
-    pub(super) fn find_msbuild<F>(_target: TargetArch<'_>, _: F) -> Option<Tool> {
+    pub(super) fn find_msbuild(_target: TargetArch<'_>, _: &dyn EnvGetter) -> Option<Tool> {
         None
     }
 
     // Finding devenv.exe tool under unix system is not currently supported.
     // Maybe can check it using an environment variable looks like `DEVENV_BIN`.
     #[inline(always)]
-    pub(super) fn find_devenv<F>(_target: TargetArch<'_>, _: F) -> Option<Tool> {
+    pub(super) fn find_devenv(_target: TargetArch<'_>, _: &dyn EnvGetter) -> Option<Tool> {
         None
     }
 
@@ -1174,24 +1174,36 @@ mod impl_ {
     }
 
     #[inline(always)]
-    pub(super) fn find_msvc_15plus<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
+    pub(super) fn find_msvc_15plus(
+        _tool: &str,
+        _target: TargetArch<'_>,
+        _: &dyn EnvGetter,
+    ) -> Option<Tool> {
         None
     }
 
     // For MSVC 14 we need to find the Universal CRT as well as either
     // the Windows 10 SDK or Windows 8.1 SDK.
     #[inline(always)]
-    pub(super) fn find_msvc_14<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
+    pub(super) fn find_msvc_14(
+        _tool: &str,
+        _target: TargetArch<'_>,
+        _: &dyn EnvGetter,
+    ) -> Option<Tool> {
         None
     }
 
     // For MSVC 12 we need to find the Windows 8.1 SDK.
     #[inline(always)]
-    pub(super) fn find_msvc_12<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
+    pub(super) fn find_msvc_12(
+        _tool: &str,
+        _target: TargetArch<'_>,
+        _: &dyn EnvGetter,
+    ) -> Option<Tool> {
         None
     }
 
-    pub(super) fn has_msbuild_version<F>(version: &str, _: F) -> bool {
+    pub(super) fn has_msbuild_version(version: &str, _: &dyn EnvGetter) -> bool {
         match version {
             "17.0" => false,
             "16.0" => false,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -171,6 +171,10 @@ pub enum VsVers {
 /// generator.
 #[allow(clippy::disallowed_methods)]
 pub fn find_vs_version() -> Result<VsVers, String> {
+    fn has_msbuild_version(version: &str) -> bool {
+        impl_::has_msbuild_version(version, &StdEnvGetter)
+    }
+
     match std::env::var("VisualStudioVersion") {
         Ok(version) => match &version[..] {
             "17.0" => Ok(VsVers::Vs17),
@@ -191,15 +195,15 @@ pub fn find_vs_version() -> Result<VsVers, String> {
         _ => {
             // Check for the presence of a specific registry key
             // that indicates visual studio is installed.
-            if impl_::has_msbuild_version("17.0", &StdEnvGetter) {
+            if has_msbuild_version("17.0") {
                 Ok(VsVers::Vs17)
-            } else if impl_::has_msbuild_version("16.0", &StdEnvGetter) {
+            } else if has_msbuild_version("16.0") {
                 Ok(VsVers::Vs16)
-            } else if impl_::has_msbuild_version("15.0", &StdEnvGetter) {
+            } else if has_msbuild_version("15.0") {
                 Ok(VsVers::Vs15)
-            } else if impl_::has_msbuild_version("14.0", &StdEnvGetter) {
+            } else if has_msbuild_version("14.0") {
                 Ok(VsVers::Vs14)
-            } else if impl_::has_msbuild_version("12.0", &StdEnvGetter) {
+            } else if has_msbuild_version("12.0") {
                 Ok(VsVers::Vs12)
             } else {
                 Err("\n\n\
@@ -1047,6 +1051,7 @@ mod impl_ {
         max_key
     }
 
+    #[inline(always)]
     pub(super) fn has_msbuild_version(version: &str, env_getter: &dyn EnvGetter) -> bool {
         match version {
             "17.0" => {
@@ -1203,6 +1208,7 @@ mod impl_ {
         None
     }
 
+    #[inline(always)]
     pub(super) fn has_msbuild_version(version: &str, _: &dyn EnvGetter) -> bool {
         match version {
             "17.0" => false,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -60,7 +60,7 @@ pub fn find_tool(target: &str, tool: &str) -> Option<Tool> {
     find_tool_inner(target, tool, env::var_os)
 }
 
-pub(super) fn find_tool_inner<F, R>(target: &str, tool: &str, get_env: F) -> Option<Tool>
+pub(crate) fn find_tool_inner<F, R>(target: &str, tool: &str, get_env: F) -> Option<Tool>
 where
     F: Fn(&'static str) -> Option<R>,
     R: AsRef<OsStr> + 'static,

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -1130,12 +1130,14 @@ mod impl_ {
 
     /// Finding msbuild.exe tool under unix system is not currently supported.
     /// Maybe can check it using an environment variable looks like `MSBUILD_BIN`.
+    #[inline(always)]
     pub(super) fn find_msbuild<F>(_target: TargetArch<'_>, _: F) -> Option<Tool> {
         None
     }
 
     // Finding devenv.exe tool under unix system is not currently supported.
     // Maybe can check it using an environment variable looks like `DEVENV_BIN`.
+    #[inline(always)]
     pub(super) fn find_devenv<F>(_target: TargetArch<'_>, _: F) -> Option<Tool> {
         None
     }
@@ -1171,17 +1173,20 @@ mod impl_ {
             })
     }
 
+    #[inline(always)]
     pub(super) fn find_msvc_15plus<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
         None
     }
 
     // For MSVC 14 we need to find the Universal CRT as well as either
     // the Windows 10 SDK or Windows 8.1 SDK.
+    #[inline(always)]
     pub(super) fn find_msvc_14<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
         None
     }
 
     // For MSVC 12 we need to find the Windows 8.1 SDK.
+    #[inline(always)]
     pub(super) fn find_msvc_12<F>(_tool: &str, _target: TargetArch<'_>, _: F) -> Option<Tool> {
         None
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(clippy::disallowed_methods)]
 
 use std::env;
 use std::ffi::{OsStr, OsString};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use crate::support::Test;
 
 mod support;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -577,8 +577,8 @@ fn clang_apple_tvos() {
         let test = Test::clang();
         test.gcc()
             .__set_env("TVOS_DEPLOYMENT_TARGET", "9.0")
-            .target(&target)
-            .host(&target)
+            .target(target)
+            .host(target)
             .file("foo.c")
             .compile("foo");
 
@@ -630,8 +630,8 @@ fn clang_apple_tvsimulator() {
         let test = Test::clang();
         test.gcc()
             .__set_env("TVOS_DEPLOYMENT_TARGET", "9.0")
-            .target(&target)
-            .host(&target)
+            .target(target)
+            .host(target)
             .file("foo.c")
             .compile("foo");
 


### PR DESCRIPTION
So that we would get:
 - recompilation when the env is changed
 - cached env

Also some optimisation