### PR TITLE
Include wrapper args. in `stdout` family heuristics to restore classifying `clang --driver-mode=cl` as `Msvc { clang_cl: true }`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2753,16 +2753,13 @@ impl Build {
         let tool_opt: Option<Tool> = self
             .env_tool(env)
             .map(|(tool, wrapper, args)| {
-                // find the driver mode, if any
-                const DRIVER_MODE: &str = "--driver-mode=";
-                let driver_mode = args.iter().find_map(|a| a.strip_suffix(DRIVER_MODE));
                 // Chop off leading/trailing whitespace to work around
                 // semi-buggy build scripts which are shared in
                 // makefiles/configure scripts (where spaces are far more
                 // lenient)
-                let mut t = Tool::with_clang_driver(
+                let mut t = Tool::with_args(
                     tool,
-                    driver_mode,
+                    args.clone(),
                     &self.build_cache.cached_compiler_family,
                     &self.cargo_output,
                     out_dir,
@@ -2882,7 +2879,7 @@ impl Build {
             };
             let mut nvcc_tool = Tool::with_features(
                 nvcc,
-                None,
+                vec![],
                 self.cuda,
                 &self.build_cache.cached_compiler_family,
                 &self.cargo_output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2755,10 +2755,7 @@ impl Build {
             .map(|(tool, wrapper, args)| {
                 // find the driver mode, if any
                 const DRIVER_MODE: &str = "--driver-mode=";
-                let driver_mode = args
-                    .iter()
-                    .find(|a| a.starts_with(DRIVER_MODE))
-                    .map(|a| &a[DRIVER_MODE.len()..]);
+                let driver_mode = args.iter().find_map(|a| a.strip_suffix(DRIVER_MODE));
                 // Chop off leading/trailing whitespace to work around
                 // semi-buggy build scripts which are shared in
                 // makefiles/configure scripts (where spaces are far more

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ use command_helpers::*;
 
 mod tool;
 pub use tool::Tool;
-use tool::ToolFamily;
+use tool::{CompilerFamilyLookupCache, ToolFamily};
 
 mod tempfile;
 
@@ -277,7 +277,7 @@ struct BuildCache {
     env_cache: RwLock<HashMap<Box<str>, Env>>,
     apple_sdk_root_cache: RwLock<HashMap<Box<str>, Arc<OsStr>>>,
     apple_versions_cache: RwLock<HashMap<Box<str>, Arc<str>>>,
-    cached_compiler_family: RwLock<HashMap<Box<Path>, ToolFamily>>,
+    cached_compiler_family: RwLock<CompilerFamilyLookupCache>,
     known_flag_support_status_cache: RwLock<HashMap<CompilerFlag, bool>>,
     target_info_parser: target::TargetInfoParser,
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -16,6 +16,8 @@ use crate::{
     Error, ErrorKind, OutputKind,
 };
 
+pub(crate) type CompilerFamilyLookupCache = HashMap<Box<Path>, ToolFamily>;
+
 /// Configuration used to represent an invocation of a C compiler.
 ///
 /// This can be used to figure out what compiler is in use, what the arguments
@@ -40,7 +42,7 @@ pub struct Tool {
 impl Tool {
     pub(crate) fn new(
         path: PathBuf,
-        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -57,7 +59,7 @@ impl Tool {
     pub(crate) fn with_args(
         path: PathBuf,
         args: Vec<String>,
-        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -90,7 +92,7 @@ impl Tool {
         path: PathBuf,
         args: Vec<String>,
         cuda: bool,
-        cached_compiler_family: &RwLock<HashMap<Box<Path>, ToolFamily>>,
+        cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
@@ -238,7 +240,7 @@ impl Tool {
                 Some(fname) if fname.contains("clang") => {
                     let is_clang_cl = args
                         .iter()
-                        .find_map(|a| a.strip_prefix("--driver-mode=") == Some("cl"))
+                        .any(|a| a.strip_prefix("--driver-mode=") == Some("cl"));
                     if is_clang_cl {
                         ToolFamily::Msvc { clang_cl: true }
                     } else {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -16,7 +16,7 @@ use crate::{
     Error, ErrorKind, OutputKind,
 };
 
-pub(crate) type CompilerFamilyLookupCache = HashMap<Box<Path>, ToolFamily>;
+pub(crate) type CompilerFamilyLookupCache = HashMap<Box<[Box<OsStr>]>, ToolFamily>;
 
 /// Configuration used to represent an invocation of a C compiler.
 ///
@@ -116,21 +116,25 @@ impl Tool {
         fn guess_family_from_stdout(
             stdout: &str,
             path: &Path,
+            args: &[String],
             cargo_output: &CargoOutput,
         ) -> Result<ToolFamily, Error> {
             cargo_output.print_debug(&stdout);
 
             // https://gitlab.kitware.com/cmake/cmake/-/blob/69a2eeb9dff5b60f2f1e5b425002a0fd45b7cadb/Modules/CMakeDetermineCompilerId.cmake#L267-271
             // stdin is set to null to ensure that the help output is never paginated.
-            let accepts_cl_style_flags =
-                run(Command::new(path).arg("-?").stdin(Stdio::null()), path, &{
+            let accepts_cl_style_flags = run(
+                Command::new(path).args(args).arg("-?").stdin(Stdio::null()),
+                path,
+                &{
                     // the errors are not errors!
                     let mut cargo_output = cargo_output.clone();
                     cargo_output.warnings = cargo_output.debug;
                     cargo_output.output = OutputKind::Discard;
                     cargo_output
-                })
-                .is_ok();
+                },
+            )
+            .is_ok();
 
             let clang = stdout.contains(r#""clang""#);
             let gcc = stdout.contains(r#""gcc""#);
@@ -155,6 +159,7 @@ impl Tool {
 
         fn detect_family_inner(
             path: &Path,
+            args: &[String],
             cargo_output: &CargoOutput,
             out_dir: Option<&Path>,
         ) -> Result<ToolFamily, Error> {
@@ -209,25 +214,31 @@ impl Tool {
                     &compiler_detect_output,
                 )?;
                 let stdout = String::from_utf8_lossy(&stdout);
-                guess_family_from_stdout(&stdout, path, cargo_output)
+                guess_family_from_stdout(&stdout, path, args, cargo_output)
             } else {
-                guess_family_from_stdout(&stdout, path, cargo_output)
+                guess_family_from_stdout(&stdout, path, args, cargo_output)
             }
         }
-        let detect_family = |path: &Path| -> Result<ToolFamily, Error> {
-            if let Some(family) = cached_compiler_family.read().unwrap().get(path) {
+        let detect_family = |path: &Path, args: &[String]| -> Result<ToolFamily, Error> {
+            let cache_key = [path.as_os_str()]
+                .iter()
+                .cloned()
+                .chain(args.iter().map(OsStr::new))
+                .map(Into::into)
+                .collect();
+            if let Some(family) = cached_compiler_family.read().unwrap().get(&cache_key) {
                 return Ok(*family);
             }
 
-            let family = detect_family_inner(path, cargo_output, out_dir)?;
+            let family = detect_family_inner(path, args, cargo_output, out_dir)?;
             cached_compiler_family
                 .write()
                 .unwrap()
-                .insert(path.into(), family);
+                .insert(cache_key, family);
             Ok(family)
         };
 
-        let family = detect_family(&path).unwrap_or_else(|e| {
+        let family = detect_family(&path, &args).unwrap_or_else(|e| {
             cargo_output.print_warning(&format_args!(
                 "Compiler family detection failed due to error: {}",
                 e

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -1,3 +1,4 @@
+#[cfg(not(windows))]
 use crate::support::Test;
 mod support;
 


### PR DESCRIPTION
I'm not sure which version exactly broke this, but between 1.0.89 and latest releases, this case had broken for the primary tool family heuristic. This forces Firefox/[`mozilla-central`](https://hg.mozilla.org/mozilla-central) to work around breakage in a `cc` upgrade a la [D236305](https://phabricator.services.mozilla.com/D236305). We introduced it in https://github.com/rust-lang/cc-rs/pull/455, so we'd like to keep it working!