### PR TITLE
Support target mips-zkm-zkvm-elf

### DIFF
--- a/src/target/generated.rs
+++ b/src/target/generated.rs
@@ -1517,6 +1517,18 @@ pub(crate) const LIST: &[(&str, TargetInfo<'static>)] = &[
         },
     ),
     (
+        "mips-zkm-zkvm-elf",
+        TargetInfo {
+            full_arch: "mips",
+            arch: "mips",
+            vendor: "zkm",
+            os: "zkvm",
+            env: "",
+            abi: "",
+            unversioned_llvm_target: "mips",
+        },
+    ),
+    (
         "mips64-openwrt-linux-musl",
         TargetInfo {
             full_arch: "mips64",


### PR DESCRIPTION
A general-purpose zkVM based on MIPS32V2 has been implemented and we are trying to add a new target for Rust.  