### PR TITLE
Allow a "default" environment for the apple_sdk_name function instead of a blank one

### DIFF
--- a/src/target/apple.rs
+++ b/src/target/apple.rs
@@ -3,16 +3,20 @@ use super::TargetInfo;
 impl TargetInfo<'_> {
     pub(crate) fn apple_sdk_name(&self) -> &'static str {
         match (self.os, self.env) {
-            ("macos", "") => "macosx",
-            ("ios", "") => "iphoneos",
+            // The target_env variable, as written here:
+            // https://doc.rust-lang.org/reference/conditional-compilation.html#target_env
+            // is only really used for disambiguation, so we use a "default" case instead of
+            // checking for a blank string.
+            ("macos", _) => "macosx",
             ("ios", "sim") => "iphonesimulator",
             ("ios", "macabi") => "macosx",
-            ("tvos", "") => "appletvos",
+            ("ios", _) => "iphoneos",
             ("tvos", "sim") => "appletvsimulator",
-            ("watchos", "") => "watchos",
+            ("tvos", _) => "appletvos",
             ("watchos", "sim") => "watchsimulator",
-            ("visionos", "") => "xros",
+            ("watchos", _) => "watchos",
             ("visionos", "sim") => "xrsimulator",
+            ("visionos", _) => "xros",
             (os, _) => panic!("invalid Apple target OS {}", os),
         }
     }
@@ -31,18 +35,22 @@ impl TargetInfo<'_> {
         // https://clang.llvm.org/docs/AttributeReference.html#availability
         // https://gcc.gnu.org/onlinedocs/gcc/Darwin-Options.html#index-mmacosx-version-min
         match (self.os, self.env) {
-            ("macos", "") => format!("-mmacosx-version-min={min_version}"),
-            ("ios", "") => format!("-miphoneos-version-min={min_version}"),
+            // The target_env variable, as written here:
+            // https://doc.rust-lang.org/reference/conditional-compilation.html#target_env
+            // is only really used for disambiguation, so we use a "default" case instead of
+            // checking for a blank string.
+            ("macos", _) => format!("-mmacosx-version-min={min_version}"),
             ("ios", "sim") => format!("-mios-simulator-version-min={min_version}"),
             ("ios", "macabi") => format!("-mtargetos=ios{min_version}-macabi"),
-            ("tvos", "") => format!("-mappletvos-version-min={min_version}"),
+            ("ios", _) => format!("-miphoneos-version-min={min_version}"),
             ("tvos", "sim") => format!("-mappletvsimulator-version-min={min_version}"),
-            ("watchos", "") => format!("-mwatchos-version-min={min_version}"),
+            ("tvos", _) => format!("-mappletvos-version-min={min_version}"),
             ("watchos", "sim") => format!("-mwatchsimulator-version-min={min_version}"),
+            ("watchos", _) => format!("-mwatchos-version-min={min_version}"),
             // `-mxros-version-min` does not exist
             // https://github.com/llvm/llvm-project/issues/88271
-            ("visionos", "") => format!("-mtargetos=xros{min_version}"),
             ("visionos", "sim") => format!("-mtargetos=xros{min_version}-simulator"),
+            ("visionos", _) => format!("-mtargetos=xros{min_version}"),
             (os, _) => panic!("invalid Apple target OS {}", os),
         }
     }


### PR DESCRIPTION
The CARGO_CFG_TARGET_ENV variable, as stated here: 

https://doc.rust-lang.org/reference/conditional-compilation.html#target_env

Is only specified for disambiguation, meaning that some platforms specify it themselves to values like "gnu" (Nix's buildRustCrate does this).  Therefore, to prevent failure when the string is not blank, the default case is allowed.