### PR TITLE
Disable `CC_ENABLE_DEBUG_OUTPUT` if it is set to "0"

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -44,7 +44,10 @@ impl CargoOutput {
             metadata: true,
             warnings: true,
             output: OutputKind::Forward,
-            debug: std::env::var_os("CC_ENABLE_DEBUG_OUTPUT").is_some(),
+            debug: match std::env::var_os("CC_ENABLE_DEBUG_OUTPUT") {
+                Some(v) => v != "0",
+                None => false,
+            },
             checked_dbg_var: Arc::new(AtomicBool::new(false)),
         }
     }


### PR DESCRIPTION
It isn't always possible to completely unset an environment variable, but it is pretty common that a value of "0" should be treated as disabled. Use that here for `CC_ENABLE_DEBUG_OUTPUT`.