### PR TITLE
tool: Add `is_like_clang_cl()` getter

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -421,6 +421,11 @@ impl Tool {
         matches!(self.family, ToolFamily::Msvc { .. })
     }
 
+    /// Whether the tool is `clang-cl`-based MSVC-like.
+    pub fn is_like_clang_cl(&self) -> bool {
+        matches!(self.family, ToolFamily::Msvc { clang_cl: true })
+    }
+
     /// Supports using `--` delimiter to separate arguments and path to source files.
     pub(crate) fn supports_path_delimiter(&self) -> bool {
         matches!(


### PR DESCRIPTION
In `ring` we need to check if the compiler is `clang-cl` to prevent overwriting it with `clang` (see all details in https://github.com/briansmith/ring/issues/2215), but `cc-rs` does not currently expose this despite already tracking it.  By adding this getter we can steer that logic to not overwrite the compiler when it is `clang-cl`.

Perhaps, since `ToolFamily` is `pub` (but not yet reexported from `lib.rs`), could we have a public `Tool::family()` getter to not have to extend these `is_xxx()` getters whenever a downstream crate wants to know something new?
