### PR TITLE
Don't inherit the `/Oy` flag for 64-bit targets

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -296,8 +296,11 @@ impl<'this> RustcCodegenFlags<'this> {
                 }
                 // https://learn.microsoft.com/en-us/cpp/build/reference/oy-frame-pointer-omission
                 if let Some(value) = self.force_frame_pointers {
-                    let cc_flag = if value { "/Oy-" } else { "/Oy" };
-                    push_if_supported(cc_flag.into());
+                    // Flag is unsupported on 64-bit arches
+                    if !target.arch.contains("64") {
+                        let cc_flag = if value { "/Oy-" } else { "/Oy" };
+                        push_if_supported(cc_flag.into());
+                    }
                 }
             }
         }


### PR DESCRIPTION
> [`/Oy` enables frame-pointer omission and `/Oy-` disables omission. In x64 compilers, `/Oy` and `/Oy-` are not available.](https://learn.microsoft.com/en-us/cpp/build/reference/oy-frame-pointer-omission?view=msvc-170)

Use an easy heuristic to avoid probing this flag for 64-bit targets

Closes https://github.com/rust-lang/rust/issues/134657