### PR TITLE
Fix tool existence check in find_tool method

### DIFF
--- a/find-msvc-tools/src/find_tools.rs
+++ b/find-msvc-tools/src/find_tools.rs
@@ -420,7 +420,7 @@ mod impl_ {
     impl SdkInfo {
         fn find_tool(&self, tool: &str) -> Option<PathBuf> {
             self.path.iter().map(|p| p.join(tool)).find_map(|mut p| {
-                (p.exists() || (p.set_extension(env::consts::EXE_EXTENSION) && p.exists()))
+                (p.exists() || (p.set_extension(env::consts::EXE_SUFFIX) && p.exists()))
                     .then_some(p)
             })
         }


### PR DESCRIPTION
Use EXE_SUFFIX instead of EXE_EXTENSIONS