### PR TITLE
Fix gen-windows-sys-binding

### DIFF
--- a/dev-tools/gen-windows-sys-binding/src/main.rs
+++ b/dev-tools/gen-windows-sys-binding/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
         "--filter",
         "--etc",
         &filter,
-    ]);
+    ]).unwrap();
 
     let bindings =
         fs::read_to_string(temp_file.path()).expect("failed to read temp windows_sys.rs");


### PR DESCRIPTION
Unwrap on warning returned by windows_bindgen::bindgen