### PR TITLE
make `powerp64` use `powerpc64-linux-gnu` prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3490,7 +3490,7 @@ impl Build {
                     "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                     "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
                     "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
-                    "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                    "powerpc64-unknown-linux-gnu" => Some("powerpc64-linux-gnu"),
                     "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
                     "riscv32i-unknown-none-elf" => self.find_working_gnu_prefix(&[
                         "riscv32-unknown-elf",


### PR DESCRIPTION
It used `powerpc-linux-gnu` before, which is 32-bit powerpc. In rustc, when trying build the standard library for `powerpc64-unknown-linux-gnu`, the incorrect `powerpc-linux-gnu-gcc` compiler was used to link, and obviously that fails:

```
> ./x build library --target powerpc64-unknown-linux-gnu
Building bootstrap
...
error: linking with `powerpc-linux-gnu-gcc` failed: exit status: 1
  |
  = note:  "powerpc-linux-gnu-gcc" "-Wl,--version-script=/tmp/rustcsC80vo/list" "-Wl,--no-undefined-version" "-m64" "/tmp/rustcsC80vo/symbols.o" "<1 object files omitted>" "<sysroot>-std/powerpc64-unknown-linux-gnu/release/deps/std-5e3f803cf58a855e.bzvh7vcwga1qlad606jancys7.rcgu.rmeta" "<1 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/folkertdev/rust/rust/build/x86_64-unknown-linux-gnu/stage1-std/powerpc64-unknown-linux-gnu/release/deps/{libpanic_unwind-1f020338bc1e8af9.rlib,libobject-a75853c156cb0024.rlib,libmemchr-90ff2f4a325a2809.rlib,libaddr2line-2238ab7bf0328d2f.rlib,libgimli-6d21f4f2c28b8c6f.rlib,librustc_demangle-c6511c721e56f8bd.rlib,libstd_detect-2f4797527fccecc7.rlib,libhashbrown-c0196e443c6b6c08.rlib,librustc_std_workspace_alloc-9c564b37efed1e47.rlib,libminiz_oxide-9fae5f49579d30a6.rlib,libadler2-74b2b55096133f12.rlib,libunwind-c02a408dea0e2c54.rlib,libcfg_if-f5607b661baf6d9d.rlib,liblibc-f142b73f2ee4b210.rlib,liballoc-3be94aa799bfe2b3.rlib,librustc_std_workspace_core-1b286e1072b636e8.rlib,libcore-045af9f0029370db.rlib,libcompiler_builtins-bffc26ceadea7fa2.rlib}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcsC80vo/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/powerpc64-unknown-linux-gnu/lib" "-o" "<sysroot>-std/powerpc64-unknown-linux-gnu/release/deps/libstd-5e3f803cf58a855e.so" "-shared" "-Wl,-soname=libstd-5e3f803cf58a855e.so" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-Wl,-z,origin" "-Wl,-rpath,$ORIGIN/../lib"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/lib/gcc-cross/powerpc-linux-gnu/13/../../../../powerpc-linux-gnu/bin/ld: skipping incompatible /usr/lib/gcc-cross/powerpc-linux-gnu/13/../../../../powerpc-linux-gnu/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
          /usr/lib/gcc-cross/powerpc-linux-gnu/13/../../../../powerpc-linux-gnu/bin/ld: skipping incompatible /usr/lib/gcc-cross/powerpc-linux-gnu/13/libgcc.a when searching for -lgcc
          /usr/lib/gcc-cross/powerpc-linux-gnu/13/../../../../powerpc-linux-gnu/bin/ld: cannot find -lgcc: No such file or directory
          collect2: error: ld returned 1 exit status
          

error: could not compile `std` (lib) due to 1 previous error
```

manually adding the following to the `bootstrap.toml` fixed the issue 

```
[target.powerpc64-unknown-linux-gnu]
cc = "powerpc64-linux-gnu-gcc"
cxx = "powerpc64-linux-gnu-g++"
ar = "powerpc64-linux-gnu-ar"
```

Hence I believe that this fix is correct.