### PR TITLE
Always read from all `CFLAGS`-style flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3663,8 +3663,12 @@ impl Build {
 
     /// Get a single-valued environment variable with target variants.
     fn getenv_with_target_prefixes(&self, env: &str) -> Result<Arc<OsStr>, Error> {
-        let envs = self.target_envs(env)?;
-        let res = envs.iter().filter_map(|env| self.getenv(&env)).next();
+        // Take from first environment variable in the environment.
+        let res = self
+            .target_envs(env)?
+            .iter()
+            .filter_map(|env| self.getenv(env))
+            .next();
 
         match res {
             Some(res) => Ok(res),

--- a/tests/cc_env.rs
+++ b/tests/cc_env.rs
@@ -16,6 +16,7 @@ fn main() {
     path_to_ccache();
     more_spaces();
     clang_cl();
+    env_var_alternatives_override();
 }
 
 fn ccache() {
@@ -125,4 +126,34 @@ fn clang_cl() {
         };
         test_compiler(test.gcc());
     }
+}
+
+fn env_var_alternatives_override() {
+    let compiler1 = format!("clang1{}", env::consts::EXE_SUFFIX);
+    let compiler2 = format!("clang2{}", env::consts::EXE_SUFFIX);
+    let compiler3 = format!("clang3{}", env::consts::EXE_SUFFIX);
+    let compiler4 = format!("clang4{}", env::consts::EXE_SUFFIX);
+
+    let test = Test::new();
+    test.shim(&compiler1);
+    test.shim(&compiler2);
+    test.shim(&compiler3);
+    test.shim(&compiler4);
+
+    env::set_var("CC", &compiler1);
+    let compiler = test.gcc().target("x86_64-unknown-none").get_compiler();
+    assert_eq!(compiler.path(), Path::new(&compiler1));
+
+    env::set_var("HOST_CC", &compiler2);
+    env::set_var("TARGET_CC", &compiler2);
+    let compiler = test.gcc().target("x86_64-unknown-none").get_compiler();
+    assert_eq!(compiler.path(), Path::new(&compiler2));
+
+    env::set_var("CC_x86_64_unknown_none", &compiler3);
+    let compiler = test.gcc().target("x86_64-unknown-none").get_compiler();
+    assert_eq!(compiler.path(), Path::new(&compiler3));
+
+    env::set_var("CC_x86_64-unknown-none", &compiler4);
+    let compiler = test.gcc().target("x86_64-unknown-none").get_compiler();
+    assert_eq!(compiler.path(), Path::new(&compiler4));
 }

--- a/tests/cflags.rs
+++ b/tests/cflags.rs
@@ -1,15 +1,39 @@
+//! This test is in its own module because it modifies the environment and would affect other tests
+//! when run in parallel with them.
 mod support;
 
 use crate::support::Test;
 use std::env;
 
-/// This test is in its own module because it modifies the environment and would affect other tests
-/// when run in parallel with them.
 #[test]
+fn cflags() {
+    gnu_no_warnings_if_cflags();
+    cflags_order();
+}
+
 fn gnu_no_warnings_if_cflags() {
     env::set_var("CFLAGS", "-arbitrary");
     let test = Test::gnu();
     test.gcc().file("foo.c").compile("foo");
 
     test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
+}
+
+/// Test the ordering of `CFLAGS*` variables.
+fn cflags_order() {
+    unsafe { env::set_var("CFLAGS", "-arbitrary1") };
+    unsafe { env::set_var("HOST_CFLAGS", "-arbitrary2") };
+    unsafe { env::set_var("TARGET_CFLAGS", "-arbitrary2") };
+    unsafe { env::set_var("CFLAGS_x86_64_unknown_none", "-arbitrary3") };
+    unsafe { env::set_var("CFLAGS_x86_64-unknown-none", "-arbitrary4") };
+    let test = Test::gnu();
+    test.gcc()
+        .target("x86_64-unknown-none")
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0)
+        .must_have_in_order("-arbitrary1", "-arbitrary2")
+        .must_have_in_order("-arbitrary2", "-arbitrary3")
+        .must_have_in_order("-arbitrary3", "-arbitrary4");
 }


### PR DESCRIPTION
Reading from just one of these means that users setting different environment variables in different parts of the build process would not get flags from the other parts.

This tripped me up in https://github.com/rust-lang/rust/pull/133092 / https://github.com/rust-lang/rust/issues/136984, where I thought that since I was extending `CFLAGS_*` instead of overwriting it, I was allowing `cc-rs` to also read from `CFLAGS`.

Instead, we now read all of the flags, but in order such that more specific flags override less specific ones.

So e.g. when users set `CFLAGS=-flag1 CFLAGS_aarch64_apple_darwin=-flag2 cargo build`, we end up passing `-flag1 -flag2` to the compiler (in that order specifically).

NOTE: This has the slight chance of breaking builds where users assume that `CFLAGS_$TARGET` overwrites `CFLAGS`. I will argue that that is likely to be the minority, relative to users that do want flags from all `CFLAGS*` env vars.
To fix such cases, users should pass the negative flag in `CFLAGS_$TARGET` that they don't want `CFLAGS` to set (e.g. if `CFLAGS` contains `-pthread`, users should pass `CFLAGS_$TARGET=-no-pthread`).