### PR TITLE
Change flag ordering

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -160,8 +160,8 @@ impl Execution {
         match (before_position, after_position) {
             (Some(b), Some(a)) if b < a => {}
             (b, a) => panic!(
-                "{:?} (last position: {:?}) did not appear before {:?} (last position: {:?})",
-                before, b, after, a
+                "{:?} (last position: {:?}) did not appear before {:?} (last position: {:?}): {:?}",
+                before, b, after, a, self.args
             ),
         };
         self


### PR DESCRIPTION
To allow flags set on the builder with `Build::flag`/`Build::flag_if_supported` to override other flags, and to allow `CFLAGS` to override _all_ other flags.

Found while doing https://github.com/rust-lang/cc-rs/pull/1401.

Now the order of flags are as follows, with later flags overriding previous ones. I've also here shown who "controls" which flag, to make it clear why we want the ordering to be like this.
1. Default flags
    - Controlled by `cc-rs`.
2. `rustc`-inherited flags
    - Controlled by `rustc`.
3. Builder flags
    - Controlled by the developer using `cc-rs` in e.g. their `build.rs`.
4. Environment flags
    - Controlled by the end user.
