### PR TITLE
Support new NTO QNX targets

### DIFF
--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -42,7 +42,8 @@ pub(crate) fn guess_llvm_target_triple(
         os => os,
     };
     let env = match env {
-        "newlib" | "nto70" | "nto71" | "ohos" | "p1" | "p2" | "relibc" | "sgx" | "uclibc" => "",
+        "newlib" | "nto70" | "nto71" | "nto71_iosock" | "ohos" | "p1" | "p2" | "relibc" | "sgx"
+        | "uclibc" => "",
         env => env,
     };
     let abi = match abi {


### PR DESCRIPTION
This change:
- Adds support for two new targets
- Adds support for a new target_env value
- Gives users a bit more information where an error message comes from (e.g. if target is unknown)

This depends on rust-lang/rust/pull/133631

CC: @jonathanpallant @japaric @gh-tr @AkhilTThomas