### PR TITLE
Remove workaround for `mips64-openwrt-linux-musl` parsing

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -381,8 +381,6 @@ impl<'a> TargetInfo<'a> {
         let vendor = match vendor {
             // esp, esp32, esp32s2 etc.
             vendor if vendor.starts_with("esp") => "espressif",
-            // FIXME(madsmtm): https://github.com/rust-lang/rust/issues/131165
-            "openwrt" => "unknown",
             // FIXME(madsmtm): Badly named targets `*-linux-android*`,
             // "linux" makes no sense as the vendor name.
             "linux" if os == "android" || os == "androideabi" => "unknown",


### PR DESCRIPTION
This was fixed upstream in https://github.com/rust-lang/rust/pull/137836.

Part of https://github.com/rust-lang/cc-rs/issues/1426.