### PR TITLE
allow specifying `rustc` when generating target information

### DIFF
--- a/dev-tools/gen-target-info/src/main.rs
+++ b/dev-tools/gen-target-info/src/main.rs
@@ -84,15 +84,22 @@ fn generate_target_mapping(f: &mut File, target_specs: &RustcTargetSpecs) -> std
 
 fn main() {
     // Primarily use information from nightly.
-    let mut target_specs = get_target_specs_from_json();
+    let mut target_specs = get_target_specs_from_json(std::env::var("RUSTC").ok());
     // Next, read from MSRV to support old, removed targets.
-    for target_triple in get_targets_msrv().lines() {
-        let target_triple = target_triple.unwrap();
-        let target_triple = target_triple.trim();
-        target_specs
-            .0
-            .entry(target_triple.to_string())
-            .or_insert_with(|| get_target_spec_from_msrv(target_triple));
+    if std::env::var("CC_RS_MSRV")
+        .unwrap_or("1".to_string())
+        .parse::<u32>()
+        .unwrap()
+        != 0
+    {
+        for target_triple in get_targets_msrv().lines() {
+            let target_triple = target_triple.unwrap();
+            let target_triple = target_triple.trim();
+            target_specs
+                .0
+                .entry(target_triple.to_string())
+                .or_insert_with(|| get_target_spec_from_msrv(target_triple));
+        }
     }
 
     // Open file to write to

--- a/dev-tools/gen-target-info/src/read.rs
+++ b/dev-tools/gen-target-info/src/read.rs
@@ -40,14 +40,14 @@ pub fn get_target_spec_from_msrv(target: &str) -> TargetSpec {
     serde_json::from_slice(&stdout).unwrap()
 }
 
-pub fn get_target_specs_from_json() -> RustcTargetSpecs {
-    let mut cmd = process::Command::new("rustc");
-    cmd.args([
-        "+nightly",
-        "-Zunstable-options",
-        "--print",
-        "all-target-specs-json",
-    ]);
+pub fn get_target_specs_from_json(rustc: Option<String>) -> RustcTargetSpecs {
+    let mut cmd = process::Command::new(rustc.clone().unwrap_or("rustc".into()));
+
+    if rustc.is_none() {
+        cmd.arg("+nightly");
+    }
+
+    cmd.args(["-Zunstable-options", "--print", "all-target-specs-json"]);
     cmd.stdout(process::Stdio::piped());
     cmd.stderr(process::Stdio::inherit());
 


### PR DESCRIPTION
Hello!

Adding a new platform target to `rust-lang/rust` was resulting in some hard to track errors, but I finally figured out it had to do with the generated list here. Adding them manually to the generated output in a fork is of course possible but I also added a means of passing in a path to `rustc`, e.g. from one of the bootstrap stages, to automatically update the target list.

Might be useful for those who are trying to get a fork up and running without manually editing generated stuff.