### PR TITLE
Improve ESP microcontroller targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2944,7 +2944,7 @@ impl Build {
                             let cc = if target.abi == "llvm" { clang } else { gnu };
                             format!("{prefix}-{cc}").into()
                         }
-                        None => default.into()
+                        None => default.into(),
                     }
                 } else {
                     default.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3589,10 +3589,10 @@ impl Build {
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
                     "xtensa-esp32-espidf" => Some("xtensa-esp32-elf"),
                     "xtensa-esp32-none-elf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32s2-espidf" => Some("xtensa-esp32s2-elf"),
-                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp32s2-elf"),
-                    "xtensa-esp32s3-espidf" => Some("xtensa-esp32s3-elf"),
-                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp32s3-elf"),
+                    "xtensa-esp32s2-espidf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32s3-espidf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp32-elf"),
                     _ => None,
                 }
                 .map(Cow::Borrowed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3587,12 +3587,12 @@ impl Build {
                         self.find_working_gnu_prefix(&["x86_64-linux-musl", "musl"])
                     }
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
-                    "xtensa-esp32-espidf" => Some("xtensa-esp-elf"),
-                    "xtensa-esp32-none-elf" => Some("xtensa-esp-elf"),
-                    "xtensa-esp32s2-espidf" => Some("xtensa-esp-elf"),
-                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp-elf"),
-                    "xtensa-esp32s3-espidf" => Some("xtensa-esp-elf"),
-                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32-espidf"
+                    | "xtensa-esp32-none-elf"
+                    | "xtensa-esp32s2-espidf"
+                    | "xtensa-esp32s2-none-elf"
+                    | "xtensa-esp32s3-espidf"
+                    | "xtensa-esp32s3-none-elf" => Some("xtensa-esp-elf"),
                     _ => None,
                 }
                 .map(Cow::Borrowed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2944,13 +2944,7 @@ impl Build {
                             let cc = if target.abi == "llvm" { clang } else { gnu };
                             format!("{prefix}-{cc}").into()
                         }
-                        None => {
-                            if raw_target == "xtensa-esp32s3-espidf" {
-                                "xtensa-esp32s3-elf".into()
-                            } else {
-                                default.into()
-                            }
-                        }
+                        None => default.into()
                     }
                 } else {
                     default.into()
@@ -3593,6 +3587,12 @@ impl Build {
                         self.find_working_gnu_prefix(&["x86_64-linux-musl", "musl"])
                     }
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
+                    "xtensa-esp32-espidf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32-none-elf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32s2-espidf" => Some("xtensa-esp32s2-elf"),
+                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp32s2-elf"),
+                    "xtensa-esp32s3-espidf" => Some("xtensa-esp32s3-elf"),
+                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp32s3-elf"),
                     _ => None,
                 }
                 .map(Cow::Borrowed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3587,12 +3587,12 @@ impl Build {
                         self.find_working_gnu_prefix(&["x86_64-linux-musl", "musl"])
                     }
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
-                    "xtensa-esp32-espidf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32-none-elf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32s2-espidf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32s3-espidf" => Some("xtensa-esp32-elf"),
-                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp32-elf"),
+                    "xtensa-esp32-espidf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32-none-elf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32s2-espidf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32s2-none-elf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32s3-espidf" => Some("xtensa-esp-elf"),
+                    "xtensa-esp32s3-none-elf" => Some("xtensa-esp-elf"),
                     _ => None,
                 }
                 .map(Cow::Borrowed)


### PR DESCRIPTION
Targets for _ESP32_, _ESP32-S2_, _ESP32-S3_.

**Note:** _ESP32-C6_ is covered by target `riscv32imac`

**Improves:** #1569