### PR TITLE
Add custom CC wrapper to the wrapper whitelist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3120,7 +3120,11 @@ impl Build {
         //
         // It's true that everything here is a bit of a pain, but apparently if
         // you're not literally make or bash then you get a lot of bug reports.
-        let known_wrappers = ["ccache", "distcc", "sccache", "icecc", "cachepot"];
+        let mut known_wrappers = vec!["ccache", "distcc", "sccache", "icecc", "cachepot"];
+        let custom_wrapper = self.getenv("CC_KNOWN_WRAPPER_CUSTOM");
+        if custom_wrapper.is_some() {
+            known_wrappers.push(custom_wrapper.as_deref().unwrap().to_str().unwrap());
+        }
 
         let mut parts = tool.split_whitespace();
         let maybe_wrapper = match parts.next() {


### PR DESCRIPTION
Some toolchains use custom (or at least not widely used) CC wrappers, and passes that through the CC env var before the compiler, like:

  CC = <custom_wrapper> <something>-gcc

Add support to CC_KNOWN_WRAPPER_CUSTOM env var, to be able to extend the 'known_wrappers' list with this <custom_wrapper>, and handle these special cases.