### PR TITLE
Add support for recognizing some architectures supported by GCC, but not LLVM.

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -184,6 +184,10 @@ fn parse_arch(full_arch: &str) -> Option<&str> {
         "s390x" => "s390x",
         "xtensa" => "xtensa",
 
+        // Arches supported by gcc, but not LLVM.
+        arch if arch.starts_with("alpha") => "alpha", // DEC Alpha
+        "hppa" => "hppa", // https://en.wikipedia.org/wiki/PA-RISC, also known as HPPA
+        arch if arch.starts_with("sh") => "sh", // SuperH
         _ => return None,
     })
 }


### PR DESCRIPTION
This PR adds support for parsing targets with architectures supported by GCC, but not LLVM. 

I am currently working on adding support for those architectures to `rustc_codegen_gcc` .  Adding full support for those architectures would allow Rust packages to be built for all the platforms [debian supports](https://buildd.debian.org/status/package.php?p=rustc&suite=experimental). 

Since `alpha` and SuperH(`sh`) have multiple variants, I use `starts_with` to detect them, as seems to be the convention. 

The GCC config does not mention any variants of `parisc`, so I just match on that strict. 