### PR TITLE
ci: Fix failure from cargo not propagating because of pipe

### DIFF
--- a/.github/workflows/test-rustc-targets.yml
+++ b/.github/workflows/test-rustc-targets.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Test with `RUSTFLAGS=--cfg=rustc_target_test cargo test --lib`
         id: test
         continue-on-error: true # We want to open an issue if it fails
-        run: cargo test --lib 2>&1 | tee test_output.txt
+        run: |
+          set -o pipefail
+          cargo test --lib 2>&1 | tee test_output.txt
         env:
           RUSTFLAGS: --cfg=rustc_target_test
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/cc-rs/pull/1413.

Workflow run in https://github.com/rust-lang/cc-rs/actions/runs/13834048235/job/38704775630, the step fails as expected, but the error isn't visible to GitHub Actions because of the pipe to `tee`.