### PR TITLE
fix: force windows compiler to run in `out_dir` to prevent artifacts in cwd

### DIFF
--- a/.github/actions/check-clean-git-working-tree/action.yaml
+++ b/.github/actions/check-clean-git-working-tree/action.yaml
@@ -1,0 +1,18 @@
+name: "Check Clean Git Working Tree"
+description: "Check that the git working tree is clean"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check clean Git working tree
+      shell: bash
+      run: |
+        status_output=$(git status --porcelain=v1)
+        if [ -z "$status_output" ]; then
+          echo "Git working tree is clean."
+          exit 0
+        else
+          echo "dirty Git working tree detected!"
+          echo "$status_output"
+          exit 1
+        fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,9 @@ jobs:
       - run: cargo update
       - uses: Swatinem/rust-cache@v2
       - run: cargo test ${{ matrix.no_run }} --workspace --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
 
   # This is separate from the matrix above because there is no prebuilt rust-std component for these targets.
   check-build-std:
@@ -234,6 +237,9 @@ jobs:
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }}
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --release
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --features parallel
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
 
   check-wasm:
     name: Test wasm
@@ -252,6 +258,9 @@ jobs:
       - run: cargo test --no-run --target ${{ matrix.target }}
       - run: cargo test --no-run --target ${{ matrix.target }} --release
       - run: cargo test --no-run --target ${{ matrix.target }} --features parallel
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
 
   test-wasm32-wasip1-thread:
     name: Test wasm32-wasip1-thread
@@ -297,6 +306,10 @@ jobs:
       - name: Run tests
         run: cargo +nightly build -p $TARGET-test --target $TARGET
 
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
+
   cuda:
     name: Test CUDA support
     runs-on: ubuntu-22.04
@@ -317,6 +330,9 @@ jobs:
         run: |
           PATH="/usr/local/cuda/bin:$PATH" cargo test --manifest-path dev-tools/cc-test/Cargo.toml --features test_cuda
           PATH="/usr/local/cuda/bin:$PATH" CXX=clang++ cargo test --manifest-path dev-tools/cc-test/Cargo.toml --features test_cuda
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
 
   msrv:
     name: MSRV
@@ -353,6 +369,9 @@ jobs:
         shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --no-deps
+      # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
+      - name: check clean Git workting tree
+        uses: ./.github/actions/check-clean-git-working-tree
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,12 +169,14 @@ jobs:
         if: startsWith(matrix.build, 'cross-macos') || startsWith(matrix.build, 'cross-ios')
         run: sudo apt-get install llvm
       - name: Download macOS SDK
+        working-directory: ${{ runner.temp }}
         if: startsWith(matrix.build, 'cross-macos')
         run: |
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz
           tar -xf MacOSX11.3.sdk.tar.xz
           echo "SDKROOT=$(pwd)/MacOSX11.3.sdk" >> $GITHUB_ENV
       - name: Download iOS SDK
+        working-directory: ${{ runner.temp }}
         if: startsWith(matrix.build, 'cross-ios')
         run: |
           wget https://github.com/xybp888/iOS-SDKs/releases/download/iOS18.1-SDKs/iPhoneOS18.1.sdk.zip
@@ -283,7 +285,7 @@ jobs:
           echo "WASI_TOOLCHAIN_VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Install wasi-sdk
-        working-directory: /tmp
+        working-directory: ${{ runner.temp }}
         env:
           REPO: WebAssembly/wasi-sdk
         run: |
@@ -316,6 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install cuda-minimal-build-11-8
+        working-directory: ${{ runner.temp }}
         shell: bash
         run: |
           # https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1337,8 +1337,6 @@ impl Build {
 
         let mut cmd = compiler.to_command();
         let is_arm = matches!(target.arch, "aarch64" | "arm");
-        let clang = compiler.is_like_clang();
-        let gnu = compiler.family == ToolFamily::Gnu;
         command_add_output_file(
             &mut cmd,
             &obj,
@@ -1346,8 +1344,8 @@ impl Build {
                 cuda: self.cuda,
                 is_assembler_msvc: false,
                 msvc: compiler.is_like_msvc(),
-                clang,
-                gnu,
+                clang: compiler.is_like_clang(),
+                gnu: compiler.is_like_gnu(),
                 is_asm: false,
                 is_arm,
             },
@@ -1366,7 +1364,7 @@ impl Build {
             cmd.env("_LINK_", "-entry:main");
         }
 
-        let output = cmd.output()?;
+        let output = cmd.current_dir(out_dir).output()?;
         let is_supported = output.status.success() && output.stderr.is_empty();
 
         self.build_cache
@@ -1749,8 +1747,6 @@ impl Build {
         let target = self.get_target()?;
         let msvc = target.env == "msvc";
         let compiler = self.try_get_compiler()?;
-        let clang = compiler.is_like_clang();
-        let gnu = compiler.family == ToolFamily::Gnu;
 
         let is_assembler_msvc = msvc && asm_ext == Some(AsmFileExt::DotAsm);
         let mut cmd = if is_assembler_msvc {
@@ -1770,8 +1766,8 @@ impl Build {
                 cuda: self.cuda,
                 is_assembler_msvc,
                 msvc: compiler.is_like_msvc(),
-                clang,
-                gnu,
+                clang: compiler.is_like_clang(),
+                gnu: compiler.is_like_gnu(),
                 is_asm,
                 is_arm,
             },


### PR DESCRIPTION
MSVC was dumping `flag_check.exe` in the crate's root directory whenever `is_flag_supported_inner` was called. This PR changes the cwd of the compiler to be in `out_dir`, adds a local github action to check whether the git working tree is clean, and then uses that action to check that the CI pipelines that produce artifacts haven't dumped anything in the git working tree.

### GitHub Actions and Workflow Improvements:

* [`.github/actions/check-clean-git-working-tree/action.yaml`](diffhunk://#diff-9c611404cbb72ce15c1f6b0a3671448acd23eacca0a49e2eda8d8dbdb2e55cf1R1-R18): Added a new action named "Check Clean Git Working Tree" to verify that the Git working tree is clean.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R201-R203): Integrated the new "Check Clean Git Working Tree" action into various job steps to prevent bugs related to uncommitted changes. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R201-R203) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R242-R244) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R263-R265) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R311-R321) [[5]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R336-R338) [[6]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R375-R377)
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R172-R179): Updated several job steps to use the `${{ runner.temp }}` directory for temporary files. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R172-R179) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L277-R288)

### Codebase Simplification:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1340-R1348): Simplified the `Build` implementation by directly calling methods on the `compiler` object instead of storing their results in temporary variables. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1340-R1348) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1752-L1753) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1773-R1770)
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1369-R1367): Ensured the `cmd` command runs in the `out_dir` directory by using the `current_dir` method.

fixes #1411