### PR TITLE
Fixed link break about compile-time-requirements

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -361,7 +361,7 @@ pub(crate) fn spawn(
         Ok(child) => Ok(child),
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
             let extra = if cfg!(windows) {
-                " (see https://github.com/rust-lang/cc-rs#compile-time-requirements \
+                " (see https://docs.rs/cc/latest/cc/#compile-time-requirements \
 for help)"
             } else {
                 ""


### PR DESCRIPTION
It had already been removed from the README and could no longer be found through this link.

I considered linking to it below, but thought docs.rs would be a better place for documentation.

https://github.com/rust-lang/cc-rs/blob/243038b6e956615e04a98fc2ed44e155719ae20a/src/lib.rs#L129