### PR TITLE
Fix compilation of C++ code for armv7-unknown-linux-gnueabihf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2187,6 +2187,7 @@ impl Build {
                     if target.abi == "eabihf" {
                         // lowest common denominator FPU
                         cmd.args.push("-mfpu=vfpv3-d16".into());
+                        cmd.args.push("-mfloat-abi=hard".into());
                     }
                 }
 


### PR DESCRIPTION
Inclusion of features.h for armv7-unknown-linux-gnueabihf will, in stubs-32.h, try to include stubs for hard or soft fp:

    #if !defined __ARM_PCS_VFP
    # include <gnu/stubs-soft.h>
    #endif
    #if defined __ARM_PCS_VFP
    # include <gnu/stubs-hard.h>
    #endif

gcc 13.3.0 as built by Yocto does not set __ARM_PCS_VFP unless -mfloat-abi=hard is set. The build will fail as stubs-soft.h may not be present.

Therefore, enable -mfloat-abi=hard when possible. gcc accepts it when an FPU is selected (-mfpu=vfpv3-d16 in this case).