### PR TITLE
Fix is_flag_supported on msvc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,13 @@ impl Build {
 
         cmd.arg(&src);
 
+        // On MSVC skip the CRT by setting the entry point to `main`.
+        // This way we don't need to add the default library paths.
+        if compiler.is_like_msvc() {
+            // Flags from _LINK_ are appended to the linker arguments.
+            cmd.env("_LINK_", "-entry:main");
+        }
+
         let output = cmd.output()?;
         let is_supported = output.status.success() && output.stderr.is_empty();
 


### PR DESCRIPTION
Fixes #1324 by skipping linking the CRT when testing for supported compiler flags on Windows. We use the `_LINK_` environment variable to avoid disturbing the command line.

The more complex alternative would be to get the library paths and add them to the `LIB` environment variable.