### PR TITLE
Refactor: extract compile_objects_sequential

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1819,7 +1819,7 @@ impl Build {
 
         Ok(())
     }
-    
+
     #[cfg(not(feature = "parallel"))]
     fn compile_objects(&self, objs: &[Object]) -> Result<(), Error> {
         check_disabled()?;


### PR DESCRIPTION
Reduce duplicates and just in case if we need to change sequential compilation in the future.