### PR TITLE
Fix generate-windows-sys-bindings

### DIFF
--- a/dev-tools/gen-windows-sys-binding/src/main.rs
+++ b/dev-tools/gen-windows-sys-binding/src/main.rs
@@ -29,6 +29,7 @@ fn main() -> io::Result<()> {
         "--config",
         "flatten",
         "sys",
+        "minimal",
         "--out",
         temp_file.path().to_str().unwrap(),
         "--filter",


### PR DESCRIPTION
Pass --config minimal to generate sys binding without any dependencies