### PR TITLE
chore(ci) move ubuntu-20 job to ubuntu-22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,7 +240,7 @@ jobs:
 
   cuda:
     name: Test CUDA support
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install cuda-minimal-build-11-8


### PR DESCRIPTION
ubuntu-20 will be removed in April. See the announcement [here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down).