### PR TITLE
Fix gen-windows-sys-binding

### DIFF
--- a/dev-tools/gen-windows-sys-binding/src/main.rs
+++ b/dev-tools/gen-windows-sys-binding/src/main.rs
@@ -28,6 +28,7 @@ fn main() -> io::Result<()> {
     let mut args = vec![
         "--config",
         "flatten",
+        "sys",
         "--out",
         temp_file.path().to_str().unwrap(),
         "--filter",


### PR DESCRIPTION
Make sure standalone binding without dependencies is generated.