### PR TITLE
Add support for parsing `*FLAGS` with `shlex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rust-version = "1.63"
 
 [dependencies]
 jobserver = { version = "0.1.30", default-features = false, optional = true }
+shlex = "1.3.0"
 
 [target.'cfg(unix)'.dependencies]
 # Don't turn on the feature "std" for this, see https://github.com/rust-lang/cargo/issues/4866

--- a/tests/cflags_shell_escaped.rs
+++ b/tests/cflags_shell_escaped.rs
@@ -1,0 +1,24 @@
+mod support;
+
+use crate::support::Test;
+use std::env;
+
+/// This test is in its own module because it modifies the environment and would affect other tests
+/// when run in parallel with them.
+#[test]
+fn gnu_test_parse_shell_escaped_flags() {
+    env::set_var("CFLAGS", "foo \"bar baz\"");
+    env::set_var("CC_SHELL_ESCAPED_FLAGS", "1");
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    test.cmd(0).must_have("foo").must_have("bar baz");
+
+    env::remove_var("CC_SHELL_ESCAPED_FLAGS");
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    test.cmd(0)
+        .must_have("foo")
+        .must_have_in_order("\"bar", "baz\"");
+}


### PR DESCRIPTION
Hello,
This PR adds support for parsing `*FLAGS` with the `shlex` crate. This effectively fixes #847, and means `*FLAGS` with spaces designed for `meson`, `make` and `cmake` will work with no extra configuration.
In order to preserve compatibility with existing setups, the behavior must be opted into with `CC_PARSE_FLAGS_WITH_SHLEX`, or the `parse_flags_with_shlex` method on the `Builder`.