### PR TITLE
Fix gen-windows-sys-binding

### DIFF
--- a/dev-tools/gen-windows-sys-binding/src/main.rs
+++ b/dev-tools/gen-windows-sys-binding/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     windows_bindgen::bindgen([
         "--flat",
         "--sys",
-        "--no-core",
+        "--no-deps",
         "--out",
         temp_file.path().to_str().unwrap(),
         "--filter",


### PR DESCRIPTION
--no-core is renamed to --no-deps