### PR TITLE
Add `flags` method to `cc::Build` for adding multiple flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,19 @@ impl Build {
         self
     }
 
+    /// Add multiple flags to the invocation of the compiler.
+    /// This is equivalent to calling `.flag()` for each item in the iterator.
+    pub fn flags<Iter>(&mut self, flags: Iter) -> &mut Build
+    where
+        Iter: IntoIterator,
+        Iter::Item: AsRef<OsStr>,
+    {
+        for flag in flags {
+            self.flag(flag);
+        }
+        self
+    }
+
     /// Removes a compiler flag that was added by [`Build::flag`].
     ///
     /// Will not remove flags added by other means (default flags,


### PR DESCRIPTION
Closes #1465. Thank you @NobodyXu.

My concerns:

- Should we have some tests?
- Should the `flags` method also handle the case where a single string of flags (e.g., `"flag1 flag2"`) is passed and split it into individual flags? Alternatively, should we delegate this responsibility to an external crate like [shell-words](https://crates.io/crates/shell-words) to handle more complex cases like quoted strings with spaces?