### PR TITLE
Make hidden lifetimes explicit.

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -157,7 +157,7 @@ impl<'this> RustcCodegenFlags<'this> {
     }
 
     // Rust and clang/cc don't agree on what equivalent flags should look like.
-    pub(crate) fn cc_flags(&self, build: &Build, tool: &mut Tool, target: &TargetInfo) {
+    pub(crate) fn cc_flags(&self, build: &Build, tool: &mut Tool, target: &TargetInfo<'_>) {
         let family = tool.family;
         // Push `flag` to `flags` if it is supported by the currently used CC
         let mut push_if_supported = |flag: OsString| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2437,7 +2437,11 @@ impl Build {
         Ok(())
     }
 
-    fn add_inherited_rustflags(&self, cmd: &mut Tool, target: &TargetInfo) -> Result<(), Error> {
+    fn add_inherited_rustflags(
+        &self,
+        cmd: &mut Tool,
+        target: &TargetInfo<'_>,
+    ) -> Result<(), Error> {
         let env_os = match self.getenv("CARGO_ENCODED_RUSTFLAGS") {
             Some(env) => env,
             // No encoded RUSTFLAGS -> nothing to do
@@ -3760,7 +3764,7 @@ impl Build {
         Ok(Arc::from(OsStr::new(sdk_path.trim())))
     }
 
-    fn apple_sdk_root(&self, target: &TargetInfo) -> Result<Arc<OsStr>, Error> {
+    fn apple_sdk_root(&self, target: &TargetInfo<'_>) -> Result<Arc<OsStr>, Error> {
         let sdk = target.apple_sdk_name();
 
         if let Some(ret) = self


### PR DESCRIPTION
Mainline rustc has deprecated hidden lifetime parameters.

This change is required to build rustc with your own cc-rs fork.