### PR TITLE
Check linking when testing if compiler flags are supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,9 +725,6 @@ impl Build {
             },
         );
 
-        // Checking for compiler flags does not require linking
-        cmd.arg("-c");
-
         cmd.arg(&src);
 
         let output = cmd.output()?;


### PR DESCRIPTION
Fixes #1321

Several of the inherited flags affect the linker, so we *do* need to go all the way to linking to verify them