### PR TITLE
Fix building for Mac Catalyst

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -6,7 +6,6 @@ mod generated;
 mod llvm;
 mod parser;
 
-pub(crate) use apple::*;
 pub(crate) use parser::TargetInfoParser;
 
 /// Information specific to a `rustc` target.

--- a/src/target/apple.rs
+++ b/src/target/apple.rs
@@ -1,33 +1,18 @@
 use super::TargetInfo;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) enum AppleEnv {
-    Simulator,
-    MacCatalyst,
-}
-pub(crate) use AppleEnv::*;
-
 impl TargetInfo<'_> {
-    pub(crate) fn get_apple_env(&self) -> Option<AppleEnv> {
-        match (self.env, self.abi) {
-            ("sim", _) | (_, "sim") => Some(Simulator),
-            ("macabi", _) | (_, "macabi") => Some(MacCatalyst),
-            _ => None,
-        }
-    }
-
     pub(crate) fn apple_sdk_name(&self) -> &'static str {
-        match (self.os, self.get_apple_env()) {
-            ("macos", None) => "macosx",
-            ("ios", None) => "iphoneos",
-            ("ios", Some(Simulator)) => "iphonesimulator",
-            ("ios", Some(MacCatalyst)) => "macosx",
-            ("tvos", None) => "appletvos",
-            ("tvos", Some(Simulator)) => "appletvsimulator",
-            ("watchos", None) => "watchos",
-            ("watchos", Some(Simulator)) => "watchsimulator",
-            ("visionos", None) => "xros",
-            ("visionos", Some(Simulator)) => "xrsimulator",
+        match (self.os, self.env) {
+            ("macos", "") => "macosx",
+            ("ios", "") => "iphoneos",
+            ("ios", "sim") => "iphonesimulator",
+            ("ios", "macabi") => "macosx",
+            ("tvos", "") => "appletvos",
+            ("tvos", "sim") => "appletvsimulator",
+            ("watchos", "") => "watchos",
+            ("watchos", "sim") => "watchsimulator",
+            ("visionos", "") => "xros",
+            ("visionos", "sim") => "xrsimulator",
             (os, _) => panic!("invalid Apple target OS {}", os),
         }
     }
@@ -45,19 +30,19 @@ impl TargetInfo<'_> {
         // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mmacos-version-min
         // https://clang.llvm.org/docs/AttributeReference.html#availability
         // https://gcc.gnu.org/onlinedocs/gcc/Darwin-Options.html#index-mmacosx-version-min
-        match (self.os, self.get_apple_env()) {
-            ("macos", None) => format!("-mmacosx-version-min={min_version}"),
-            ("ios", None) => format!("-miphoneos-version-min={min_version}"),
-            ("ios", Some(Simulator)) => format!("-mios-simulator-version-min={min_version}"),
-            ("ios", Some(MacCatalyst)) => format!("-mtargetos=ios{min_version}-macabi"),
-            ("tvos", None) => format!("-mappletvos-version-min={min_version}"),
-            ("tvos", Some(Simulator)) => format!("-mappletvsimulator-version-min={min_version}"),
-            ("watchos", None) => format!("-mwatchos-version-min={min_version}"),
-            ("watchos", Some(Simulator)) => format!("-mwatchsimulator-version-min={min_version}"),
+        match (self.os, self.env) {
+            ("macos", "") => format!("-mmacosx-version-min={min_version}"),
+            ("ios", "") => format!("-miphoneos-version-min={min_version}"),
+            ("ios", "sim") => format!("-mios-simulator-version-min={min_version}"),
+            ("ios", "macabi") => format!("-mtargetos=ios{min_version}-macabi"),
+            ("tvos", "") => format!("-mappletvos-version-min={min_version}"),
+            ("tvos", "sim") => format!("-mappletvsimulator-version-min={min_version}"),
+            ("watchos", "") => format!("-mwatchos-version-min={min_version}"),
+            ("watchos", "sim") => format!("-mwatchsimulator-version-min={min_version}"),
             // `-mxros-version-min` does not exist
             // https://github.com/llvm/llvm-project/issues/88271
-            ("visionos", None) => format!("-mtargetos=xros{min_version}"),
-            ("visionos", Some(Simulator)) => format!("-mtargetos=xros{min_version}-simulator"),
+            ("visionos", "") => format!("-mtargetos=xros{min_version}"),
+            ("visionos", "sim") => format!("-mtargetos=xros{min_version}-simulator"),
             (os, _) => panic!("invalid Apple target OS {}", os),
         }
     }

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -95,13 +95,6 @@ impl TargetInfo<'_> {
             env => env,
         };
         let abi = match self.abi {
-            "sim" => {
-                if env != "simulator" {
-                    "simulator"
-                } else {
-                    ""
-                }
-            }
             "llvm" | "softfloat" | "uwp" | "vec-extabi" => "",
             "ilp32" => "_ilp32",
             "abi64" => "",
@@ -198,8 +191,8 @@ mod tests {
                 arch: "aarch64",
                 vendor: "apple",
                 os: "ios",
-                env: "",
-                abi: "sim",
+                env: "sim",
+                abi: "",
             }
             .llvm_target("aarch64-apple-ios-sim", Some("14.0")),
             "arm64-apple-ios14.0-simulator"


### PR DESCRIPTION
Without this change, we end up passing `aarch64-apple-ios26.0-macabimacabi` to the compiler, which is definitely wrong.

The core change here is to handle this in `from_cargo_environment_variables` as well, the rest is just a cleanup now that `target.env` contains the canonical value (and `target.abi`).

See also the previous https://github.com/rust-lang/cc-rs/pull/1517 and https://github.com/rust-lang/cc-rs/pull/1534.

I really should've checked that this worked in `cc-rs` before landing https://github.com/rust-lang/rust/pull/139451, sorry about that!