### PR TITLE
Add support for using sccache wrapper with cuda/nvcc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2813,6 +2813,9 @@ impl Build {
                     .args
                     .push(format!("-ccbin={}", tool.path.display()).into());
             }
+            if let Some(cc_wrapper) = self.rustc_wrapper_fallback() {
+                nvcc_tool.cc_wrapper_path = Some(Path::new(&cc_wrapper).to_owned());
+            }
             nvcc_tool.family = tool.family;
             nvcc_tool
         } else {


### PR DESCRIPTION
This allows any specified `RUSTC_WRAPPER` to be invoked when using nvcc.