### PR TITLE
[win][arm64ec] Add testing for Arm64EC Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,15 @@ jobs:
             os: windows-11-arm
             rust: stable
             target: aarch64-pc-windows-msvc
+          - build: cross-windows-arm64ec
+            os: windows-latest
+            rust: beta
+            target: arm64ec-pc-windows-msvc
+            no_run: --no-run
+          - build: windows-arm64ec
+            os: windows-11-arm
+            rust: beta
+            target: arm64ec-pc-windows-msvc
           - build: cross-win64
             os: windows-11-arm
             rust: stable

--- a/dev-tools/cc-test/build.rs
+++ b/dev-tools/cc-test/build.rs
@@ -134,6 +134,18 @@ fn main() {
             .arg("/fsrc/NMakefile")
             .env("OUT_DIR", &out)
             .env("CC_FRONTEND", cc_frontend)
+            .env(
+                "EXTRA_CFLAGS",
+                if arch == "arm64ec" { "-arm64EC" } else { "" },
+            )
+            .env(
+                "EXTRA_LIBFLAGS",
+                if arch == "arm64ec" {
+                    "-machine:arm64ec"
+                } else {
+                    ""
+                },
+            )
             .status()
             .unwrap();
         assert!(status.success());

--- a/dev-tools/cc-test/src/NMakefile
+++ b/dev-tools/cc-test/src/NMakefile
@@ -1,14 +1,14 @@
 all: $(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.exe
 
 !IF "$(CC_FRONTEND)" == "MSVC"
-EXTRA_CFLAGS=-nologo
+EXTRA_CFLAGS=$(EXTRA_CFLAGS) -nologo
 CFLAG_OUTPUT=-Fo
 !ELSE
 CFLAG_OUTPUT=-o
 !ENDIF
 
 $(OUT_DIR)/msvc.lib: $(OUT_DIR)/msvc.o
-	lib -nologo -out:$(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.o
+	lib $(EXTRA_LIBFLAGS) -nologo -out:$(OUT_DIR)/msvc.lib $(OUT_DIR)/msvc.o
 
 $(OUT_DIR)/msvc.o: src/msvc.c
 	$(CC) $(EXTRA_CFLAGS) -c $(CFLAG_OUTPUT)$@ src/msvc.c -MD

--- a/dev-tools/cc-test/src/arm64ec.asm
+++ b/dev-tools/cc-test/src/arm64ec.asm
@@ -1,0 +1,8 @@
+    AREA |.text|, CODE, READONLY
+    GLOBAL |#asm|
+    ALIGN 4
+|#asm| PROC
+    mov w0, #7
+    ret
+    ENDP
+    END


### PR DESCRIPTION
* Add a native and cross-build Arm64EC job, using beta as stable doesn't have <https://github.com/rust-lang/rust/pull/143387>.
* Add a dedicated arm64ec.asm test file with correctly mangled names.
* Pass the correct cl and lib flags to the NMake test to build as Arm64EC.