### PR TITLE
Fix `wasm32-wali-linux-musl` target parsing

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -386,6 +386,9 @@ impl<'a> TargetInfo<'a> {
             // FIXME(madsmtm): Badly named targets `*-linux-android*`,
             // "linux" makes no sense as the vendor name.
             "linux" if os == "android" || os == "androideabi" => "unknown",
+            // FIXME(madsmtm): Fix in `rustc` after
+            // https://github.com/rust-lang/compiler-team/issues/850.
+            "wali" => "unknown",
             // Some Linux distributions set their name as the target vendor,
             // so we have to assume that it can be an arbitary string.
             vendor => vendor,


### PR DESCRIPTION
See https://github.com/rust-lang/cc-rs/issues/1426#issuecomment-2721475424.

Intentionally left out of https://github.com/rust-lang/cc-rs/pull/1413 to allow testing the CI.

(I think this is actually a `rustc` issue, but I will wait 'till after the resolution of https://github.com/rust-lang/compiler-team/issues/850 before I go and fix that).