### PR TITLE
Simplify the error output on failed `Command` invocation

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -247,7 +247,6 @@ fn write_warning(line: &[u8]) {
 
 fn wait_on_child(
     cmd: &Command,
-    program: &Path,
     child: &mut Child,
     cargo_output: &CargoOutput,
 ) -> Result<(), Error> {
@@ -258,12 +257,7 @@ fn wait_on_child(
         Err(e) => {
             return Err(Error::new(
                 ErrorKind::ToolExecError,
-                format!(
-                    "Failed to wait on spawned child process, command {:?} with args {}: {}.",
-                    cmd,
-                    program.display(),
-                    e
-                ),
+                format!("failed to wait on spawned child process `{cmd:?}`: {e}"),
             ));
         }
     };
@@ -275,12 +269,7 @@ fn wait_on_child(
     } else {
         Err(Error::new(
             ErrorKind::ToolExecError,
-            format!(
-                "Command {:?} with args {} did not execute successfully (status code {}).",
-                cmd,
-                program.display(),
-                status
-            ),
+            format!("command did not execute successfully (status code {status}): {cmd:?}"),
         ))
     }
 }
@@ -350,28 +339,16 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
     Ok(objects)
 }
 
-pub(crate) fn run(
-    cmd: &mut Command,
-    program: impl AsRef<Path>,
-    cargo_output: &CargoOutput,
-) -> Result<(), Error> {
-    let program = program.as_ref();
-
-    let mut child = spawn(cmd, program, cargo_output)?;
-    wait_on_child(cmd, program, &mut child, cargo_output)
+pub(crate) fn run(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<(), Error> {
+    let mut child = spawn(cmd, cargo_output)?;
+    wait_on_child(cmd, &mut child, cargo_output)
 }
 
-pub(crate) fn run_output(
-    cmd: &mut Command,
-    program: impl AsRef<Path>,
-    cargo_output: &CargoOutput,
-) -> Result<Vec<u8>, Error> {
-    let program = program.as_ref();
-
+pub(crate) fn run_output(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<Vec<u8>, Error> {
     // We specifically need the output to be captured, so override default
     let mut captured_cargo_output = cargo_output.clone();
     captured_cargo_output.output = OutputKind::Capture;
-    let mut child = spawn(cmd, program, &captured_cargo_output)?;
+    let mut child = spawn(cmd, &captured_cargo_output)?;
 
     let mut stdout = vec![];
     child
@@ -382,16 +359,12 @@ pub(crate) fn run_output(
         .unwrap();
 
     // Don't care about this output, use the normal settings
-    wait_on_child(cmd, program, &mut child, cargo_output)?;
+    wait_on_child(cmd, &mut child, cargo_output)?;
 
     Ok(stdout)
 }
 
-pub(crate) fn spawn(
-    cmd: &mut Command,
-    program: &Path,
-    cargo_output: &CargoOutput,
-) -> Result<Child, Error> {
+pub(crate) fn spawn(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<Child, Error> {
     struct ResetStderr<'cmd>(&'cmd mut Command);
 
     impl Drop for ResetStderr<'_> {
@@ -414,28 +387,18 @@ pub(crate) fn spawn(
         Ok(child) => Ok(child),
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
             let extra = if cfg!(windows) {
-                " (see https://docs.rs/cc/latest/cc/#compile-time-requirements \
-for help)"
+                " (see https://docs.rs/cc/latest/cc/#compile-time-requirements for help)"
             } else {
                 ""
             };
             Err(Error::new(
                 ErrorKind::ToolNotFound,
-                format!(
-                    "Failed to find tool. Is `{}` installed?{}",
-                    program.display(),
-                    extra
-                ),
+                format!("failed to find tool {:?}{extra}: {e}", cmd.0.get_program()),
             ))
         }
         Err(e) => Err(Error::new(
             ErrorKind::ToolExecError,
-            format!(
-                "Command {:?} with args {} failed to start: {:?}",
-                cmd.0,
-                program.display(),
-                e
-            ),
+            format!("command `{:?}` failed to start: {e}", cmd.0),
         )),
     }
 }
@@ -465,7 +428,6 @@ pub(crate) fn command_add_output_file(cmd: &mut Command, dst: &Path, args: CmdAd
 #[cfg(feature = "parallel")]
 pub(crate) fn try_wait_on_child(
     cmd: &Command,
-    program: &Path,
     child: &mut Child,
     stdout: &mut dyn io::Write,
     stderr_forwarder: &mut StderrForwarder,
@@ -483,12 +445,7 @@ pub(crate) fn try_wait_on_child(
             } else {
                 Err(Error::new(
                     ErrorKind::ToolExecError,
-                    format!(
-                        "Command {:?} with args {} did not execute successfully (status code {}).",
-                        cmd,
-                        program.display(),
-                        status
-                    ),
+                    format!("command did not execute successfully (status code {status}): {cmd:?}"),
                 ))
             }
         }
@@ -497,12 +454,7 @@ pub(crate) fn try_wait_on_child(
             stderr_forwarder.forward_all();
             Err(Error::new(
                 ErrorKind::ToolExecError,
-                format!(
-                    "Failed to wait on spawned child process, command {:?} with args {}: {}.",
-                    cmd,
-                    program.display(),
-                    e
-                ),
+                format!("failed to wait on spawned child process `{cmd:?}`: {e}"),
             ))
         }
     }

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -393,7 +393,7 @@ pub(crate) fn spawn(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<Chi
             };
             Err(Error::new(
                 ErrorKind::ToolNotFound,
-                format!("failed to find tool {:?}{extra}: {e}", cmd.0.get_program()),
+                format!("failed to find tool {:?}: {e}{extra}", cmd.0.get_program()),
             ))
         }
         Err(e) => Err(Error::new(

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -99,7 +99,6 @@ impl Tool {
         fn is_zig_cc(path: &Path, cargo_output: &CargoOutput) -> bool {
             run_output(
                 Command::new(path).arg("--version"),
-                path,
                 // tool detection issues should always be shown as warnings
                 cargo_output,
             )
@@ -125,7 +124,6 @@ impl Tool {
             // stdin is set to null to ensure that the help output is never paginated.
             let accepts_cl_style_flags = run(
                 Command::new(path).args(args).arg("-?").stdin(Stdio::null()),
-                path,
                 &{
                     // the errors are not errors!
                     let mut cargo_output = cargo_output.clone();
@@ -202,7 +200,6 @@ impl Tool {
 
             let stdout = run_output(
                 Command::new(path).arg("-E").arg(tmp.path()),
-                path,
                 &compiler_detect_output,
             )?;
             let stdout = String::from_utf8_lossy(&stdout);
@@ -210,7 +207,6 @@ impl Tool {
             if stdout.contains("-Wslash-u-filename") {
                 let stdout = run_output(
                     Command::new(path).arg("-E").arg("--").arg(tmp.path()),
-                    path,
                     &compiler_detect_output,
                 )?;
                 let stdout = String::from_utf8_lossy(&stdout);


### PR DESCRIPTION
Passing around the `program` we wanted to execute in `command_helpers.rs` is unnecessary, we can retrieve it from `Command::get_program` instead when required, and that path is usually more descriptive anyhow.


## Motivation

I'm currently debugging [this](https://github.com/rust-lang/rust/pull/133092#issuecomment-2647012444). The error that `cc-rs` gives is:
```
error occurred: Command "sccache" "aarch64-unknown-fuchsia-clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=aarch64-unknown-fuchsia" "-I" "/checkout/src/llvm-project/compiler-rt/lib/builtins" "-fno-builtin" "-fvisibility=hidden" "-ffreestanding" "-fomit-frame-pointer" "-ffile-prefix-map=/checkout/src/llvm-project/compiler-rt=." "-DCOMPILER_RT_HAS_FLOAT16" "-DVISIBILITY_HIDDEN" "-o" "/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-std/aarch64-unknown-fuchsia/release/build/compiler_builtins-6830d4e928982f93/out/670c1ed24249df13-aarch64.o" "-c" "/checkout/src/llvm-project/compiler-rt/lib/builtins/cpu_model/aarch64.c" with args aarch64-unknown-fuchsia-clang did not execute successfully (status code exit status: 1).
```

This was confusing, as "aarch64-unknown-fuchsia-clang" is really the compiler and not "args". Besides, I didn't actually need to know that the tool we "wanted" to invoke; that is evident from the pretty-printed command line arguments.

With this PR, the above error would have been:
```
error occurred: command did not execute successfully (status code 1): "sccache" "aarch64-unknown-fuchsia-clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=aarch64-unknown-fuchsia" "-I" "/checkout/src/llvm-project/compiler-rt/lib/builtins" "-fno-builtin" "-fvisibility=hidden" "-ffreestanding" "-fomit-frame-pointer" "-ffile-prefix-map=/checkout/src/llvm-project/compiler-rt=." "-DCOMPILER_RT_HAS_FLOAT16" "-DVISIBILITY_HIDDEN" "-o" "/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-std/aarch64-unknown-fuchsia/release/build/compiler_builtins-6830d4e928982f93/out/670c1ed24249df13-aarch64.o" "-c" "/checkout/src/llvm-project/compiler-rt/lib/builtins/cpu_model/aarch64.c"
```

Which is shorter, and makes it clearer where the command starts and ends (after the colon and at the end of the line).