### PR TITLE
Fix: Fetch target info from Cargo even if `Build::target` is manually set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,10 +1088,16 @@ impl Build {
         self
     }
 
-    /// Configures the target this configuration will be compiling for.
+    /// Configures the `rustc` target this configuration will be compiling
+    /// for.
     ///
-    /// This option is automatically scraped from the `TARGET` environment
-    /// variable by build scripts, so it's not required to call this function.
+    /// This will fail if using a target not in a pre-compiled list taken from
+    /// `rustc +nightly --print target-list`. The list will be updated
+    /// periodically.
+    ///
+    /// You should avoid setting this in build scripts, as that allows `cc`
+    /// to instead retrieve the desired target information from the
+    /// environment variables that Cargo sets.
     ///
     /// # Example
     ///


### PR DESCRIPTION
In the first commit, I've documented more closely what `Build::target` does, which should avoid confusion like in https://github.com/rust-lang/cc-rs/issues/1297.

And then it occurs to me that some users might be doing `build.target(&std::env::var("TARGET").unwrap())` (even though `Build::target` has been available since `cc v1.0.0`), which would give different behaviour than if they didn't do that (since we no longer source from Cargo). So I've added a hacky fix for this case.

We might want to take it even further, and warn if both `TARGET` and `Build::target` are set?