### PR TITLE
Fix is_flag_supported not respecting emit_rerun_if_env_changed (#1147)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,7 +641,8 @@ impl Build {
                 .host(&self.get_host()?)
                 .debug(false)
                 .cpp(self.cpp)
-                .cuda(self.cuda);
+                .cuda(self.cuda)
+                .emit_rerun_if_env_changed(self.emit_rerun_if_env_changed);
             cfg.try_get_compiler()?
         };
 


### PR DESCRIPTION
When I add a Cargo override to the example from #1147:

```toml
[patch.crates-io]
cc = { path = "/tmp/cc-rs" }
```

Then the extra `rerun-if-env-changed` directives go away (except for one that's maybe a separate small bug):

```
$ touch build.rs && cargo build -vvv 2>&1 | grep rerun-if-env-changed
[scratch 0.1.0] cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
[scratch 0.1.0] cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
```

I'm not sure how to add a unit test for this, since it doesn't look like `emit_rerun_if_env_changed` is currently tested.

It also seems like it's pretty easy to write more bugs like this, since anytime a feature is added to `Build` we need to remember to come to these lines and think about whether it should be inherited. I'm not sure how to make that better though. Thoughts?