### PR TITLE
Replace vector of tuples with BTreeMap which already is sorted and free of duplicate

### DIFF
--- a/dev-tools/gen-target-info/Cargo.toml
+++ b/dev-tools/gen-target-info/Cargo.toml
@@ -6,5 +6,4 @@ publish = false
 
 [dependencies]
 serde = { version = "1.0.163", features = ["derive"] }
-serde-tuple-vec-map = "1.0.1"
 serde_json = "1.0.107"

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -1,5 +1,5 @@
 use gen_target_info::{get_target_specs_from_json, write_target_tuple_mapping, RustcTargetSpecs};
-use std::{fs::File, io::Write as _};
+use std::{collections::BTreeMap, fs::File, io::Write as _};
 
 const PRELUDE: &str = r#"//! This file is generated code. Please edit the generator
 //! in dev-tools/gen-target-info if you need to make changes.
@@ -7,7 +7,7 @@ const PRELUDE: &str = r#"//! This file is generated code. Please edit the genera
 "#;
 
 fn generate_riscv_arch_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
-    let mut riscv_target_mapping = target_specs
+    let riscv_target_mapping = target_specs
         .0
         .iter()
         .filter_map(|(target, target_spec)| {
@@ -15,14 +15,12 @@ fn generate_riscv_arch_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
             (arch.contains("riscv") && arch != target_spec.arch)
                 .then_some((arch, &*target_spec.arch))
         })
-        .collect::<Vec<_>>();
-    riscv_target_mapping.sort_unstable_by_key(|(arch, _)| &**arch);
-    riscv_target_mapping.dedup();
+        .collect::<BTreeMap<_, _>>();
     write_target_tuple_mapping(f, "RISCV_ARCH_MAPPING", &riscv_target_mapping);
 }
 
 fn generate_windows_triple_mapping(f: &mut File, target_specs: &RustcTargetSpecs) {
-    let mut windows_target_mapping = target_specs
+    let windows_target_mapping = target_specs
         .0
         .iter()
         .filter_map(|(target, target_spec)| {
@@ -31,9 +29,7 @@ fn generate_windows_triple_mapping(f: &mut File, target_specs: &RustcTargetSpecs
             (os.contains("windows") && target != &*target_spec.llvm_target)
                 .then_some((&**target, &*target_spec.llvm_target))
         })
-        .collect::<Vec<_>>();
-    windows_target_mapping.sort_unstable_by_key(|(triple, _)| &**triple);
-    windows_target_mapping.dedup();
+        .collect::<BTreeMap<_, _>>();
     write_target_tuple_mapping(f, "WINDOWS_TRIPLE_MAPPING", &windows_target_mapping);
 }
 

--- a/dev-tools/gen-target-info/src/target_specs.rs
+++ b/dev-tools/gen-target-info/src/target_specs.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize)]
 #[serde(transparent)]
 pub struct PreLinkArgs(
     /// First field in the linker name,
     /// second field is the args.
-    #[serde(with = "tuple_vec_map")]
-    pub Vec<(String, Vec<String>)>,
+    pub BTreeMap<String, Vec<String>>,
 );
 
 #[derive(Debug, Deserialize)]
@@ -28,6 +28,5 @@ pub struct TargetSpec {
 #[serde(transparent)]
 pub struct RustcTargetSpecs(
     /// First field in the tuple is the rustc target
-    #[serde(with = "tuple_vec_map")]
-    pub Vec<(String, TargetSpec)>,
+    pub BTreeMap<String, TargetSpec>,
 );

--- a/dev-tools/gen-target-info/src/write.rs
+++ b/dev-tools/gen-target-info/src/write.rs
@@ -1,6 +1,10 @@
-use std::{fmt::Write as _, fs, io::Write as _};
+use std::{collections::BTreeMap, fmt::Write as _, fs, io::Write as _};
 
-pub fn write_target_tuple_mapping(f: &mut fs::File, variable_name: &str, data: &[(&str, &str)]) {
+pub fn write_target_tuple_mapping(
+    f: &mut fs::File,
+    variable_name: &str,
+    data: &BTreeMap<&str, &str>,
+) {
     let mut content = format!("pub const {variable_name}: &[(&str, &str)] = &[\n");
 
     for (f1, f2) in data {


### PR DESCRIPTION
I think this is more convenient to work with but feel free to close it if you don't agree.

Depends on: https://github.com/rust-lang/cc-rs/pull/1176