### PR TITLE
Support compiler prefix `x86_64-linux-musl`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3510,9 +3510,7 @@ impl Build {
                     "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
                         "x86_64-linux-gnu", // rustfmt wrap
                     ]), // explicit None if not found, so caller knows to fall back
-                    "x86_64-unknown-linux-musl" => {
-                        self.find_working_gnu_prefix(&["musl", "x86_64-linux-musl"])
-                    }
+                    "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
                     _ => None,
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3510,7 +3510,9 @@ impl Build {
                     "x86_64-unknown-linux-gnu" => self.find_working_gnu_prefix(&[
                         "x86_64-linux-gnu", // rustfmt wrap
                     ]), // explicit None if not found, so caller knows to fall back
-                    "x86_64-unknown-linux-musl" => Some("musl"),
+                    "x86_64-unknown-linux-musl" => {
+                        self.find_working_gnu_prefix(&["musl", "x86_64-linux-musl"])
+                    }
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
                     _ => None,
                 }


### PR DESCRIPTION
### Motivation
* See: [aws/aws-lc-rs#736](https://github.com/aws/aws-lc-rs/issues/736#issuecomment-2758980258)

### Context
I found that in some (most?) environments, the musl compiler to use for targeting `x86_64-unknown-linux-gnu` is prefixed with `x86_64-linux-musl`. For example, on Ubuntu (AMD64) the [`musl-dev` package](https://packages.ubuntu.com/noble/amd64/musl-dev/filelist) contains `/usr/bin/x86_64-linux-musl-gcc` but it does not contain `/usr/bin/musl-gcc`, which is provided by the [`musl-tools` package](https://packages.ubuntu.com/noble/amd64/musl-tools/filelist). (The [`musl-tools` package](https://packages.ubuntu.com/noble/musl-tools) depend on `musl-dev`.) 

When `musl-tools` is installed, `/usr/bin/musl-gcc` is simply a symlink to the former:
```
❯ file /usr/bin/musl-gcc
/usr/bin/musl-gcc: symbolic link to x86_64-linux-musl-gcc
```

### Change
This adds another compiler prefix (`x86_64-linux-musl`) to check for when building for this target.