### PR TITLE
Add empty `jobserver` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ libc = { version = "0.2.62", default-features = false, optional = true }
 
 [features]
 parallel = ["dep:libc", "dep:jobserver", "dep:once_cell"]
+# This is a placeholder feature for people who incorrectly used `cc` with `features = ["jobserver"]`
+# so that they aren't broken. This has never enabled `parallel`, so we won't do that.
+jobserver = []
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Since we removed implicit features, anyone that used this crate and specifically enabled `jobserver` would now be broken as this crate no longer had that feature (or a couple of others).

Add a placeholder `jobserver` feature that doesn't enable `parallel` (just as it didn't enable it before).

The other features removed weren't likely to be enabled by anyone.