### PR TITLE
Also set `SDKROOT` when building apple platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2742,6 +2742,8 @@ impl Build {
 
             cmd.args.push("-isysroot".into());
             cmd.args.push(OsStr::new(&sdk_path).to_owned());
+            cmd.env
+                .push(("SDKROOT".into(), OsStr::new(&sdk_path).to_owned()));
 
             if target.abi == "macabi" {
                 // Mac Catalyst uses the macOS SDK, but to compile against and


### PR DESCRIPTION
This also has the downstream effect of properly setting `CMAKE_OSX_ARCHITECTURES` and `CMAKE_OSX_SYSROOT` automatically for non-macOS apple targets for cmake projects

Picks up where https://github.com/rust-lang/cmake-rs/pull/197 leaves off, obsoletes https://github.com/rust-lang/cmake-rs/pull/244