### PR TITLE
Do not add -fPIC by default on UEFI targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1997,7 +1997,7 @@ impl Build {
                 if self.pic.unwrap_or(
                     target.os != "windows"
                         && target.os != "none"
-                        && target.env != "uefi"
+                        && target.os != "uefi"
                         && target.os != "wasi",
                 ) {
                     cmd.push_cc_arg("-fPIC".into());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -284,6 +284,23 @@ fn gnu_aarch64_none_no_pic() {
 }
 
 #[test]
+fn gnu_uefi_no_pic() {
+    reset_env();
+
+    for arch in &["aarch64", "i686", "x86_64"] {
+        let target = format!("{}-unknown-uefi", arch);
+        let test = Test::gnu();
+        test.gcc()
+            .target(&target)
+            .host(&target)
+            .file("foo.c")
+            .compile("foo");
+
+        test.cmd(0).must_not_have("-fPIC");
+    }
+}
+
+#[test]
 fn gnu_set_stdlib() {
     reset_env();
 


### PR DESCRIPTION
This fixes a regression caused by 290a6293c5e061a8a1d91a6521ff4ffc66d93a2a.