### PR TITLE
Speedup regenerate-target-info and regenerate-windows-sys

### DIFF
--- a/.github/workflows/regenerate-target-info.yml
+++ b/.github/workflows/regenerate-target-info.yml
@@ -21,8 +21,13 @@ jobs:
       - name: Install rust
         run: |
           rustup toolchain install stable nightly --no-self-update --profile minimal
+
+      - name: Create lockfile
+        run: cargo update
   
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: 'true'
       - name: Regenerate target info
         run: cargo run -p gen-target-info
 

--- a/.github/workflows/regenerate-windows-sys.yml
+++ b/.github/workflows/regenerate-windows-sys.yml
@@ -18,7 +18,13 @@ jobs:
         run: |
           git checkout -b regenerate-windows-sys-${{ github.run_id }}
 
+      - name: Create lockfile
+        run: cargo update
+  
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: 'true'
+      
       - name: Regenerate windows sys bindings
         run: cargo run -p gen-windows-sys-binding
 


### PR DESCRIPTION
Create lockfile so that rust-cache knows if a new cache needs to be saved.

Also enables cache-all-crates since the crates themselves rarely changes.