### PR TITLE
add `.objects`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,17 @@ impl Build {
         self
     }
 
+    /// Add arbitrary object files to link in
+    pub fn objects<P>(&mut self, objs: P) -> &mut Build
+    where
+        P: IntoIterator,
+        P::Item: AsRef<Path>,{
+        for obj in objs {
+            self.object(obj);
+        };
+        self
+    }
+
     /// Add an arbitrary flag to the invocation of the compiler
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,10 +505,11 @@ impl Build {
     pub fn objects<P>(&mut self, objs: P) -> &mut Build
     where
         P: IntoIterator,
-        P::Item: AsRef<Path>,{
+        P::Item: AsRef<Path>,
+    {
         for obj in objs {
             self.object(obj);
-        };
+        }
         self
     }
 


### PR DESCRIPTION
This adds the `.objects` method mentioned in https://github.com/rust-lang/cc-rs/issues/1165