### PR TITLE
Fix CC_FORCE_DISABLE=0 evaluating to true

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4157,10 +4157,9 @@ fn is_disabled() -> bool {
         match std::env::var_os("CC_FORCE_DISABLE") {
             // Not set? Not disabled.
             None => false,
-            // Respect `CC_FORCE_DISABLE=0` and some simple synonyms.
-            Some(v) if &*v != "0" && &*v != "false" && &*v != "no" => false,
-            // Otherwise, we're disabled. This intentionally includes `CC_FORCE_DISABLE=""`
-            Some(_) => true,
+            // Respect `CC_FORCE_DISABLE=0` and some simple synonyms, otherwise
+            // we're disabled. This intentionally includes `CC_FORCE_DISABLE=""`
+            Some(v) => &*v != "0" && &*v != "false" && &*v != "no",
         }
     }
     match val {


### PR DESCRIPTION
Found by @saleemrashid in https://github.com/rust-lang/cc-rs/pull/1292#pullrequestreview-2557590639.

Tested by running `CC_FORCE_DISABLE=0 cargo test`.