### PR TITLE
Add Visual Studio 2026 support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,8 @@ pub mod windows_registry {
         Vs16,
         /// Visual Studio 17 (2022)
         Vs17,
+        /// Visual Studio 18 (2026)
+        Vs18,
     }
 
     /// Find the most recent installed version of Visual Studio
@@ -326,6 +328,7 @@ pub mod windows_registry {
             ::find_msvc_tools::VsVers::Vs15 => VsVers::Vs15,
             ::find_msvc_tools::VsVers::Vs16 => VsVers::Vs16,
             ::find_msvc_tools::VsVers::Vs17 => VsVers::Vs17,
+            ::find_msvc_tools::VsVers::Vs18 => VsVers::Vs18,
             _ => unreachable!("unknown VS version"),
         })
     }


### PR DESCRIPTION
I wasn't able to test everything, but a patched version of `cmake-rs` is able to build projects using the `Visual Studio 18 2026` generator successfully.