### PR TITLE
windows_registry: Allow only specifying the architecture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3874,7 +3874,11 @@ impl Build {
             }
         }
 
-        windows_registry::find_tool_inner(target, tool, &BuildEnvGetter(self))
+        if target.env != "msvc" {
+            return None;
+        }
+
+        windows_registry::find_tool_inner(target.full_arch, tool, &BuildEnvGetter(self))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cc-rs/issues/1265 by allowing either an architecture or a full target name to be specified.

Would have avoided the regression from https://github.com/rust-lang/cc-rs/pull/1225 in https://github.com/rust-lang/cc-rs/issues/1281.