### PR TITLE
clang-cl: use `/arch:SSE2` for `x86` target arch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2224,7 +2224,16 @@ impl Build {
                         cmd.push_cc_arg("-m64".into());
                     } else if target.arch == "x86" {
                         cmd.push_cc_arg("-m32".into());
-                        cmd.push_cc_arg("-arch:IA32".into());
+                        // See
+                        // <https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170>.
+                        //
+                        // NOTE: Rust officially supported Windows targets all require SSE2 as part
+                        // of baseline target features.
+                        //
+                        // NOTE: The same applies for STL. See: -
+                        // <https://github.com/microsoft/STL/issues/3922>, and -
+                        // <https://github.com/microsoft/STL/pull/4741>.
+                        cmd.push_cc_arg("-arch:SSE2".into());
                     } else {
                         cmd.push_cc_arg(format!("--target={}", target.llvm_target).into());
                     }


### PR DESCRIPTION
This PR changes the flag emitted for `clang-cl` on `x86` Windows archs to use `/arch:SSE2` instead of `/arch:IA32`[^default-arch] to fix [compilation errors related to missing SSE2 types][wchar-bug] following GitHub Runner Image updates that bumped the MSVC toolchain version.

### Context

- Official Rust Windows targets require `SSE2` as part of baseline target features.
    - `i586` Windows target without SSE2 is in process of being removed, so wasn't changed in this PR.
- STL is built with `/arch:SSE2` and no longer `/arch:IA32` since <https://github.com/microsoft/STL/pull/4741>.
- Relevant for GitHub Runner Image `windows-2022` version `20250224.5.0` and higher.

This was noticed in rust-lang/rust CI for `i686-pc-windows-msvc`, where `rustc_llvm` builds failed because `__m128i` wasn't available, and it seems to be due to emitting `/arch:IA32` for `clang-cl`.

Thanks to Fulgen for noticing this `/arch:IA32` flag!

### Testing

Tested over at https://github.com/rust-lang/rust/pull/137724 with the changes in my branch by changing compiler `cc` to use my branch. It gets us past `rustc_llvm` builds (where it previously failed) but fails at stage 2 cargo because cargo has its own `cc` (and fails on `curl-sys`).

[wchar-bug]: https://developercommunity.visualstudio.com/t/wcharh-from-SDK-100261000-cannot-be/10860122

[^default-arch]: `/arch:SSE2` is now the default instruction set "if no /arch option is specified", see https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170. (Viewed on 2025-02-27).