### PR TITLE
Fix atomicity violations in concurrent cache operations

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -66,8 +66,12 @@ impl CargoOutput {
     }
 
     pub(crate) fn print_debug(&self, arg: &dyn Display) {
-        if self.metadata && !self.checked_dbg_var.load(Ordering::Relaxed) {
-            self.checked_dbg_var.store(true, Ordering::Relaxed);
+        if self.metadata
+            && self
+                .checked_dbg_var
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
             println!("cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT");
         }
         if self.debug {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4326,9 +4326,8 @@ fn is_disabled() -> bool {
         0 => {
             let truth = compute_is_disabled();
             let encoded_truth = if truth { 2u8 } else { 1 };
-            // Might race against another thread, but we'd both be setting the
-            // same value so it should be fine.
-            CACHE.store(encoded_truth, Relaxed);
+            // Use compare_exchange to avoid race condition
+            let _ = CACHE.compare_exchange(0, encoded_truth, Relaxed, Relaxed);
             truth
         }
         _ => unreachable!(),


### PR DESCRIPTION
Replace load-then-store patterns with atomic compare_exchange operations to eliminate race conditions. 

The changes ensure thread-safe initialization and prevent duplicate operations in multi-threaded scenarios.
