### PR TITLE
Constrain `-Clto` and `-Cembed-bitcode` flag inheritance to be `clang`-only

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -223,11 +223,6 @@ impl<'this> RustcCodegenFlags<'this> {
                     push_if_supported(cc_flag.into());
                 }
             }
-            // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fembed-bitcode
-            if let Some(value) = self.embed_bitcode {
-                let cc_val = if value { "all" } else { "off" };
-                push_if_supported(format!("-fembed-bitcode={cc_val}").into());
-            }
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fno-omit-frame-pointer
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fomit-frame-pointer
             if let Some(value) = self.force_frame_pointers {
@@ -273,6 +268,12 @@ impl<'this> RustcCodegenFlags<'this> {
                 // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fprofile-use
                 if let Some(value) = self.profile_use {
                     push_if_supported(format!("-fprofile-use={value}").into());
+                }
+
+                // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fembed-bitcode
+                if let Some(value) = self.embed_bitcode {
+                    let cc_val = if value { "all" } else { "off" };
+                    push_if_supported(format!("-fembed-bitcode={cc_val}").into());
                 }
 
                 // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-flto

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -209,17 +209,6 @@ impl<'this> RustcCodegenFlags<'this> {
                     push_if_supported(format!("-mguard={cc_val}").into());
                 }
             }
-            // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-flto
-            if let Some(value) = self.lto {
-                let cc_val = match value {
-                    "y" | "yes" | "on" | "true" | "fat" => Some("full"),
-                    "thin" => Some("thin"),
-                    _ => None,
-                };
-                if let Some(cc_val) = cc_val {
-                    push_if_supported(format!("-flto={cc_val}").into());
-                }
-            }
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fPIC
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fPIE
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mdynamic-no-pic
@@ -284,6 +273,18 @@ impl<'this> RustcCodegenFlags<'this> {
                 // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fprofile-use
                 if let Some(value) = self.profile_use {
                     push_if_supported(format!("-fprofile-use={value}").into());
+                }
+
+                // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-flto
+                if let Some(value) = self.lto {
+                    let cc_val = match value {
+                        "y" | "yes" | "on" | "true" | "fat" => Some("full"),
+                        "thin" => Some("thin"),
+                        _ => None,
+                    };
+                    if let Some(cc_val) = cc_val {
+                        push_if_supported(format!("-flto={cc_val}").into());
+                    }
                 }
             }
             ToolFamily::Gnu { .. } => {}


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/136338 we noticed two unsupported inherited flag warnings when the underlying `cc` is `gcc` and not `clang`:

```
warning: rustc_llvm@0.0.0: Inherited flag "-flto=thin" is not supported by the currently used CC
warning: rustc_llvm@0.0.0: Inherited flag "-fembed-bitcode=all" is not supported by the currently used CC
```

This PR constraints `-Clto` and `-Cembed-bitcode` flag inheritance to be `clang`-only, compared the current behavior of inheriting the flags for both `clang` and `gcc`.

### Constrain `-Cembed-bitcode` flag inheritance to be `clang`-only

`embed-bitcode` refers to embedding LLVM bitcode, which is not a thing for `gcc`[^gimple].

This PR moves the `-Cembed-bitcode` flag inheritance from being shared by `gcc`/`clang` to be `clang`-*only*.

### Constrain `-Clto` flag inheritance to be `clang`-only

While `clang` supports `-flto={thin,fat}`, `gcc` does not support this form. Furthermore, there isn't really a 1-to-1 mapping between `clang`'s ThinLTO/FatLTO and `gcc`'s LTO.

We noticed this in https://github.com/rust-lang/rust/issues/136338 when trying to compile `rustc_llvm` but with the underlying `cc` being `gcc`:

```
warning: rustc_llvm@0.0.0: Inherited flag "-flto=thin" is not supported by the currently used CC
```

For instance, [`gcc` has *multiple* LTO-related / LTO-affecting flags][gcc-lto-flags]:

- [`-ffat-lto-objects` and `-fno-fat-lto-objects`][gcc-no-fat-lto-objects]. And its docs state:
    > `-fno-fat-lto-objects` improves compilation time over plain LTO, but requires the complete toolchain to be aware of LTO.
- [`-fwhole-program`][gcc-whole-program]
- [`-flto-partition`][gcc-lto-partition]
- [`-flto-compression-level`][gcc-lto-compression-level]
- ... and a few more.

[gcc-lto-flags]: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto
[gcc-no-fat-lto-objects]: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffat-lto-objects
[gcc-whole-program]: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fwhole-program
[gcc-lto-partition]: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto-partition
[gcc-lto-compression-level]: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto-compression-level

This PR moves the `-Clto` flag inheritance from being shared by `gcc`/`clang` to be `clang`-*only*.

[^gimple]: I suppose if you squint super super hard, embedding GIMPLE bytecode somehow...?