### PR TITLE
Support more of Cargo's debug levels with Build::debug_str

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -63,7 +63,10 @@ fn gnu_debug() {
         .debug(true)
         .file("foo.c")
         .compile("foo");
-    test.cmd(0).must_have("-gdwarf-4");
+    test.cmd(0)
+        .must_have("-g")
+        .must_not_have("-g1")
+        .must_have("-gdwarf-4");
 
     let test = Test::gnu();
     test.gcc()
@@ -71,7 +74,31 @@ fn gnu_debug() {
         .debug(true)
         .file("foo.c")
         .compile("foo");
-    test.cmd(0).must_have("-gdwarf-2");
+    test.cmd(0)
+        .must_have("-g")
+        .must_not_have("-g1")
+        .must_have("-gdwarf-2");
+}
+
+#[test]
+fn gnu_debug_limited() {
+    let test = Test::gnu();
+    test.gcc().debug_str("limited").file("foo.c").compile("foo");
+    test.cmd(0).must_not_have("-g").must_have("-g1");
+}
+
+#[test]
+fn gnu_debug_none() {
+    let test = Test::gnu();
+    test.gcc().debug_str("none").file("foo.c").compile("foo");
+    test.cmd(0).must_not_have("-g").must_not_have("-g1");
+}
+
+#[test]
+fn gnu_debug_unknown() {
+    let test = Test::gnu();
+    test.gcc().debug_str("99").file("foo.c").compile("foo");
+    test.cmd(0).must_have("-g").must_not_have("-g1");
 }
 
 #[test]


### PR DESCRIPTION
...at least when using GCC or Clang. (MSVC doesn't seem to have a `-g1` equivalent from a cursory search, and I'm not an MSVC expert. This can always be improved later.)

I modeled this after the handling for optimization levels, making sure not to break the existing `debug` and `get_debug` functionality.

There are two cases where this will behave differently from before (besides the cases that now produce `-g1`):
- `"none"` is now treated as "no debug info" in addition to `"0"` and `"false"` and `""`, for consistency with Cargo
- If the `DEBUG` environment variable is set, but its contents are not valid UTF-8, we now produce "no debug info". Previously that would count as "include debug info" for being non-empty. I don't expect this to break anyone in practice; it certainly won't ever happen from a Cargo build script.

I could not figure out how to test the special case of `-gline-directives-only`, which is supported by Clang and *not* GCC; the test utility's `gnu` mode doesn't have a way to force one or the other. It seems unlikely to be a problem, but if someone can describe the right test incantation I can add it!

Fixes #1622.