### PR TITLE
Solarish-ish: define _REENTRANT by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ impl Build {
     ///
     /// [`compile`]: struct.Build.html#method.compile
     pub fn new() -> Build {
-        let mut config = Build {
+        Build {
             include_directories: Vec::new(),
             definitions: Vec::new(),
             objects: Vec::new(),
@@ -459,25 +459,7 @@ impl Build {
             shell_escaped_flags: None,
             build_cache: Arc::default(),
             inherit_rustflags: true,
-        };
-        if cfg!(target_os = "solaris") || cfg!(target_os = "illumos") {
-            // On Solaris and illumos, multi-threaded C programs must be built with `_REENTRANT`
-            // defined. This configures headers to define APIs appropriately for multi-threaded
-            // use. This is documented in threads(7), see also https://illumos.org/man/7/threads.
-            //
-            // If C code is compiled without multi-threading support but does use multiple threads,
-            // incorrect behavior may result. One extreme example is that on some systems the
-            // global errno may be at the same address as the process' first thread's errno; errno
-            // clobbering may occur to disastrous effect. Conversely, if _REENTRANT is defined
-            // while it is not actually needed, system headers may define some APIs suboptimally
-            // but will not result in incorrect behavior. Other code *should* be reasonable under
-            // such conditions.
-            //
-            // We're typically building C code to eventually link into a Rust program. Many Rust
-            // programs are multi-threaded in some form. So, set the flag by default.
-            config.define("_REENTRANT", None);
         }
-        config
     }
 
     /// Add a directory to the `-I` or include path for headers
@@ -2499,6 +2481,24 @@ impl Build {
                     }
                 }
             }
+        }
+
+        if target.os == "solaris" || target.os == "illumos" {
+            // On Solaris and illumos, multi-threaded C programs must be built with `_REENTRANT`
+            // defined. This configures headers to define APIs appropriately for multi-threaded
+            // use. This is documented in threads(7), see also https://illumos.org/man/7/threads.
+            //
+            // If C code is compiled without multi-threading support but does use multiple threads,
+            // incorrect behavior may result. One extreme example is that on some systems the
+            // global errno may be at the same address as the process' first thread's errno; errno
+            // clobbering may occur to disastrous effect. Conversely, if _REENTRANT is defined
+            // while it is not actually needed, system headers may define some APIs suboptimally
+            // but will not result in incorrect behavior. Other code *should* be reasonable under
+            // such conditions.
+            //
+            // We're typically building C code to eventually link into a Rust program. Many Rust
+            // programs are multi-threaded in some form. So, set the flag by default.
+            cmd.args.push("-D_REENTRANT".into());
         }
 
         if target.vendor == "apple" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ impl Build {
     ///
     /// [`compile`]: struct.Build.html#method.compile
     pub fn new() -> Build {
-        Build {
+        let mut config = Build {
             include_directories: Vec::new(),
             definitions: Vec::new(),
             objects: Vec::new(),
@@ -459,7 +459,25 @@ impl Build {
             shell_escaped_flags: None,
             build_cache: Arc::default(),
             inherit_rustflags: true,
+        };
+        if cfg!(target_os = "solaris") || cfg!(target_os = "illumos") {
+            // On Solaris and illumos, multi-threaded C programs must be built with `_REENTRANT`
+            // defined. This configures headers to define APIs appropriately for multi-threaded
+            // use. This is documented in threads(7), see also https://illumos.org/man/7/threads.
+            //
+            // If C code is compiled without multi-threading support but does use multiple threads,
+            // incorrect behavior may result. One extreme example is that on some systems the
+            // global errno may be at the same address as the process' first thread's errno; errno
+            // clobbering may occur to disastrous effect. Conversely, if _REENTRANT is defined
+            // while it is not actually needed, system headers may define some APIs suboptimally
+            // but will not result in incorrect behavior. Other code *should* be reasonable under
+            // such conditions.
+            //
+            // We're typically building C code to eventually link into a Rust program. Many Rust
+            // programs are multi-threaded in some form. So, set the flag by default.
+            config.define("_REENTRANT", None);
         }
+        config
     }
 
     /// Add a directory to the `-I` or include path for headers


### PR DESCRIPTION
Descendants of Solaris require `_REENTRANT` to be defined for multi-threaded code. Older systems and systems whose defaults have not yet changed may define some C APIs in a manner that can result in incorrect behavior when used from code with mixed multi-threading support. One example here is that illumos defines `errno` such that `errno` used in a process' first thread happens to be the same `errno` as global `errno`; in https://github.com/oxidecomputer/helios/issues/192 this results in a Tokio panic as it appears that `read()` errored with errno of 0!

Given the prevalence of multi-threaded programs these days, it would be nice for the compilation environment to not need additional flags "basically always." But until illumos' headers are adjusted in this direction, `cc` can at least define `_REENTRANT` as a default for these systems.

(In practice `errno` is probably the only footgun here, and Solaris has moved away from this definition of `erno`. On the illumos side, https://www.illumos.org/issues/13842 intends to improve the default too. Other cases are more subtle, and non-system C code may have `_REENTRANT`-gated multithreaded support. Admitting the default in `cc` helps keep that expectation from having to proliferate across Rust crates configuring `cc` too.)

Concretely, patching `rustup`'s `Cargo.toml` with this builds an executable that thankfully only links to `___errno()` instead of both `___errno()` and `errno`-the-static:
```
root@helios:/rpool/devel/rustup# nm target/debug/rustup-init | grep 'errno$'
[146063]        |            26033952|                   0|FUNC |GLOB |0    |UNDEF  |___errno
```

I've talked with @jclulow about this change but if he'd like to take a look here too, I'd be much obliged :) My use of `target_os = "solaris"` here is untested but the issue should be applicable on Solaris as well, excepting `errno`.

If a user _really_ wants to not have `_REENTRANT`, `CFLAGS="-U_REENTRANT"` should do the trick, but I'll admit I haven't tried that..