### PR TITLE
Add elf abi to ppc64 targets

### DIFF
--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -98,6 +98,7 @@ impl TargetInfo<'_> {
             "llvm" | "softfloat" | "uwp" | "vec-extabi" => "",
             "ilp32" => "_ilp32",
             "abi64" => "",
+            "elfv1" | "elfv2" => "",
             abi => abi,
         };
         Cow::Owned(match (vendor, env, abi) {


### PR DESCRIPTION
Related to the Rust 1.90.0 to "expose elf abi on ppc64 targets": https://github.com/rust-lang/rust/pull/142321

Without this, build (e.g. firefox) fails on powerpc targets with the error message:

	warning: glslopt@0.1.11: clang-20: error: version 'elfv2' in target triple 'powerpc64le-alpine-linux-muslelfv2' is invalid

Closes: https://github.com/rust-lang/cc-rs/issues/1581