### PR TITLE
Don't rerun if PATH changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3718,7 +3718,7 @@ impl Build {
         if let Some(val) = self.env_cache.read().unwrap().get(v).cloned() {
             return val;
         }
-        if self.emit_rerun_if_env_changed && !provided_by_cargo(v) {
+        if self.emit_rerun_if_env_changed && !provided_by_cargo(v) && v != "PATH" {
             self.cargo_output
                 .print_metadata(&format_args!("cargo:rerun-if-env-changed={}", v));
         }


### PR DESCRIPTION
Prevents spurious rebuilds on Windows (https://github.com/rust-lang/cc-rs/pull/1103/files#r1674907945) as suggested by @NobodyXu.

> It looks like this change causes crates to rebuild on Windows any time the `PATH` changes. Anecdotally, that seems to have a pretty high false positive rate, and since some `PATH` changes are associated with tools like rust-analyer that run constantly in the background, this can make it so that every build is a complete rebuild in some setups / with some dependencies. See for example https://github.com/BLAKE3-team/BLAKE3/issues/324. I might file this as an issue shortly, but I wanted to mention it real quick before I forget.

_Originally posted by oconnor663_

> Perhaps we can special-case PATH here?
>
> For example, Update the getenv to not emit anything for PATH

_Originally posted by NobodyXu_
