### PR TITLE
Optimize parse_version in find_tools.rs

### DIFF
--- a/src/windows/find_tools.rs
+++ b/src/windows/find_tools.rs
@@ -633,9 +633,12 @@ mod impl_ {
     // Inspired from official microsoft/vswhere ParseVersionString
     // i.e. at most four u16 numbers separated by '.'
     fn parse_version(version: &str) -> Option<[u16; 4]> {
-        let mut iter = version.split('.').map(|chunk| u16::from_str(chunk)).fuse();
-        let mut get_next_number =
-            move || iter.next().transpose().ok().map(|digit| digit.unwrap_or(0));
+        let mut iter = version.split('.').map(u16::from_str).fuse();
+        let mut get_next_number = move || match iter.next() {
+            Some(Ok(version_part)) => Some(version_part),
+            Some(Err(_)) => None,
+            None => Some(0),
+        };
         Some([
             get_next_number()?,
             get_next_number()?,
@@ -646,7 +649,7 @@ mod impl_ {
 
     pub(super) fn find_msvc_15plus(
         tool: &str,
-        target: TargetArch, cc
+        target: TargetArch,
         env_getter: &dyn EnvGetter,
     ) -> Option<Tool> {
         let iter = vs15plus_instances(target, env_getter)?;


### PR DESCRIPTION
Avoid heap alloc given that it can have at most 4 numbers