### PR TITLE
Treat VxWorks wr-cc as a Gnu compiler

### DIFF
--- a/src/detect_compiler_family.c
+++ b/src/detect_compiler_family.c
@@ -10,3 +10,6 @@
 #pragma message "emscripten"
 #endif
 
+#ifdef __VXWORKS__
+#pragma message "VxWorks"
+#endif

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -170,18 +170,19 @@ impl Tool {
             let clang = stdout.contains(r#""clang""#);
             let gcc = stdout.contains(r#""gcc""#);
             let emscripten = stdout.contains(r#""emscripten""#);
+            let vxworks = stdout.contains(r#""VxWorks""#);
 
-            match (clang, accepts_cl_style_flags, gcc, emscripten) {
-                (clang_cl, true, _, false) => Ok(ToolFamily::Msvc { clang_cl }),
-                (true, _, _, _) | (_, _, _, true) => Ok(ToolFamily::Clang {
+            match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
+                (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),
+                (true, _, _, _, false) | (_, _, _, true, false) => Ok(ToolFamily::Clang {
                     zig_cc: is_zig_cc(path, cargo_output),
                 }),
-                (false, false, true, _) => Ok(ToolFamily::Gnu),
-                (false, false, false, false) => {
-                    cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__` or `__EMSCRIPTEN__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
+                (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
+                (false, false, false, false, false) => {
+                    cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
                     Err(Error::new(
                         ErrorKind::ToolFamilyMacroNotFound,
-                        "Expects macro `__clang__`, `__GNUC__` or `__EMSCRIPTEN__`, or accepts cl style flag `-?`, but found none",
+                        "Expects macro `__clang__`, `__GNUC__` or `__EMSCRIPTEN__`, `__VXWORKS__` or accepts cl style flag `-?`, but found none",
                     ))
                 }
             }


### PR DESCRIPTION
Fixes #1197 
Solution: 
1. Remove ci style arguments from command for wr-cc.
2. Remove --target=value from command as this caused wr-cc to look for wrong target config file.
