### PR TITLE
Recognize `mlibc` environment

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -221,6 +221,7 @@ fn parse_envabi(last_component: &str) -> Option<(&str, &str)> {
         "qnx800" => ("nto80", ""),
         "sgx" => ("sgx", ""),
         "threads" => ("threads", ""),
+        "mlibc" => ("mlibc", ""),
 
         // ABIs
         "abi64" => ("", "abi64"),
@@ -463,6 +464,7 @@ mod tests {
             "x86_64-foxkit-linux-musl",
             "arm-poky-linux-gnueabi",
             "x86_64-unknown-moturus",
+            "x86_64-unknown-managarm-mlibc",
         ];
 
         for target in targets {


### PR DESCRIPTION
This PR serves to upstream the mlibc environment so that the `x86_64-unknown-managarm-mlibc` target can be upstreamed into rustc (see rust-lang/rust#123319) after this PR appears in a tagged release (and rustc bumps its cc-rs version for bootstrap).

This is the triple upstreamed into LLVM (as of commit llvm/llvm-project@0f302f38b0014a0018031ffb3cb898fdc7d90880), so no further changed are needed. Running the `rustc_target_test` with a rustc with this and the rustc PR applied succeeds, as do all other tests.