### PR TITLE
Use `rustc`'s knowledge of LLVM/Clang target triples

### DIFF
--- a/.github/workflows/regenerate-target-info.yml
+++ b/.github/workflows/regenerate-target-info.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create --base main --title "Update src/target_info.rs" --body "Automatically regenerated in CI"
+          gh pr create --base main --title "Update src/target/generated.rs" --body "Automatically regenerated in CI"

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -30,20 +30,11 @@ fn generate_target_mapping(f: &mut File, target_specs: &RustcTargetSpecs) -> std
         // FIXME(madsmtm): Should become unnecessary after
         // https://github.com/rust-lang/rust/pull/131037
         let unversioned_llvm_target = if spec.llvm_target.contains("apple") {
-            let mut components = spec.llvm_target.split("-");
-            let arch = components.next().expect("LLVM target should have arch");
-            let vendor = components.next().expect("LLVM target should have vendor");
-            let os = components.next().expect("LLVM target should have os");
-            let environment = components.next();
-            assert_eq!(components.next(), None, "too many LLVM target components");
+            let mut components = spec.llvm_target.split("-").collect::<Vec<_>>();
 
-            let os = os.trim_end_matches(|c: char| c.is_numeric() || c == '.');
+            components[2] = components[2].trim_end_matches(|c: char| c.is_numeric() || c == '.');
 
-            if let Some(env) = environment {
-                format!("{arch}-{vendor}-{os}-{env}")
-            } else {
-                format!("{arch}-{vendor}-{os}")
-            }
+            components.join("-")
         } else {
             spec.llvm_target.clone()
         };

--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -11,10 +11,10 @@ const PRELUDE: &str = r#"//! This file is generated code. Please edit the genera
 "#;
 
 fn generate_target_mapping(f: &mut File, target_specs: &RustcTargetSpecs) -> std::io::Result<()> {
-    writeln!(f, "use super::Target;")?;
+    writeln!(f, "use super::TargetInfo;")?;
     writeln!(f, "use std::borrow::Cow;")?;
     writeln!(f)?;
-    writeln!(f, "pub(crate) const LIST: &[(&str, Target)] = &[")?;
+    writeln!(f, "pub(crate) const LIST: &[(&str, TargetInfo)] = &[")?;
 
     for (triple, spec) in &target_specs.0 {
         let full_arch = triple.split_once('-').unwrap().0;
@@ -26,7 +26,7 @@ fn generate_target_mapping(f: &mut File, target_specs: &RustcTargetSpecs) -> std
 
         writeln!(f, "    (")?;
         writeln!(f, "        {triple:?},")?;
-        writeln!(f, "        Target {{")?;
+        writeln!(f, "        TargetInfo {{")?;
         writeln!(f, "            full_arch: Cow::Borrowed({full_arch:?}),")?;
         writeln!(f, "            arch: Cow::Borrowed({arch:?}),")?;
         writeln!(f, "            vendor: Cow::Borrowed({vendor:?}),")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ use shlex::Shlex;
 mod parallel;
 mod target;
 mod windows;
-use target::Target;
+use self::target::TargetInfo;
 // Regardless of whether this should be in this crate's public API,
 // it has been since 2015, so don't break it.
 pub use windows::find_tools as windows_registry;
@@ -634,7 +634,7 @@ impl Build {
         &self,
         flag: &OsStr,
         compiler_path: &Path,
-        target: &Target,
+        target: &TargetInfo,
     ) -> Result<bool, Error> {
         let compiler_flag = CompilerFlag {
             compiler: compiler_path.into(),
@@ -1932,7 +1932,7 @@ impl Build {
     fn add_default_flags(
         &self,
         cmd: &mut Tool,
-        target: &Target,
+        target: &TargetInfo,
         opt_level: &str,
     ) -> Result<(), Error> {
         let raw_target = self.get_raw_target()?;
@@ -3579,10 +3579,10 @@ impl Build {
             .or_else(|| prefixes.first().copied())
     }
 
-    fn get_target(&self) -> Result<Target, Error> {
+    fn get_target(&self) -> Result<TargetInfo, Error> {
         match &self.target {
             Some(t) => t.parse(),
-            None => Target::from_cargo_environment_variables(),
+            None => TargetInfo::from_cargo_environment_variables(),
         }
     }
 
@@ -4040,12 +4040,12 @@ impl Build {
         None
     }
 
-    fn windows_registry_find(&self, target: &Target, tool: &str) -> Option<Command> {
+    fn windows_registry_find(&self, target: &TargetInfo, tool: &str) -> Option<Command> {
         self.windows_registry_find_tool(target, tool)
             .map(|c| c.to_command())
     }
 
-    fn windows_registry_find_tool(&self, target: &Target, tool: &str) -> Option<Tool> {
+    fn windows_registry_find_tool(&self, target: &TargetInfo, tool: &str) -> Option<Tool> {
         struct BuildEnvGetter<'s>(&'s Build);
 
         impl windows_registry::EnvGetter for BuildEnvGetter<'_> {
@@ -4204,7 +4204,7 @@ fn autodetect_android_compiler(raw_target: &str, gnu: &str, clang: &str) -> Stri
 }
 
 // Rust and clang/cc don't agree on how to name the target.
-fn map_darwin_target_from_rust_to_compiler_architecture(target: &Target) -> &str {
+fn map_darwin_target_from_rust_to_compiler_architecture(target: &TargetInfo) -> &str {
     match &*target.full_arch {
         "aarch64" => "arm64",
         "arm64_32" => "arm64_32",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2083,7 +2083,7 @@ impl Build {
 
                     // Add version information to the target.
                     let llvm_target = if target.vendor == "apple" {
-                        let deployment_target = self.apple_deployment_target(&target);
+                        let deployment_target = self.apple_deployment_target(target);
                         target.versioned_llvm_target(Some(&deployment_target))
                     } else {
                         target.versioned_llvm_target(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2075,19 +2075,14 @@ impl Build {
                             .push(format!("--target={}-apple-ios-macabi", arch).into());
                     } else if target.os == "ios" && target.abi == "sim" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details = apple_os_sdk_parts("ios", &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!("--target={}-apple-ios{}-simulator", arch, deployment_target)
                                 .into(),
                         );
                     } else if target.os == "watchos" && target.abi == "sim" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details =
-                            apple_os_sdk_parts("watchos", &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!(
                                 "--target={}-apple-watchos{}-simulator",
@@ -2097,9 +2092,7 @@ impl Build {
                         );
                     } else if target.os == "tvos" && target.abi == "sim" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details = apple_os_sdk_parts("tvos", &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!(
                                 "--target={}-apple-tvos{}-simulator",
@@ -2109,18 +2102,13 @@ impl Build {
                         );
                     } else if target.os == "tvos" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details = apple_os_sdk_parts("tvos", &AppleArchSpec::Device(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!("--target={}-apple-tvos{}", arch, deployment_target).into(),
                         );
                     } else if target.os == "visionos" && target.abi == "sim" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details =
-                            apple_os_sdk_parts("visionos", &AppleArchSpec::Simulator(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!(
                                 "--target={}-apple-xros{}-simulator",
@@ -2130,10 +2118,7 @@ impl Build {
                         );
                     } else if target.os == "visionos" {
                         let arch = map_darwin_target_from_rust_to_compiler_architecture(target);
-                        let sdk_details =
-                            apple_os_sdk_parts("visionos", &AppleArchSpec::Device(""));
-                        let deployment_target =
-                            self.apple_deployment_version(target, &sdk_details.sdk);
+                        let deployment_target = self.apple_deployment_target(target);
                         cmd.args.push(
                             format!("--target={}-apple-xros{}", arch, deployment_target).into(),
                         );
@@ -2675,7 +2660,7 @@ impl Build {
         };
 
         let sdk_details = apple_os_sdk_parts(&target.os, &arch);
-        let min_version = self.apple_deployment_version(&target, &sdk_details.sdk);
+        let min_version = self.apple_deployment_target(&target);
 
         match arch {
             AppleArchSpec::Device(_) if target.os == "macos" => {
@@ -3818,7 +3803,8 @@ impl Build {
         Ok(sdk_path)
     }
 
-    fn apple_deployment_version(&self, target: &TargetInfo, sdk: &str) -> Arc<str> {
+    fn apple_deployment_target(&self, target: &TargetInfo) -> Arc<str> {
+        let sdk = target.apple_sdk_name();
         if let Some(ret) = self
             .apple_versions_cache
             .read()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1974,14 +1974,6 @@ impl Build {
                     cmd.push_opt_unless_duplicate(format!("-O{}", opt_level).into());
                 }
 
-                if cmd.is_like_clang() && target.os == "windows" {
-                    // Disambiguate mingw and msvc on Windows. Problem is that
-                    // depending on the origin clang can default to a mismatchig
-                    // run-time.
-                    let llvm_target = target.versioned_llvm_target(None);
-                    cmd.push_cc_arg(format!("--target={llvm_target}").into());
-                }
-
                 if cmd.is_like_clang() && target.os == "android" {
                     // For compatibility with code that doesn't use pre-defined `__ANDROID__` macro.
                     // If compiler used via ndk-build or cmake (officially supported build methods)
@@ -2097,6 +2089,8 @@ impl Build {
                         target.versioned_llvm_target(None)
                     };
 
+                    // Pass `--target` with the LLVM target to properly
+                    // configure Clang even when cross-compiling.
                     cmd.args.push(format!("--target={llvm_target}").into());
                 }
             }

--- a/src/target.rs
+++ b/src/target.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, env, str::FromStr};
 
 use crate::{Error, ErrorKind};
 
+mod apple;
 mod generated;
 mod llvm;
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -12,7 +12,7 @@ mod generated;
 ///
 /// See <https://doc.rust-lang.org/cargo/appendix/glossary.html#target>.
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct Target {
+pub(crate) struct TargetInfo {
     /// The full architecture, including the subarchitecture.
     ///
     /// This differs from `cfg!(target_arch)`, which only specifies the
@@ -40,7 +40,7 @@ pub(crate) struct Target {
     pub abi: Cow<'static, str>,
 }
 
-impl Target {
+impl TargetInfo {
     pub fn from_cargo_environment_variables() -> Result<Self, Error> {
         // `TARGET` must be present.
         //
@@ -90,7 +90,7 @@ impl Target {
         // back back to data from the known set of target triples instead.
         //
         // See discussion in #1225 for further details.
-        let fallback_target = Target::from_str(&target_triple).ok();
+        let fallback_target = TargetInfo::from_str(&target_triple).ok();
         let ft = fallback_target.as_ref();
         let arch = cargo_env("CARGO_CFG_TARGET_ARCH", ft.map(|t| t.arch.clone()))?;
         let vendor = cargo_env("CARGO_CFG_TARGET_VENDOR", ft.map(|t| t.vendor.clone()))?;
@@ -113,7 +113,7 @@ impl Target {
     }
 }
 
-impl FromStr for Target {
+impl FromStr for TargetInfo {
     type Err = Error;
 
     /// This will fail when using a custom target triple unknown to `rustc`.
@@ -121,8 +121,8 @@ impl FromStr for Target {
         if let Ok(index) =
             generated::LIST.binary_search_by_key(&target_triple, |(target_triple, _)| target_triple)
         {
-            let (_, target) = &generated::LIST[index];
-            Ok(target.clone())
+            let (_, info) = &generated::LIST[index];
+            Ok(info.clone())
         } else {
             Err(Error::new(
                 ErrorKind::InvalidTarget,
@@ -136,7 +136,7 @@ impl FromStr for Target {
 mod tests {
     use std::str::FromStr;
 
-    use super::Target;
+    use super::TargetInfo;
 
     // Test tier 1 targets
     #[test]
@@ -155,7 +155,7 @@ mod tests {
 
         for target in targets {
             // Check that it parses
-            let _ = Target::from_str(target).unwrap();
+            let _ = TargetInfo::from_str(target).unwrap();
         }
     }
 
@@ -177,7 +177,7 @@ mod tests {
 
         for target in targets {
             // Check that it does not parse
-            let _ = Target::from_str(target).unwrap_err();
+            let _ = TargetInfo::from_str(target).unwrap_err();
         }
     }
 }

--- a/src/target/apple.rs
+++ b/src/target/apple.rs
@@ -1,0 +1,19 @@
+use super::TargetInfo;
+
+impl TargetInfo {
+    pub(crate) fn apple_sdk_name(&self) -> &'static str {
+        match (&*self.os, &*self.abi) {
+            ("macos", "") => "macosx",
+            ("ios", "") => "iphoneos",
+            ("ios", "sim") => "iphonesimulator",
+            ("ios", "macabi") => "macosx",
+            ("tvos", "") => "appletvos",
+            ("tvos", "sim") => "appletvsimulator",
+            ("watchos", "") => "watchos",
+            ("watchos", "sim") => "watchsimulator",
+            ("visionos", "") => "xros",
+            ("visionos", "sim") => "xrsimulator",
+            (os, _) => panic!("invalid Apple target OS {}", os),
+        }
+    }
+}

--- a/src/target/generated.rs
+++ b/src/target/generated.rs
@@ -1,13 +1,13 @@
 //! This file is generated code. Please edit the generator
 //! in dev-tools/gen-target-info if you need to make changes.
 
-use super::Target;
+use super::TargetInfo;
 use std::borrow::Cow;
 
-pub(crate) const LIST: &[(&str, Target)] = &[
+pub(crate) const LIST: &[(&str, TargetInfo)] = &[
     (
         "aarch64-apple-darwin",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -18,7 +18,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -29,7 +29,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-ios-macabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -40,7 +40,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-ios-sim",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -51,7 +51,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-tvos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -62,7 +62,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-tvos-sim",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -73,7 +73,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-visionos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -84,7 +84,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-visionos-sim",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -95,7 +95,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-watchos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -106,7 +106,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-apple-watchos-sim",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -117,7 +117,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-fuchsia",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -128,7 +128,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-kmc-solid_asp3",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("kmc"),
@@ -139,7 +139,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-linux-android",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -150,7 +150,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-nintendo-switch-freestanding",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("nintendo"),
@@ -161,7 +161,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-pc-windows-gnullvm",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("pc"),
@@ -172,7 +172,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("pc"),
@@ -183,7 +183,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -194,7 +194,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-fuchsia",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -205,7 +205,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-hermit",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -216,7 +216,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-illumos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -227,7 +227,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -238,7 +238,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-linux-gnu_ilp32",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -249,7 +249,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -260,7 +260,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-linux-ohos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -271,7 +271,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -282,7 +282,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -293,7 +293,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-none-softfloat",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -304,7 +304,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-nto-qnx700",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -315,7 +315,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-nto-qnx710",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -326,7 +326,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -337,7 +337,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-redox",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -348,7 +348,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-teeos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -359,7 +359,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-trusty",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -370,7 +370,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-unknown-uefi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -381,7 +381,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-uwp-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("uwp"),
@@ -392,7 +392,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("wrs"),
@@ -403,7 +403,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64_be-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64_be"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -414,7 +414,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64_be-unknown-linux-gnu_ilp32",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64_be"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -425,7 +425,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "aarch64_be-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("aarch64_be"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -436,7 +436,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm-linux-androideabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -447,7 +447,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm-unknown-linux-gnueabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -458,7 +458,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm-unknown-linux-gnueabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -469,7 +469,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm-unknown-linux-musleabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -480,7 +480,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm-unknown-linux-musleabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -491,7 +491,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm64_32-apple-watchos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm64_32"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -502,7 +502,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm64e-apple-darwin",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm64e"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -513,7 +513,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm64e-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm64e"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -524,7 +524,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm64e-apple-tvos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm64e"),
             arch: Cow::Borrowed("aarch64"),
             vendor: Cow::Borrowed("apple"),
@@ -535,7 +535,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "arm64ec-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("arm64ec"),
             arch: Cow::Borrowed("arm64ec"),
             vendor: Cow::Borrowed("pc"),
@@ -546,7 +546,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armeb-unknown-linux-gnueabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armeb"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -557,7 +557,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armebv7r-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armebv7r"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -568,7 +568,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armebv7r-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armebv7r"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -579,7 +579,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv4t-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv4t"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -590,7 +590,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv4t-unknown-linux-gnueabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv4t"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -601,7 +601,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv5te-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv5te"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -612,7 +612,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv5te-unknown-linux-gnueabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv5te"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -623,7 +623,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv5te-unknown-linux-musleabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv5te"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -634,7 +634,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv5te-unknown-linux-uclibceabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv5te"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -645,7 +645,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv6-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv6"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -656,7 +656,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv6-unknown-netbsd-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv6"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -667,7 +667,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv6k-nintendo-3ds",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv6k"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("nintendo"),
@@ -678,7 +678,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("apple"),
@@ -689,7 +689,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-linux-androideabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -700,7 +700,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-rtems-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -711,7 +711,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-sony-vita-newlibeabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("sony"),
@@ -722,7 +722,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -733,7 +733,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-gnueabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -744,7 +744,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-gnueabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -755,7 +755,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-musleabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -766,7 +766,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-musleabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -777,7 +777,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-ohos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -788,7 +788,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-uclibceabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -799,7 +799,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-linux-uclibceabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -810,7 +810,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-netbsd-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -821,7 +821,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-unknown-trusty",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -832,7 +832,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7-wrs-vxworks-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("wrs"),
@@ -843,7 +843,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7a-kmc-solid_asp3-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("kmc"),
@@ -854,7 +854,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7a-kmc-solid_asp3-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("kmc"),
@@ -865,7 +865,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7a-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -876,7 +876,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7a-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -887,7 +887,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7k-apple-watchos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7k"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("apple"),
@@ -898,7 +898,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7r-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7r"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -909,7 +909,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7r-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7r"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -920,7 +920,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv7s-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv7s"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("apple"),
@@ -931,7 +931,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "armv8r-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("armv8r"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -942,7 +942,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "asmjs-unknown-emscripten",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("asmjs"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -953,7 +953,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "avr-unknown-gnu-atmega328",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("avr"),
             arch: Cow::Borrowed("avr"),
             vendor: Cow::Borrowed("unknown"),
@@ -964,7 +964,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "bpfeb-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("bpfeb"),
             arch: Cow::Borrowed("bpf"),
             vendor: Cow::Borrowed("unknown"),
@@ -975,7 +975,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "bpfel-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("bpfel"),
             arch: Cow::Borrowed("bpf"),
             vendor: Cow::Borrowed("unknown"),
@@ -986,7 +986,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "csky-unknown-linux-gnuabiv2",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("csky"),
             arch: Cow::Borrowed("csky"),
             vendor: Cow::Borrowed("unknown"),
@@ -997,7 +997,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "csky-unknown-linux-gnuabiv2hf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("csky"),
             arch: Cow::Borrowed("csky"),
             vendor: Cow::Borrowed("unknown"),
@@ -1008,7 +1008,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "hexagon-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("hexagon"),
             arch: Cow::Borrowed("hexagon"),
             vendor: Cow::Borrowed("unknown"),
@@ -1019,7 +1019,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "hexagon-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("hexagon"),
             arch: Cow::Borrowed("hexagon"),
             vendor: Cow::Borrowed("unknown"),
@@ -1030,7 +1030,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i386-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i386"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("apple"),
@@ -1041,7 +1041,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i586-pc-nto-qnx700",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i586"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("pc"),
@@ -1052,7 +1052,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i586-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i586"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("pc"),
@@ -1063,7 +1063,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i586-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i586"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1074,7 +1074,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i586-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i586"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1085,7 +1085,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i586-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i586"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1096,7 +1096,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-apple-darwin",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("apple"),
@@ -1107,7 +1107,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-linux-android",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1118,7 +1118,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-pc-windows-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("pc"),
@@ -1129,7 +1129,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-pc-windows-gnullvm",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("pc"),
@@ -1140,7 +1140,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("pc"),
@@ -1151,7 +1151,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1162,7 +1162,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-haiku",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1173,7 +1173,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-hurd-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1184,7 +1184,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1195,7 +1195,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1206,7 +1206,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1217,7 +1217,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1228,7 +1228,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-redox",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1239,7 +1239,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-unknown-uefi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("unknown"),
@@ -1250,7 +1250,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-uwp-windows-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("uwp"),
@@ -1261,7 +1261,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-uwp-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("uwp"),
@@ -1272,7 +1272,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-win7-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("win7"),
@@ -1283,7 +1283,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "i686-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("i686"),
             arch: Cow::Borrowed("x86"),
             vendor: Cow::Borrowed("wrs"),
@@ -1294,7 +1294,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "loongarch64-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("loongarch64"),
             arch: Cow::Borrowed("loongarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1305,7 +1305,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "loongarch64-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("loongarch64"),
             arch: Cow::Borrowed("loongarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1316,7 +1316,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "loongarch64-unknown-linux-ohos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("loongarch64"),
             arch: Cow::Borrowed("loongarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1327,7 +1327,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "loongarch64-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("loongarch64"),
             arch: Cow::Borrowed("loongarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1338,7 +1338,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "loongarch64-unknown-none-softfloat",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("loongarch64"),
             arch: Cow::Borrowed("loongarch64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1349,7 +1349,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "m68k-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("m68k"),
             arch: Cow::Borrowed("m68k"),
             vendor: Cow::Borrowed("unknown"),
@@ -1360,7 +1360,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1371,7 +1371,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1382,7 +1382,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips-unknown-linux-uclibc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1393,7 +1393,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips64-openwrt-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips64"),
             arch: Cow::Borrowed("mips64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1404,7 +1404,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips64-unknown-linux-gnuabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips64"),
             arch: Cow::Borrowed("mips64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1415,7 +1415,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips64-unknown-linux-muslabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips64"),
             arch: Cow::Borrowed("mips64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1426,7 +1426,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips64el-unknown-linux-gnuabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips64el"),
             arch: Cow::Borrowed("mips64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1437,7 +1437,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mips64el-unknown-linux-muslabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mips64el"),
             arch: Cow::Borrowed("mips64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1448,7 +1448,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-sony-psp",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("sony"),
@@ -1459,7 +1459,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-sony-psx",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("sony"),
@@ -1470,7 +1470,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1481,7 +1481,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1492,7 +1492,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-unknown-linux-uclibc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1503,7 +1503,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1514,7 +1514,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsel-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsel"),
             arch: Cow::Borrowed("mips"),
             vendor: Cow::Borrowed("unknown"),
@@ -1525,7 +1525,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsisa32r6-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsisa32r6"),
             arch: Cow::Borrowed("mips32r6"),
             vendor: Cow::Borrowed("unknown"),
@@ -1536,7 +1536,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsisa32r6el-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsisa32r6el"),
             arch: Cow::Borrowed("mips32r6"),
             vendor: Cow::Borrowed("unknown"),
@@ -1547,7 +1547,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsisa64r6-unknown-linux-gnuabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsisa64r6"),
             arch: Cow::Borrowed("mips64r6"),
             vendor: Cow::Borrowed("unknown"),
@@ -1558,7 +1558,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "mipsisa64r6el-unknown-linux-gnuabi64",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("mipsisa64r6el"),
             arch: Cow::Borrowed("mips64r6"),
             vendor: Cow::Borrowed("unknown"),
@@ -1569,7 +1569,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "msp430-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("msp430"),
             arch: Cow::Borrowed("msp430"),
             vendor: Cow::Borrowed("unknown"),
@@ -1580,7 +1580,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "nvptx64-nvidia-cuda",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("nvptx64"),
             arch: Cow::Borrowed("nvptx64"),
             vendor: Cow::Borrowed("nvidia"),
@@ -1591,7 +1591,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1602,7 +1602,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1613,7 +1613,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-linux-gnuspe",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1624,7 +1624,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1635,7 +1635,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-linux-muslspe",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1646,7 +1646,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1657,7 +1657,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("unknown"),
@@ -1668,7 +1668,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("wrs"),
@@ -1679,7 +1679,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc-wrs-vxworks-spe",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc"),
             arch: Cow::Borrowed("powerpc"),
             vendor: Cow::Borrowed("wrs"),
@@ -1690,7 +1690,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-ibm-aix",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("ibm"),
@@ -1701,7 +1701,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1712,7 +1712,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1723,7 +1723,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1734,7 +1734,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1745,7 +1745,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("wrs"),
@@ -1756,7 +1756,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64le-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64le"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1767,7 +1767,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64le-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64le"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1778,7 +1778,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "powerpc64le-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("powerpc64le"),
             arch: Cow::Borrowed("powerpc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -1789,7 +1789,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("wrs"),
@@ -1800,7 +1800,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32e-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32e"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1811,7 +1811,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32em-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32em"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1822,7 +1822,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32emc-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32emc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1833,7 +1833,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32gc-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32gc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1844,7 +1844,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32gc-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32gc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1855,7 +1855,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32i-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32i"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1866,7 +1866,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32im-risc0-zkvm-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32im"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("risc0"),
@@ -1877,7 +1877,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32im-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32im"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1888,7 +1888,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32ima-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32ima"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1899,7 +1899,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imac-esp-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imac"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("espressif"),
@@ -1910,7 +1910,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imac-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imac"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1921,7 +1921,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imac-unknown-nuttx-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imac"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1932,7 +1932,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imac-unknown-xous-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imac"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1943,7 +1943,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imafc-esp-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imafc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("espressif"),
@@ -1954,7 +1954,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imafc-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imafc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1965,7 +1965,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imafc-unknown-nuttx-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imafc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1976,7 +1976,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imc-esp-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("espressif"),
@@ -1987,7 +1987,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imc-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -1998,7 +1998,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv32imc-unknown-nuttx-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv32imc"),
             arch: Cow::Borrowed("riscv32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2009,7 +2009,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64-linux-android",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2020,7 +2020,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("wrs"),
@@ -2031,7 +2031,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2042,7 +2042,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-fuchsia",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2053,7 +2053,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-hermit",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2064,7 +2064,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2075,7 +2075,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2086,7 +2086,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2097,7 +2097,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2108,7 +2108,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-nuttx-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2119,7 +2119,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64gc-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64gc"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2130,7 +2130,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64imac-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64imac"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2141,7 +2141,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "riscv64imac-unknown-nuttx-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("riscv64imac"),
             arch: Cow::Borrowed("riscv64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2152,7 +2152,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "s390x-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("s390x"),
             arch: Cow::Borrowed("s390x"),
             vendor: Cow::Borrowed("unknown"),
@@ -2163,7 +2163,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "s390x-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("s390x"),
             arch: Cow::Borrowed("s390x"),
             vendor: Cow::Borrowed("unknown"),
@@ -2174,7 +2174,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparc-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparc"),
             arch: Cow::Borrowed("sparc"),
             vendor: Cow::Borrowed("unknown"),
@@ -2185,7 +2185,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparc-unknown-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparc"),
             arch: Cow::Borrowed("sparc"),
             vendor: Cow::Borrowed("unknown"),
@@ -2196,7 +2196,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparc64-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparc64"),
             arch: Cow::Borrowed("sparc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2207,7 +2207,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparc64-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparc64"),
             arch: Cow::Borrowed("sparc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2218,7 +2218,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparc64-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparc64"),
             arch: Cow::Borrowed("sparc64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2229,7 +2229,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "sparcv9-sun-solaris",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("sparcv9"),
             arch: Cow::Borrowed("sparc64"),
             vendor: Cow::Borrowed("sun"),
@@ -2240,7 +2240,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv4t-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv4t"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2251,7 +2251,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv5te-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv5te"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2262,7 +2262,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv6m-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv6m"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2273,7 +2273,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv6m-nuttx-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv6m"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2284,7 +2284,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7a-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("pc"),
@@ -2295,7 +2295,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7a-uwp-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7a"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("uwp"),
@@ -2306,7 +2306,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7em-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7em"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2317,7 +2317,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7em-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7em"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2328,7 +2328,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7em-nuttx-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7em"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2339,7 +2339,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7em-nuttx-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7em"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2350,7 +2350,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7m-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7m"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2361,7 +2361,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7m-nuttx-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7m"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2372,7 +2372,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7neon-linux-androideabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7neon"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2383,7 +2383,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7neon-unknown-linux-gnueabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7neon"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2394,7 +2394,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv7neon-unknown-linux-musleabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv7neon"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2405,7 +2405,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.base-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.base"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2416,7 +2416,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.base-nuttx-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.base"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2427,7 +2427,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.main-none-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.main"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2438,7 +2438,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.main-none-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.main"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2449,7 +2449,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.main-nuttx-eabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.main"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2460,7 +2460,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "thumbv8m.main-nuttx-eabihf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("thumbv8m.main"),
             arch: Cow::Borrowed("arm"),
             vendor: Cow::Borrowed("unknown"),
@@ -2471,7 +2471,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-unknown-emscripten",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2482,7 +2482,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-unknown-unknown",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2493,7 +2493,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-wasi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2504,7 +2504,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-wasip1",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2515,7 +2515,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-wasip1-threads",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2526,7 +2526,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32-wasip2",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2537,7 +2537,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm32v1-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm32v1"),
             arch: Cow::Borrowed("wasm32"),
             vendor: Cow::Borrowed("unknown"),
@@ -2548,7 +2548,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "wasm64-unknown-unknown",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("wasm64"),
             arch: Cow::Borrowed("wasm64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2559,7 +2559,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-apple-darwin",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2570,7 +2570,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-apple-ios",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2581,7 +2581,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-apple-ios-macabi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2592,7 +2592,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-apple-tvos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2603,7 +2603,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-apple-watchos-sim",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2614,7 +2614,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-fortanix-unknown-sgx",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("fortanix"),
@@ -2625,7 +2625,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-fuchsia",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2636,7 +2636,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-linux-android",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2647,7 +2647,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-pc-nto-qnx710",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("pc"),
@@ -2658,7 +2658,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-pc-solaris",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("pc"),
@@ -2669,7 +2669,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-pc-windows-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("pc"),
@@ -2680,7 +2680,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-pc-windows-gnullvm",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("pc"),
@@ -2691,7 +2691,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-pc-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("pc"),
@@ -2702,7 +2702,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-sun-solaris",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("sun"),
@@ -2713,7 +2713,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unikraft-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unikraft"),
@@ -2724,7 +2724,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-dragonfly",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2735,7 +2735,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-freebsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2746,7 +2746,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-fuchsia",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2757,7 +2757,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-haiku",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2768,7 +2768,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-hermit",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2779,7 +2779,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-hurd-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2790,7 +2790,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-illumos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2801,7 +2801,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-l4re-uclibc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2812,7 +2812,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-linux-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2823,7 +2823,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-linux-gnux32",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2834,7 +2834,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-linux-musl",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2845,7 +2845,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-linux-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2856,7 +2856,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-linux-ohos",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2867,7 +2867,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-netbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2878,7 +2878,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-none",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2889,7 +2889,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-none-linuxkernel",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2900,7 +2900,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-openbsd",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2911,7 +2911,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-redox",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2922,7 +2922,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-trusty",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2933,7 +2933,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-unknown-uefi",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("unknown"),
@@ -2944,7 +2944,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-uwp-windows-gnu",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("uwp"),
@@ -2955,7 +2955,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-uwp-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("uwp"),
@@ -2966,7 +2966,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-win7-windows-msvc",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("win7"),
@@ -2977,7 +2977,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64-wrs-vxworks",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("wrs"),
@@ -2988,7 +2988,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "x86_64h-apple-darwin",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("x86_64h"),
             arch: Cow::Borrowed("x86_64"),
             vendor: Cow::Borrowed("apple"),
@@ -2999,7 +2999,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),
@@ -3010,7 +3010,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),
@@ -3021,7 +3021,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32s2-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),
@@ -3032,7 +3032,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32s2-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),
@@ -3043,7 +3043,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32s3-espidf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),
@@ -3054,7 +3054,7 @@ pub(crate) const LIST: &[(&str, Target)] = &[
     ),
     (
         "xtensa-esp32s3-none-elf",
-        Target {
+        TargetInfo {
             full_arch: Cow::Borrowed("xtensa"),
             arch: Cow::Borrowed("xtensa"),
             vendor: Cow::Borrowed("espressif"),

--- a/src/target/generated.rs
+++ b/src/target/generated.rs
@@ -14,6 +14,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("macos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-macosx"),
         },
     ),
     (
@@ -25,6 +26,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-ios"),
         },
     ),
     (
@@ -36,6 +38,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("macabi"),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-ios-macabi"),
         },
     ),
     (
@@ -47,6 +50,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-ios-simulator"),
         },
     ),
     (
@@ -58,6 +62,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("tvos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-tvos"),
         },
     ),
     (
@@ -69,6 +74,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("tvos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-tvos-simulator"),
         },
     ),
     (
@@ -80,6 +86,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("visionos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-xros"),
         },
     ),
     (
@@ -91,6 +98,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("visionos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-xros-simulator"),
         },
     ),
     (
@@ -102,6 +110,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("watchos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-watchos"),
         },
     ),
     (
@@ -113,6 +122,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("watchos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("arm64-apple-watchos-simulator"),
         },
     ),
     (
@@ -124,6 +134,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("fuchsia"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-fuchsia"),
         },
     ),
     (
@@ -135,6 +146,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solid_asp3"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-none"),
         },
     ),
     (
@@ -146,6 +158,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-linux-android"),
         },
     ),
     (
@@ -157,6 +170,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("horizon"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-none"),
         },
     ),
     (
@@ -168,6 +182,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("llvm"),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-pc-windows-gnu"),
         },
     ),
     (
@@ -179,6 +194,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-pc-windows-msvc"),
         },
     ),
     (
@@ -190,6 +206,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-freebsd"),
         },
     ),
     (
@@ -201,6 +218,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("fuchsia"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-fuchsia"),
         },
     ),
     (
@@ -212,6 +230,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("hermit"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-hermit"),
         },
     ),
     (
@@ -223,6 +242,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("illumos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-solaris2.11"),
         },
     ),
     (
@@ -234,6 +254,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-linux-gnu"),
         },
     ),
     (
@@ -245,6 +266,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("ilp32"),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-linux-gnu_ilp32"),
         },
     ),
     (
@@ -256,6 +278,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-linux-musl"),
         },
     ),
     (
@@ -267,6 +290,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("ohos"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-linux-ohos"),
         },
     ),
     (
@@ -278,6 +302,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-netbsd"),
         },
     ),
     (
@@ -289,6 +314,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-none"),
         },
     ),
     (
@@ -300,6 +326,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("softfloat"),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-none"),
         },
     ),
     (
@@ -311,6 +338,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nto"),
             env: Cow::Borrowed("nto70"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-unknown"),
         },
     ),
     (
@@ -322,6 +350,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nto"),
             env: Cow::Borrowed("nto71"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-unknown"),
         },
     ),
     (
@@ -333,6 +362,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-openbsd"),
         },
     ),
     (
@@ -344,6 +374,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("redox"),
             env: Cow::Borrowed("relibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-redox"),
         },
     ),
     (
@@ -355,6 +386,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("teeos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-none"),
         },
     ),
     (
@@ -366,6 +398,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("trusty"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-unknown-musl"),
         },
     ),
     (
@@ -377,6 +410,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("uefi"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-windows"),
         },
     ),
     (
@@ -388,6 +422,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-pc-windows-msvc"),
         },
     ),
     (
@@ -399,6 +434,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64-unknown-linux-gnu"),
         },
     ),
     (
@@ -410,6 +446,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64_be-unknown-linux-gnu"),
         },
     ),
     (
@@ -421,6 +458,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("ilp32"),
+            unversioned_llvm_target: Cow::Borrowed("aarch64_be-unknown-linux-gnu_ilp32"),
         },
     ),
     (
@@ -432,6 +470,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("aarch64_be-unknown-netbsd"),
         },
     ),
     (
@@ -443,6 +482,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("arm-linux-androideabi"),
         },
     ),
     (
@@ -454,6 +494,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("arm-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -465,6 +506,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("arm-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -476,6 +518,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("arm-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -487,6 +530,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("arm-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -498,6 +542,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("watchos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64_32-apple-watchos"),
         },
     ),
     (
@@ -509,6 +554,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("macos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64e-apple-macosx"),
         },
     ),
     (
@@ -520,6 +566,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64e-apple-ios"),
         },
     ),
     (
@@ -531,6 +578,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("tvos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64e-apple-tvos"),
         },
     ),
     (
@@ -542,6 +590,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("arm64ec-pc-windows-msvc"),
         },
     ),
     (
@@ -553,6 +602,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armeb-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -564,6 +614,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armebv7r-none-eabi"),
         },
     ),
     (
@@ -575,6 +626,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armebv7r-none-eabihf"),
         },
     ),
     (
@@ -586,6 +638,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv4t-none-eabi"),
         },
     ),
     (
@@ -597,6 +650,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv4t-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -608,6 +662,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv5te-none-eabi"),
         },
     ),
     (
@@ -619,6 +674,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv5te-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -630,6 +686,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv5te-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -641,6 +698,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv5te-unknown-linux-uclibcgnueabi"),
         },
     ),
     (
@@ -652,6 +710,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv6-unknown-freebsd-gnueabihf"),
         },
     ),
     (
@@ -663,6 +722,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv6-unknown-netbsdelf-eabihf"),
         },
     ),
     (
@@ -674,6 +734,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("horizon"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv6k-none-eabihf"),
         },
     ),
     (
@@ -685,6 +746,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("armv7-apple-ios"),
         },
     ),
     (
@@ -696,6 +758,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-none-linux-android"),
         },
     ),
     (
@@ -707,6 +770,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("rtems"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-none-eabihf"),
         },
     ),
     (
@@ -718,6 +782,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vita"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7a-vita-eabihf"),
         },
     ),
     (
@@ -729,6 +794,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-freebsd-gnueabihf"),
         },
     ),
     (
@@ -740,6 +806,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -751,6 +818,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -762,6 +830,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -773,6 +842,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -784,6 +854,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("ohos"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-ohos"),
         },
     ),
     (
@@ -795,6 +866,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabi"),
         },
     ),
     (
@@ -806,6 +878,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -817,6 +890,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-netbsdelf-eabihf"),
         },
     ),
     (
@@ -828,6 +902,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("trusty"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-unknown-gnueabi"),
         },
     ),
     (
@@ -839,6 +914,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -850,6 +926,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solid_asp3"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7a-none-eabi"),
         },
     ),
     (
@@ -861,6 +938,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solid_asp3"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7a-none-eabihf"),
         },
     ),
     (
@@ -872,6 +950,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7a-none-eabi"),
         },
     ),
     (
@@ -883,6 +962,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7a-none-eabihf"),
         },
     ),
     (
@@ -894,6 +974,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("watchos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("armv7k-apple-watchos"),
         },
     ),
     (
@@ -905,6 +986,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7r-none-eabi"),
         },
     ),
     (
@@ -916,6 +998,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7r-none-eabihf"),
         },
     ),
     (
@@ -927,6 +1010,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("armv7s-apple-ios"),
         },
     ),
     (
@@ -938,6 +1022,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv8r-none-eabihf"),
         },
     ),
     (
@@ -949,6 +1034,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("emscripten"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-unknown-emscripten"),
         },
     ),
     (
@@ -960,6 +1046,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("avr-unknown-unknown"),
         },
     ),
     (
@@ -971,6 +1058,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("bpfeb"),
         },
     ),
     (
@@ -982,6 +1070,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("bpfel"),
         },
     ),
     (
@@ -993,6 +1082,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abiv2"),
+            unversioned_llvm_target: Cow::Borrowed("csky-unknown-linux-gnuabiv2"),
         },
     ),
     (
@@ -1004,6 +1094,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abiv2hf"),
+            unversioned_llvm_target: Cow::Borrowed("csky-unknown-linux-gnuabiv2"),
         },
     ),
     (
@@ -1015,6 +1106,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("hexagon-unknown-linux-musl"),
         },
     ),
     (
@@ -1026,6 +1118,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("hexagon-unknown-none-elf"),
         },
     ),
     (
@@ -1037,6 +1130,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("i386-apple-ios-simulator"),
         },
     ),
     (
@@ -1048,6 +1142,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nto"),
             env: Cow::Borrowed("nto70"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i586-pc-unknown"),
         },
     ),
     (
@@ -1059,6 +1154,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i586-pc-windows-msvc"),
         },
     ),
     (
@@ -1070,6 +1166,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i586-unknown-linux-gnu"),
         },
     ),
     (
@@ -1081,6 +1178,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i586-unknown-linux-musl"),
         },
     ),
     (
@@ -1092,6 +1190,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i586-unknown-netbsdelf"),
         },
     ),
     (
@@ -1103,6 +1202,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("macos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-apple-macosx"),
         },
     ),
     (
@@ -1114,6 +1214,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-linux-android"),
         },
     ),
     (
@@ -1125,6 +1226,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-gnu"),
         },
     ),
     (
@@ -1136,6 +1238,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("llvm"),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-gnu"),
         },
     ),
     (
@@ -1147,6 +1250,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-msvc"),
         },
     ),
     (
@@ -1158,6 +1262,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-freebsd"),
         },
     ),
     (
@@ -1169,6 +1274,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("haiku"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-haiku"),
         },
     ),
     (
@@ -1180,6 +1286,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("hurd"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-hurd-gnu"),
         },
     ),
     (
@@ -1191,6 +1298,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-linux-gnu"),
         },
     ),
     (
@@ -1202,6 +1310,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-linux-musl"),
         },
     ),
     (
@@ -1213,6 +1322,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-netbsdelf"),
         },
     ),
     (
@@ -1224,6 +1334,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-openbsd"),
         },
     ),
     (
@@ -1235,6 +1346,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("redox"),
             env: Cow::Borrowed("relibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-redox"),
         },
     ),
     (
@@ -1246,6 +1358,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("uefi"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-windows-gnu"),
         },
     ),
     (
@@ -1257,6 +1370,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-gnu"),
         },
     ),
     (
@@ -1268,6 +1382,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-msvc"),
         },
     ),
     (
@@ -1279,6 +1394,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-pc-windows-msvc"),
         },
     ),
     (
@@ -1290,6 +1406,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("i686-unknown-linux-gnu"),
         },
     ),
     (
@@ -1301,6 +1418,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("loongarch64-unknown-linux-gnu"),
         },
     ),
     (
@@ -1312,6 +1430,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("loongarch64-unknown-linux-musl"),
         },
     ),
     (
@@ -1323,6 +1442,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("ohos"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("loongarch64-unknown-linux-ohos"),
         },
     ),
     (
@@ -1334,6 +1454,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("loongarch64-unknown-none"),
         },
     ),
     (
@@ -1345,6 +1466,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("softfloat"),
+            unversioned_llvm_target: Cow::Borrowed("loongarch64-unknown-none"),
         },
     ),
     (
@@ -1356,6 +1478,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("m68k-unknown-linux-gnu"),
         },
     ),
     (
@@ -1367,6 +1490,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mips-unknown-linux-gnu"),
         },
     ),
     (
@@ -1378,6 +1502,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mips-unknown-linux-musl"),
         },
     ),
     (
@@ -1389,6 +1514,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mips-unknown-linux-uclibc"),
         },
     ),
     (
@@ -1400,6 +1526,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mips64-unknown-linux-musl"),
         },
     ),
     (
@@ -1411,6 +1538,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mips64-unknown-linux-gnuabi64"),
         },
     ),
     (
@@ -1422,6 +1550,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mips64-unknown-linux-musl"),
         },
     ),
     (
@@ -1433,6 +1562,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mips64el-unknown-linux-gnuabi64"),
         },
     ),
     (
@@ -1444,6 +1574,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mips64el-unknown-linux-musl"),
         },
     ),
     (
@@ -1455,6 +1586,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("psp"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-sony-psp"),
         },
     ),
     (
@@ -1466,6 +1598,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed("psx"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-sony-psx"),
         },
     ),
     (
@@ -1477,6 +1610,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-unknown-linux-gnu"),
         },
     ),
     (
@@ -1488,6 +1622,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-unknown-linux-musl"),
         },
     ),
     (
@@ -1499,6 +1634,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-unknown-linux-uclibc"),
         },
     ),
     (
@@ -1510,6 +1646,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-unknown-netbsd"),
         },
     ),
     (
@@ -1521,6 +1658,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsel-unknown-none"),
         },
     ),
     (
@@ -1532,6 +1670,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsisa32r6-unknown-linux-gnu"),
         },
     ),
     (
@@ -1543,6 +1682,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("mipsisa32r6el-unknown-linux-gnu"),
         },
     ),
     (
@@ -1554,6 +1694,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mipsisa64r6-unknown-linux-gnuabi64"),
         },
     ),
     (
@@ -1565,6 +1706,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("abi64"),
+            unversioned_llvm_target: Cow::Borrowed("mipsisa64r6el-unknown-linux-gnuabi64"),
         },
     ),
     (
@@ -1576,6 +1718,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("msp430-none-elf"),
         },
     ),
     (
@@ -1587,6 +1730,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("cuda"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("nvptx64-nvidia-cuda"),
         },
     ),
     (
@@ -1598,6 +1742,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-freebsd13.0"),
         },
     ),
     (
@@ -1609,6 +1754,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-gnu"),
         },
     ),
     (
@@ -1620,6 +1766,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("spe"),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-gnuspe"),
         },
     ),
     (
@@ -1631,6 +1778,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-musl"),
         },
     ),
     (
@@ -1642,6 +1790,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("spe"),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-muslspe"),
         },
     ),
     (
@@ -1653,6 +1802,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-netbsd"),
         },
     ),
     (
@@ -1664,6 +1814,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-openbsd"),
         },
     ),
     (
@@ -1675,6 +1826,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-gnu"),
         },
     ),
     (
@@ -1686,6 +1838,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("spe"),
+            unversioned_llvm_target: Cow::Borrowed("powerpc-unknown-linux-gnuspe"),
         },
     ),
     (
@@ -1697,6 +1850,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("aix"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("vec-extabi"),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-ibm-aix"),
         },
     ),
     (
@@ -1708,6 +1862,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-unknown-freebsd"),
         },
     ),
     (
@@ -1719,6 +1874,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-unknown-linux-gnu"),
         },
     ),
     (
@@ -1730,6 +1886,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-unknown-linux-musl"),
         },
     ),
     (
@@ -1741,6 +1898,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-unknown-openbsd"),
         },
     ),
     (
@@ -1752,6 +1910,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64-unknown-linux-gnu"),
         },
     ),
     (
@@ -1763,6 +1922,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64le-unknown-freebsd"),
         },
     ),
     (
@@ -1774,6 +1934,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64le-unknown-linux-gnu"),
         },
     ),
     (
@@ -1785,6 +1946,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("powerpc64le-unknown-linux-musl"),
         },
     ),
     (
@@ -1796,6 +1958,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1807,6 +1970,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1818,6 +1982,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1829,6 +1994,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1840,6 +2006,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32-unknown-linux-gnu"),
         },
     ),
     (
@@ -1851,6 +2018,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32-unknown-linux-musl"),
         },
     ),
     (
@@ -1862,6 +2030,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1873,6 +2042,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("zkvm"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1884,6 +2054,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1895,6 +2066,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1906,6 +2078,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1917,6 +2090,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1928,6 +2102,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1939,6 +2114,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("xous"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1950,6 +2126,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1961,6 +2138,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1972,6 +2150,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1983,6 +2162,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -1994,6 +2174,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -2005,6 +2186,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv32"),
         },
     ),
     (
@@ -2016,6 +2198,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-linux-android"),
         },
     ),
     (
@@ -2027,6 +2210,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64"),
         },
     ),
     (
@@ -2038,6 +2222,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-freebsd"),
         },
     ),
     (
@@ -2049,6 +2234,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("fuchsia"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-fuchsia"),
         },
     ),
     (
@@ -2060,6 +2246,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("hermit"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-hermit"),
         },
     ),
     (
@@ -2071,6 +2258,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-linux-gnu"),
         },
     ),
     (
@@ -2082,6 +2270,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-linux-musl"),
         },
     ),
     (
@@ -2093,6 +2282,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-netbsd"),
         },
     ),
     (
@@ -2104,6 +2294,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64"),
         },
     ),
     (
@@ -2115,6 +2306,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64"),
         },
     ),
     (
@@ -2126,6 +2318,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64-unknown-openbsd"),
         },
     ),
     (
@@ -2137,6 +2330,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64"),
         },
     ),
     (
@@ -2148,6 +2342,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("riscv64"),
         },
     ),
     (
@@ -2159,6 +2354,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("s390x-unknown-linux-gnu"),
         },
     ),
     (
@@ -2170,6 +2366,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("s390x-unknown-linux-musl"),
         },
     ),
     (
@@ -2181,6 +2378,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparc-unknown-linux-gnu"),
         },
     ),
     (
@@ -2192,6 +2390,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparc-unknown-none-elf"),
         },
     ),
     (
@@ -2203,6 +2402,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparc64-unknown-linux-gnu"),
         },
     ),
     (
@@ -2214,6 +2414,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparc64-unknown-netbsd"),
         },
     ),
     (
@@ -2225,6 +2426,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparc64-unknown-openbsd"),
         },
     ),
     (
@@ -2236,6 +2438,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solaris"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("sparcv9-sun-solaris"),
         },
     ),
     (
@@ -2247,6 +2450,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv4t-none-eabi"),
         },
     ),
     (
@@ -2258,6 +2462,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv5te-none-eabi"),
         },
     ),
     (
@@ -2269,6 +2474,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv6m-none-eabi"),
         },
     ),
     (
@@ -2280,6 +2486,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv6m-none-eabi"),
         },
     ),
     (
@@ -2291,6 +2498,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7a-pc-windows-msvc"),
         },
     ),
     (
@@ -2302,6 +2510,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7a-pc-windows-msvc"),
         },
     ),
     (
@@ -2313,6 +2522,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7em-none-eabi"),
         },
     ),
     (
@@ -2324,6 +2534,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7em-none-eabihf"),
         },
     ),
     (
@@ -2335,6 +2546,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7em-none-eabi"),
         },
     ),
     (
@@ -2346,6 +2558,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7em-none-eabihf"),
         },
     ),
     (
@@ -2357,6 +2570,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7m-none-eabi"),
         },
     ),
     (
@@ -2368,6 +2582,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv7m-none-eabi"),
         },
     ),
     (
@@ -2379,6 +2594,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-none-linux-android"),
         },
     ),
     (
@@ -2390,6 +2606,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -2401,6 +2618,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("armv7-unknown-linux-gnueabihf"),
         },
     ),
     (
@@ -2412,6 +2630,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.base-none-eabi"),
         },
     ),
     (
@@ -2423,6 +2642,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.base-none-eabi"),
         },
     ),
     (
@@ -2434,6 +2654,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.main-none-eabi"),
         },
     ),
     (
@@ -2445,6 +2666,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.main-none-eabihf"),
         },
     ),
     (
@@ -2456,6 +2678,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabi"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.main-none-eabi"),
         },
     ),
     (
@@ -2467,6 +2690,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nuttx"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("eabihf"),
+            unversioned_llvm_target: Cow::Borrowed("thumbv8m.main-none-eabihf"),
         },
     ),
     (
@@ -2478,6 +2702,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("emscripten"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-unknown-emscripten"),
         },
     ),
     (
@@ -2489,6 +2714,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("unknown"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-unknown-unknown"),
         },
     ),
     (
@@ -2500,6 +2726,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("wasi"),
             env: Cow::Borrowed("p1"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-wasi"),
         },
     ),
     (
@@ -2511,6 +2738,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("wasi"),
             env: Cow::Borrowed("p1"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-wasi"),
         },
     ),
     (
@@ -2522,6 +2750,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("wasi"),
             env: Cow::Borrowed("p1"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-wasi"),
         },
     ),
     (
@@ -2533,6 +2762,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("wasi"),
             env: Cow::Borrowed("p2"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-wasip2"),
         },
     ),
     (
@@ -2544,6 +2774,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm32-unknown-unknown"),
         },
     ),
     (
@@ -2555,6 +2786,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("unknown"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("wasm64-unknown-unknown"),
         },
     ),
     (
@@ -2566,6 +2798,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("macos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-apple-macosx"),
         },
     ),
     (
@@ -2577,6 +2810,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-apple-ios-simulator"),
         },
     ),
     (
@@ -2588,6 +2822,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("ios"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("macabi"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-apple-ios-macabi"),
         },
     ),
     (
@@ -2599,6 +2834,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("tvos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-apple-tvos-simulator"),
         },
     ),
     (
@@ -2610,6 +2846,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("watchos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed("sim"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-apple-watchos-simulator"),
         },
     ),
     (
@@ -2621,6 +2858,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("unknown"),
             env: Cow::Borrowed("sgx"),
             abi: Cow::Borrowed("fortanix"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-elf"),
         },
     ),
     (
@@ -2632,6 +2870,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("fuchsia"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-fuchsia"),
         },
     ),
     (
@@ -2643,6 +2882,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("android"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-linux-android"),
         },
     ),
     (
@@ -2654,6 +2894,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("nto"),
             env: Cow::Borrowed("nto71"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-unknown"),
         },
     ),
     (
@@ -2665,6 +2906,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solaris"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-solaris"),
         },
     ),
     (
@@ -2676,6 +2918,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-windows-gnu"),
         },
     ),
     (
@@ -2687,6 +2930,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("llvm"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-windows-gnu"),
         },
     ),
     (
@@ -2698,6 +2942,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-windows-msvc"),
         },
     ),
     (
@@ -2709,6 +2954,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("solaris"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-solaris"),
         },
     ),
     (
@@ -2720,6 +2966,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-musl"),
         },
     ),
     (
@@ -2731,6 +2978,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("dragonfly"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-dragonfly"),
         },
     ),
     (
@@ -2742,6 +2990,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("freebsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-freebsd"),
         },
     ),
     (
@@ -2753,6 +3002,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("fuchsia"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-fuchsia"),
         },
     ),
     (
@@ -2764,6 +3014,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("haiku"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-haiku"),
         },
     ),
     (
@@ -2775,6 +3026,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("hermit"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-hermit"),
         },
     ),
     (
@@ -2786,6 +3038,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("hurd"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-hurd-gnu"),
         },
     ),
     (
@@ -2797,6 +3050,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("illumos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-solaris"),
         },
     ),
     (
@@ -2808,6 +3062,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("l4re"),
             env: Cow::Borrowed("uclibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-l4re-uclibc"),
         },
     ),
     (
@@ -2819,6 +3074,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-gnu"),
         },
     ),
     (
@@ -2830,6 +3086,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("x32"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-gnux32"),
         },
     ),
     (
@@ -2841,6 +3098,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("musl"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-musl"),
         },
     ),
     (
@@ -2852,6 +3110,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-none"),
         },
     ),
     (
@@ -2863,6 +3122,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("linux"),
             env: Cow::Borrowed("ohos"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-ohos"),
         },
     ),
     (
@@ -2874,6 +3134,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("netbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-netbsd"),
         },
     ),
     (
@@ -2885,6 +3146,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-none-elf"),
         },
     ),
     (
@@ -2896,6 +3158,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-none-elf"),
         },
     ),
     (
@@ -2907,6 +3170,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("openbsd"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-openbsd"),
         },
     ),
     (
@@ -2918,6 +3182,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("redox"),
             env: Cow::Borrowed("relibc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-redox"),
         },
     ),
     (
@@ -2929,6 +3194,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("trusty"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-unknown-musl"),
         },
     ),
     (
@@ -2940,6 +3206,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("uefi"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-windows"),
         },
     ),
     (
@@ -2951,6 +3218,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-windows-gnu"),
         },
     ),
     (
@@ -2962,6 +3230,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed("uwp"),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-pc-windows-msvc"),
         },
     ),
     (
@@ -2973,6 +3242,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("windows"),
             env: Cow::Borrowed("msvc"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-win7-windows-msvc"),
         },
     ),
     (
@@ -2984,6 +3254,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("vxworks"),
             env: Cow::Borrowed("gnu"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64-unknown-linux-gnu"),
         },
     ),
     (
@@ -2995,6 +3266,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("macos"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("x86_64h-apple-macosx"),
         },
     ),
     (
@@ -3006,6 +3278,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
     (
@@ -3017,6 +3290,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
     (
@@ -3028,6 +3302,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
     (
@@ -3039,6 +3314,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
     (
@@ -3050,6 +3326,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("espidf"),
             env: Cow::Borrowed("newlib"),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
     (
@@ -3061,6 +3338,7 @@ pub(crate) const LIST: &[(&str, TargetInfo)] = &[
             os: Cow::Borrowed("none"),
             env: Cow::Borrowed(""),
             abi: Cow::Borrowed(""),
+            unversioned_llvm_target: Cow::Borrowed("xtensa-none-elf"),
         },
     ),
 ];

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -1,0 +1,92 @@
+use std::borrow::Cow;
+
+use super::TargetInfo;
+
+impl TargetInfo {
+    /// The versioned LLVM/Clang target triple.
+    #[allow(unused)]
+    pub(crate) fn versioned_llvm_target(&self, version: Option<&str>) -> Cow<'_, str> {
+        if let Some(version) = version {
+            // Only support versioned Apple targets for now.
+            assert_eq!(self.vendor, "apple");
+
+            let mut components = self.unversioned_llvm_target.split("-");
+            let arch = components.next().expect("llvm_target should have arch");
+            let vendor = components.next().expect("llvm_target should have vendor");
+            let os = components.next().expect("LLVM target should have os");
+            let environment = components.next();
+            assert_eq!(components.next(), None, "too many LLVM target components");
+
+            Cow::Owned(if let Some(env) = environment {
+                format!("{arch}-{vendor}-{os}{version}-{env}")
+            } else {
+                format!("{arch}-{vendor}-{os}{version}")
+            })
+        } else {
+            Cow::Borrowed(&self.unversioned_llvm_target)
+        }
+    }
+}
+
+/// Rust and Clang don't really agree on naming, so do a best-effort
+/// conversion to support out-of-tree / custom target-spec targets.
+pub(crate) fn guess_llvm_target_triple(
+    full_arch: &str,
+    vendor: &str,
+    os: &str,
+    env: &str,
+    abi: &str,
+) -> String {
+    let arch = match full_arch {
+        riscv32 if riscv32.starts_with("riscv32") => "riscv32",
+        riscv64 if riscv64.starts_with("riscv64") => "riscv64",
+        arch => arch,
+    };
+    let os = match os {
+        "darwin" => "macosx",
+        "visionos" => "xros",
+        "uefi" => "windows",
+        os => os,
+    };
+    let env = match env {
+        "newlib" | "nto70" | "nto71" | "ohos" | "p1" | "p2" | "relibc" | "sgx" | "uclibc" => "",
+        abi => abi,
+    };
+    let abi = match abi {
+        "sim" => "simulator",
+        "llvm" | "softfloat" | "uwp" | "vec-extabi" => "",
+        "ilp32" => "_ilp32",
+        abi => abi,
+    };
+    match (env, abi) {
+        ("", "") => format!("{arch}-{vendor}-{os}"),
+        (env, "") => format!("{arch}-{vendor}-{os}-{env}"),
+        ("", abi) => format!("{arch}-{vendor}-{os}-{abi}"),
+        (env, abi) => format!("{arch}-{vendor}-{os}-{env}{abi}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_llvm_triple_guessing() {
+        assert_eq!(
+            guess_llvm_target_triple("aarch64", "unknown", "linux", "", ""),
+            "aarch64-unknown-linux"
+        );
+        assert_eq!(
+            guess_llvm_target_triple("x86_64", "unknown", "linux", "gnu", ""),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            guess_llvm_target_triple("x86_64", "unknown", "linux", "gnu", "eabi"),
+            "x86_64-unknown-linux-gnueabi"
+        );
+        assert_eq!(
+            guess_llvm_target_triple("x86_64", "apple", "darwin", "", ""),
+            "x86_64-apple-macosx"
+        );
+    }
+}

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -4,7 +4,6 @@ use super::TargetInfo;
 
 impl TargetInfo {
     /// The versioned LLVM/Clang target triple.
-    #[allow(unused)]
     pub(crate) fn versioned_llvm_target(&self, version: Option<&str>) -> Cow<'_, str> {
         if let Some(version) = version {
             // Only support versioned Apple targets for now.

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -49,7 +49,7 @@ pub(crate) fn guess_llvm_target_triple(
     };
     let env = match env {
         "newlib" | "nto70" | "nto71" | "ohos" | "p1" | "p2" | "relibc" | "sgx" | "uclibc" => "",
-        abi => abi,
+        env => env,
     };
     let abi = match abi {
         "sim" => "simulator",

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -59,8 +59,6 @@ pub(crate) fn guess_llvm_target_triple(
     };
     match (env, abi) {
         ("", "") => format!("{arch}-{vendor}-{os}"),
-        (env, "") => format!("{arch}-{vendor}-{os}-{env}"),
-        ("", abi) => format!("{arch}-{vendor}-{os}-{abi}"),
         (env, abi) => format!("{arch}-{vendor}-{os}-{env}{abi}"),
     }
 }

--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use crate::ToolFamily;
-use crate::{target::Target, Tool};
+use crate::{target::TargetInfo, Tool};
 
 const MSVC_FAMILY: ToolFamily = ToolFamily::Msvc { clang_cl: false };
 
@@ -111,7 +111,7 @@ pub fn find_tool(target: &str, tool: &str) -> Option<Tool> {
 }
 
 pub(crate) fn find_tool_inner(
-    target: &Target,
+    target: &TargetInfo,
     tool: &str,
     env_getter: &dyn EnvGetter,
 ) -> Option<Tool> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -619,8 +619,7 @@ fn clang_apple_mac_catalyst() {
         .compile("foo");
     let execution = test.cmd(0);
 
-    // TODO: Add version to target here
-    execution.must_have("--target=arm64-apple-ios-macabi");
+    execution.must_have("--target=arm64-apple-ios15.0-macabi");
     execution.must_have_in_order("-isysroot", sdkroot);
     execution.must_have_in_order(
         "-isystem",


### PR DESCRIPTION
Part of https://github.com/rust-lang/cc-rs/issues/1249.

I _tried_ to keep it separate from cleaning up the Apple stuff, but things were quite intertwined, so I ended up having to do some of it. Still, this PR aims to have as few functional changes as possible (the only effect should be that we now use the correct Clang target).

Fixes https://github.com/rust-lang/cc-rs/issues/542 (was fixed before, but now we do it properly by passing `arm64-apple-macosx` instead of `arm64-apple-darwin`).
Fixes https://github.com/rust-lang/cc-rs/issues/1255.
Fixes https://github.com/rust-lang/cc-rs/issues/1205.
Might improve the situation in https://github.com/rust-lang/cc-rs/issues/1005.

This affects (checking local test script...) 128 targets, though I feel pretty confident that the change is correct, and if it's not, then it's likely an issue in `rustc` as well.