### PR TITLE
Fix: Make warnings(false) actually suppress compiler warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1997,9 +1997,21 @@ impl Build {
         // CFLAGS/CXXFLAGS, since those variables presumably already contain
         // the desired set of warnings flags.
         let envflags = self.envflags(if self.cpp { "CXXFLAGS" } else { "CFLAGS" })?;
-        if self.warnings.unwrap_or(envflags.is_none()) {
-            let wflags = cmd.family.warnings_flags().into();
-            cmd.push_cc_arg(wflags);
+        match self.warnings {
+            Some(true) => {
+                let wflags = cmd.family.warnings_flags().into();
+                cmd.push_cc_arg(wflags);
+            }
+            Some(false) => {
+                let wflags = cmd.family.warnings_suppression_flags().into();
+                cmd.push_cc_arg(wflags);
+            }
+            None => {
+                if envflags.is_none() {
+                    let wflags = cmd.family.warnings_flags().into();
+                    cmd.push_cc_arg(wflags);
+                }
+            }
         }
         if self.extra_warnings.unwrap_or(envflags.is_none()) {
             if let Some(wflags) = cmd.family.extra_warnings_flags() {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -566,6 +566,13 @@ impl ToolFamily {
         }
     }
 
+    pub(crate) fn warnings_suppression_flags(&self) -> &'static str {
+        match *self {
+            ToolFamily::Msvc { .. } => "-W0",
+            ToolFamily::Gnu | ToolFamily::Clang { .. } => "-w",
+        }
+    }
+
     /// What the flags to enable extra warnings
     pub(crate) fn extra_warnings_flags(&self) -> Option<&'static str> {
         match *self {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -174,6 +174,14 @@ fn gnu_warnings() {
 }
 
 #[test]
+fn gnu_warnings_disabled() {
+    let test = Test::gnu();
+    test.gcc().warnings(false).file("foo.c").compile("foo");
+
+    test.cmd(0).must_have("-w").must_not_have("-Wall");
+}
+
+#[test]
 fn gnu_extra_warnings0() {
     reset_env();
 
@@ -200,7 +208,10 @@ fn gnu_extra_warnings1() {
         .file("foo.c")
         .compile("foo");
 
-    test.cmd(0).must_not_have("-Wall").must_have("-Wextra");
+    test.cmd(0)
+        .must_have("-w")
+        .must_not_have("-Wall")
+        .must_have("-Wextra");
 }
 
 #[test]
@@ -531,6 +542,14 @@ fn msvc_std_c() {
     test.gcc().file("foo.c").std("c11").compile("foo");
 
     test.cmd(0).must_have("-std:c11");
+}
+
+#[test]
+fn msvc_warnings_disabled() {
+    let test = Test::msvc();
+    test.gcc().warnings(false).file("foo.c").compile("foo");
+
+    test.cmd(0).must_have("-W0").must_not_have("-W4");
 }
 
 // Disable this test with the parallel feature because the execution


### PR DESCRIPTION
Fixes #283

`warnings(false)` now actually suppresses compiler warnings instead of doing nothing.

Previously, calling `warnings(false)` didn't add any flags, so the compiler still showed warnings.

Now it actively adds `-w` (GCC/Clang) or `-W0` (MSVC) to properly disable them. No more needing the `.flag("-Wno-all")` workaround