### PR TITLE
Fix cross-compiling for Apple platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,16 @@ jobs:
             rust: stable
             target: x86_64-apple-ios-macabi
             no_run: --no-run # FIXME(madsmtm): Fix running tests
+          - build: cross-macos-aarch64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-apple-darwin
+            no_run: --no-run
+          - build: cross-ios-aarch64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-apple-ios
+            no_run: --no-run
           - build: windows-aarch64
             os: windows-latest
             rust: stable
@@ -155,6 +165,31 @@ jobs:
         env:
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}
+      - name: Install llvm tools (for llvm-ar)
+        if: startsWith(matrix.build, 'cross-macos') || startsWith(matrix.build, 'cross-ios')
+        run: sudo apt-get install llvm
+      - name: Download macOS SDK
+        if: startsWith(matrix.build, 'cross-macos')
+        run: |
+          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz
+          tar -xf MacOSX11.3.sdk.tar.xz
+          echo "SDKROOT=$(pwd)/MacOSX11.3.sdk" >> $GITHUB_ENV
+      - name: Download iOS SDK
+        if: startsWith(matrix.build, 'cross-ios')
+        run: |
+          wget https://github.com/xybp888/iOS-SDKs/releases/download/iOS18.1-SDKs/iPhoneOS18.1.sdk.zip
+          unzip iPhoneOS18.1.sdk.zip
+          echo "SDKROOT=$(pwd)/iPhoneOS18.1.sdk" >> $GITHUB_ENV
+      - name: Set up Apple cross-compilation
+        if: startsWith(matrix.build, 'cross-macos') || startsWith(matrix.build, 'cross-ios')
+        run: |
+          # Test with clang/llvm for now, has better cross-compilation support (GCC requires downloading a different toolchain)
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "AR=llvm-ar" >> $GITHUB_ENV
+          # Link with rust-lld
+          UPPERCASE_TARGET_NAME=$(echo "${{ matrix.target }}" | tr '[:lower:]-' '[:upper:]_')
+          echo "CARGO_TARGET_${UPPERCASE_TARGET_NAME}_LINKER=rust-lld" >> $GITHUB_ENV
       - name: setup dev environment
         uses: ilammy/msvc-dev-cmd@v1
         if: startsWith(matrix.build, 'windows-clang')

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -1,3 +1,26 @@
+use super::TargetInfo;
+
+impl TargetInfo<'_> {
+    /// The versioned LLVM/Clang target triple.
+    pub(crate) fn versioned_llvm_target(&self, version: &str) -> String {
+        // Only support versioned Apple targets for now.
+        assert_eq!(self.vendor, "apple");
+
+        let mut components = self.llvm_target.split("-");
+        let arch = components.next().expect("llvm_target should have arch");
+        let vendor = components.next().expect("llvm_target should have vendor");
+        let os = components.next().expect("LLVM target should have os");
+        let environment = components.next();
+        assert_eq!(components.next(), None, "too many LLVM target components");
+
+        if let Some(env) = environment {
+            format!("{arch}-{vendor}-{os}{version}-{env}")
+        } else {
+            format!("{arch}-{vendor}-{os}{version}")
+        }
+    }
+}
+
 /// Rust and Clang don't really agree on naming, so do a best-effort
 /// conversion to support out-of-tree / custom target-spec targets.
 pub(crate) fn guess_llvm_target_triple(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -616,7 +616,7 @@ fn clang_apple_tvos() {
         .file("foo.c")
         .compile("foo");
 
-    test.cmd(0).must_have_in_order("-arch", "arm64");
+    test.cmd(0).must_have("--target=arm64-apple-tvos");
     test.cmd(0).must_have("-mappletvos-version-min=9.0");
 }
 
@@ -640,10 +640,9 @@ fn clang_apple_mac_catalyst() {
         .compile("foo");
     let execution = test.cmd(0);
 
-    execution.must_have_in_order("-arch", "arm64");
+    execution.must_have("--target=arm64-apple-ios15.0-macabi");
     // --target and -mtargetos= don't mix
-    execution.must_not_have("--target=arm64-apple-ios-macabi");
-    execution.must_have("-mtargetos=ios15.0-macabi");
+    execution.must_not_have("-mtargetos=");
     execution.must_have_in_order("-isysroot", sdkroot);
     execution.must_have_in_order(
         "-isystem",
@@ -672,7 +671,8 @@ fn clang_apple_tvsimulator() {
         .file("foo.c")
         .compile("foo");
 
-    test.cmd(0).must_have_in_order("-arch", "x86_64");
+    test.cmd(0)
+        .must_have("--target=x86_64-apple-tvos-simulator");
     test.cmd(0).must_have("-mappletvsimulator-version-min=9.0");
 }
 
@@ -697,10 +697,9 @@ fn clang_apple_visionos() {
 
     dbg!(test.cmd(0).args);
 
-    test.cmd(0).must_have_in_order("-arch", "arm64");
+    test.cmd(0).must_have("--target=arm64-apple-xros1.0");
     // --target and -mtargetos= don't mix.
-    test.cmd(0).must_not_have("--target=arm64-apple-xros");
-    test.cmd(0).must_have("-mtargetos=xros1.0");
+    test.cmd(0).must_not_have("-mtargetos=");
 
     // Flags that don't exist.
     test.cmd(0).must_not_have("-mxros-version-min=1.0");


### PR DESCRIPTION
(So, of course we weren't done here...)

Basically, the only difference between this and pre-https://github.com/rust-lang/cc-rs/pull/1384 is that on visionOS and Mac Catalyst, we pass a versioned `--target` instead of unversioned `--target` + `-mtargetos=`.
This is similar to the alternative I noted in that PR, and while it does run into https://github.com/rust-lang/cc-rs/issues/1278 (the bug that configuration files + versioned targets are badly supported on older Clang) on those targets, I think that's the better option.

Fixes https://github.com/rust-lang/cc-rs/issues/1388. To avoid this in the future, I have added a CI step to verify that cross-compilation works (fails in the first commit, succeeds in the second).

### Alternatives

I looked through Clang's parsing code, and from that I glean that an alternative would probably be to set `--target` + `*_DEPLOYMENT_TARGET`. This has a few problems though:
- I suspect a lot of users are just inspecting `Tool::args`/`.get_compiler().get_command().get_args()`, and forget to also look at `Tool::env` (I know at least Rust's `bootstrap` currently forgets to do this).
- This also doesn't force GCC users to use a compiler configured for Darwin (so we'd still have to pass `-mmacosx-version-min=` there) (probably acceptable to not do if we did https://github.com/rust-lang/cc-rs/issues/1391).
