### PR TITLE
Allow disabling `cc`'s ability to run commands via the `CC_FORCE_DISABLE` environment variable

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,7 @@
 disallowed-methods = [
     { path = "std::env::var_os", reason = "Please use Build::getenv" },
     { path = "std::env::var", reason = "Please use Build::getenv" },
+    { path = "std::process::Command::new", reason = "Please use crate::command_new()" },
+    { path = "cc::tool::Tool::to_command", reason = "Bypasses `is_disabled()` check. Use try_to_command() instead." },
 ]
 doc-valid-idents = ["AppleClang", "OpenBSD", ".."]

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -99,6 +99,7 @@ impl EnvGetter for StdEnvGetter {
 /// tool with the appropriate environment variables set.
 ///
 /// Note that this function always returns `None` for non-MSVC targets.
+#[allow(clippy::disallowed_methods)] // `Tool::to_command`
 pub fn find(target: &str, tool: &str) -> Option<Command> {
     find_tool(target, tool).map(|c| c.to_command())
 }
@@ -478,6 +479,11 @@ mod impl_ {
         target: TargetArch<'_>,
         env_getter: &dyn EnvGetter,
     ) -> Option<VsInstances> {
+        if crate::is_disabled() {
+            // If we aren't allowed to run commands, just pretend
+            // vswhere didn't tell us anything useful.
+            return None;
+        }
         let program_files_path = env_getter
             .get_env("ProgramFiles(x86)")
             .or_else(|| env_getter.get_env("ProgramFiles"))?;
@@ -497,7 +503,8 @@ mod impl_ {
             "aarch64" | "arm64ec" => Some("ARM64"),
             _ => None,
         };
-
+        // Already checked `is_disabled()`.
+        #[allow(clippy::disallowed_methods)]
         let vswhere_output = Command::new(vswhere_path)
             .args([
                 "-latest",


### PR DESCRIPTION
This came up in RustConf as a desire from users/maintainers of 3rd-party build systems, such as Buck2, Bazel, and their ilk.

The idea is that they should be in full control over building all native dependencies, and currently it's (apparently) very annoying and time-consuming to ensure that no `build.rs` is compiling/assembling/linking/etc native libraries on it's own. By setting this flag, they can get an error on any crate that attempts this.

In terms of the implementation, this was more invasive than I'd like, and I'm open to suggestions about alternative ways of doing this. I failed to locate a single choke-point where returning a `Result::Err` would sufficiently neuter our functionality.

I think the approach I've taken is awkward, and would be borderline-unmaintainable were it not for `clippy::disallowed_methods`. That said, we do have access to that clippy lint, which I think pushes this over the edge.