### PR TITLE
Don't specify both `-target` and `-mtargetos=` on Apple targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,13 @@ jobs:
             beta,
             nightly,
             linux32,
-            macos,
             aarch64-macos,
+            x86_64-macos,
             aarch64-ios,
+            aarch64-ios-sim,
+            x86_64-ios-sim,
+            aarch64-ios-macabi,
+            x86_64-ios-macabi,
             win32,
             win64,
             mingw32,
@@ -49,19 +53,39 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: i686-unknown-linux-gnu
-          - build: macos
-            os: macos-latest
-            rust: stable
-            target: x86_64-apple-darwin
           - build: aarch64-macos
             os: macos-14
             rust: stable
             target: aarch64-apple-darwin
+          - build: x86_64-macos
+            os: macos-13 # x86
+            rust: stable
+            target: x86_64-apple-darwin
           - build: aarch64-ios
             os: macos-latest
             rust: stable
             target: aarch64-apple-ios
             no_run: --no-run
+          - build: aarch64-ios-sim
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-ios-sim
+            no_run: --no-run
+          - build: x86_64-ios-sim
+            os: macos-13 # x86
+            rust: stable
+            target: x86_64-apple-ios # Simulator
+            no_run: --no-run
+          - build: aarch64-ios-macabi
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-ios-macabi
+            no_run: --no-run # FIXME(madsmtm): Fix running tests
+          - build: x86_64-ios-macabi
+            os: macos-13 # x86
+            rust: stable
+            target: x86_64-apple-ios-macabi
+            no_run: --no-run # FIXME(madsmtm): Fix running tests
           - build: windows-aarch64
             os: windows-latest
             rust: stable
@@ -139,42 +163,42 @@ jobs:
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
-  check-tvos:
+  check-build-std:
     name: Test build-std
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     strategy:
       matrix:
-        build: [aarch64-tvos, aarch64-tvos-sim, x86_64-tvos]
-        include:
-          - build: aarch64-tvos
-            os: macos-latest
-            rust: nightly
-            target: aarch64-apple-tvos
-            no_run: --no-run
-          - build: aarch64-tvos-sim
-            os: macos-latest
-            rust: nightly
-            target: aarch64-apple-tvos-sim
-            no_run: --no-run
-          - build: x86_64-tvos
-            os: macos-latest
-            rust: nightly
-            target: x86_64-apple-tvos
-            no_run: --no-run
+        target:
+          - x86_64h-apple-darwin
+          # FIXME(madsmtm): needs deployment target
+          # - armv7s-apple-ios
+          # FIXME(madsmtm): needs deployment target
+          # - i386-apple-ios # Simulator
+          - aarch64-apple-tvos
+          - aarch64-apple-tvos-sim
+          - x86_64-apple-tvos # Simulator
+          - aarch64-apple-watchos
+          - aarch64-apple-watchos-sim
+          - x86_64-apple-watchos-sim
+          # FIXME(madsmtm): needs deployment target
+          # - arm64_32-apple-watchos
+          - armv7k-apple-watchos
+          - aarch64-apple-visionos
+          - aarch64-apple-visionos-sim
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)
         run: |
           set -euxo pipefail
-          rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal
-          rustup component add rust-src --toolchain ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup default nightly
         shell: bash
       - run: cargo update
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }}
-      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --release
-      - run: cargo test -Z build-std=std ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} --features parallel
+      - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }}
+      - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --release
+      - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --features parallel
 
   check-wasm:
     name: Test wasm
@@ -188,7 +212,7 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
         shell: bash
-      - run: cargo update 
+      - run: cargo update
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --no-run --target ${{ matrix.target }}
       - run: cargo test --no-run --target ${{ matrix.target }} --release
@@ -251,7 +275,7 @@ jobs:
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
           sudo apt-get update
           sudo apt-get -y install cuda-minimal-build-11-8
-      - run: cargo update 
+      - run: cargo update
       - uses: Swatinem/rust-cache@v2
       - name: Test 'cudart' feature
         shell: bash
@@ -321,7 +345,7 @@ jobs:
     name: Tests pass
     needs:
       - test
-      - check-tvos
+      - check-build-std
       - check-wasm
       - test-wasm32-wasip1-thread
       - cuda

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -50,10 +50,17 @@ fn main() {
         .compile("bar");
 
     let target = std::env::var("TARGET").unwrap();
-    let file = target.split('-').next().unwrap();
+    let arch = match target.split('-').next().unwrap() {
+        "arm64_32" => "aarch64",
+        "armv7k" => "armv7",
+        "armv7s" => "armv7",
+        "i386" => "i686",
+        "x86_64h" => "x86_64",
+        arch => arch,
+    };
     let file = format!(
         "src/{}.{}",
-        file,
+        arch,
         if target.contains("msvc") { "asm" } else { "S" }
     );
     cc::Build::new().file(file).compile("asm");

--- a/dev-tools/cc-test/src/armv7.S
+++ b/dev-tools/cc-test/src/armv7.S
@@ -1,4 +1,11 @@
 .globl asm
+.balign 4
 asm:
+    mov r0, #7
+    bx lr
+
+.globl _asm
+.balign 4
+_asm:
     mov r0, #7
     bx lr


### PR DESCRIPTION
So... at this point, I feel like I've made every possible mistake with this, it _has_ to be correct now! ;)

Instead of specifying `-target`, on Apple platforms, we use `-arch` + `-mtargetos=` (or likewise). This should uniquely identify the target. I mostly chose this for consistency, instead of only passing `-target` on visionOS and Mac Catalyst (to make it clear, the issue only happens there because we're forced to use `-mtargetos=` instead of `-m*-version-min=*` that we can use elsewhere).

Fixes https://github.com/rust-lang/cc-rs/issues/1383. To avoid such mistakes in the future, I've expanded our CI to include more Apple targets.

Tested locally with:
```
# Added to CI as well.
cargo +nightly build --workspace --tests -Zbuild-std \
  --target aarch64-apple-darwin \
  --target x86_64-apple-darwin \
  --target aarch64-apple-ios \
  --target aarch64-apple-ios-macabi \
  --target aarch64-apple-ios-sim \
  --target x86_64-apple-ios \
  --target x86_64-apple-ios-macabi \
  --target aarch64-apple-tvos \
  --target aarch64-apple-tvos-sim \
  --target aarch64-apple-visionos \
  --target aarch64-apple-visionos-sim \
  --target aarch64-apple-watchos \
  --target aarch64-apple-watchos-sim \
  --target arm64_32-apple-watchos \
  --target x86_64-apple-tvos \
  --target x86_64-apple-watchos-sim \
  --target x86_64h-apple-darwin

# 32-bit iOS targets
IPHONEOS_DEPLOYMENT_TARGET=10.10 cargo +nightly build --workspace --tests -Zbuild-std --target i386-apple-ios --target armv7s-apple-ios

# 32-bit watchOS target
WATCHOS_DEPLOYMENT_TARGET=5.0 cargo +nightly build --workspace --tests -Zbuild-std --target armv7k-apple-watchos

# Run on Intel macOS 10.12 (not added to CI for that reason).
cargo +nightly test --workspace -Zbuild-std --target i686-apple-darwin
```

(This excludes the `arm64e` targets, as I [still can't compile those](https://github.com/rust-lang/rust/issues/130085)).