### PR TITLE
Use relative directory for obj files hash

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -1,6 +1,7 @@
 //! Miscellaneous helpers for running commands
 
 use std::{
+    borrow::Cow,
     collections::hash_map,
     ffi::OsString,
     fmt::Display,
@@ -320,7 +321,7 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
         #[allow(clippy::disallowed_methods)]
         let dirname = if let Some(root) = std::env::var_os("CARGO_MANIFEST_DIR") {
             let root = root.to_string_lossy();
-            crate::Cow::Borrowed(dirname.strip_prefix(&*root).unwrap_or(&dirname))
+            Cow::Borrowed(dirname.strip_prefix(&*root).unwrap_or(&dirname))
         } else {
             dirname
         };

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -311,6 +311,14 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
         // Hash the dirname. This should prevent conflicts if we have multiple
         // object files with the same filename in different subfolders.
         let mut hasher = hash_map::DefaultHasher::new();
+
+        // Make the dirname relative to avoid full system paths influencing the sha and
+        // making the output system-dependent
+        let prefix = dst.parent().expect("Could not get parent of '{dst}'");
+        let prefix: &str = &prefix.to_string_lossy();
+        let err = format!("Could not strip prefix '{prefix}' from '{dirname}' to make '{dirname}' relative");
+        let dirname = dirname.strip_prefix(prefix).expect(&err);
+
         hasher.write(dirname.to_string().as_bytes());
         let obj = dst
             .join(format!("{:016x}-{}", hasher.finish(), basename))

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -315,6 +315,10 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
         // Make the dirname relative (if possible) to avoid full system paths influencing the sha
         // and making the output system-dependent
         let mut dirname = dirname.to_string();
+
+        // Here we allow using std::env::var (instead of Build::getenv) because
+        // CARGO_* variables always trigger a rebuild when changed
+        #[allow(clippy::disallowed_methods)]
         if let Ok(root) = std::env::var("CARGO_MANIFEST_DIR") {
             dirname = dirname.strip_prefix(&root).unwrap_or(&dirname).to_string();
         }


### PR DESCRIPTION
When producing `.o` files, the absolute path of each source file is hashed and used as a prefix for the output object files. While this avoids clashes between different source files with the same basenames, this causes determinism issues in the build as the full system path influences the build output.

This change strips the out_dir parent from the source file paths, assuming that the source files are in the out_dir as well.