### PR TITLE
Make `is_flag_supported_inner` take an `&Tool` instead of a `&Path`

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,8 +1,7 @@
 use crate::target::TargetInfo;
-use crate::{Build, Error, ErrorKind, ToolFamily};
+use crate::{Build, Error, ErrorKind, Tool, ToolFamily};
 use std::borrow::Cow;
 use std::ffi::OsString;
-use std::path::Path;
 
 #[derive(Debug, PartialEq, Default)]
 pub(crate) struct RustcCodegenFlags<'a> {
@@ -158,21 +157,15 @@ impl<'this> RustcCodegenFlags<'this> {
     }
 
     // Rust and clang/cc don't agree on what equivalent flags should look like.
-    pub(crate) fn cc_flags(
-        &self,
-        build: &Build,
-        path: &Path,
-        family: ToolFamily,
-        target: &TargetInfo,
-        flags: &mut Vec<OsString>,
-    ) {
+    pub(crate) fn cc_flags(&self, build: &Build, tool: &mut Tool, target: &TargetInfo) {
+        let family = tool.family;
         // Push `flag` to `flags` if it is supported by the currently used CC
         let mut push_if_supported = |flag: OsString| {
             if build
-                .is_flag_supported_inner(&flag, path, target)
+                .is_flag_supported_inner(&flag, tool, target)
                 .unwrap_or(false)
             {
-                flags.push(flag);
+                tool.args.push(flag);
             } else {
                 build.cargo_output.print_warning(&format!(
                     "Inherited flag {:?} is not supported by the currently used CC",


### PR DESCRIPTION
By passing in a `Tool` we allow other properties to be inspected by `is_flag_supported_inner` if necessary. I originally made this change to support grabbing an environment variable from the `Tool` but ended up going in a different direction. Still I think having the stronger type is useful on its own merit. And in the process of doing this I also ended up simplifying the arguments to `cc_flags`.