### PR TITLE
fix finding toolchains when invoked by msbuild

### DIFF
--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -363,9 +363,10 @@ mod impl_ {
     ) -> Option<Tool> {
         // Early return if the environment isn't one that is known to have compiler toolsets in PATH
         // `VCINSTALLDIR` is set from vcvarsall.bat (developer command prompt)
-        // `VisualStudioDir` is set by msbuild when invoking custom build steps
+        // `VSTEL_MSBuildProjectFullPath` is set by msbuild when invoking custom build steps
+        // NOTE: `VisualStudioDir` used to be used but this isn't set when invoking msbuild from the commandline
         if env_getter.get_env("VCINSTALLDIR").is_none()
-            && env_getter.get_env("VisualStudioDir").is_none()
+            && env_getter.get_env("VSTEL_MSBuildProjectFullPath").is_none()
         {
             return None;
         }


### PR DESCRIPTION
As noted in https://github.com/rust-lang/cc-rs/issues/1189#issuecomment-2332901474, when invoking msbuild from the commandline `VisualStudioDir` is not set. `VSTEL_MSBuildProjectFullPath` does seem to be set reliably, even if it's undocumented....

I'm open to alternative fixes here as well. It's possible that we should check that the value of it ends in `.vcxproj` as if it's a C# library or something it may not have the proper environment set (I'm rather unsure). 