### PR TITLE
Add missing RISC-V targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3592,8 +3592,18 @@ impl Build {
                         "riscv64-unknown-elf",
                         "riscv-none-embed",
                     ]),
+                    "riscv32im-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
                     "riscv32imac-esp-espidf" => Some("riscv32-esp-elf"),
                     "riscv32imac-unknown-none-elf" => self.find_working_gnu_prefix(&[
+                        "riscv32-unknown-elf",
+                        "riscv64-unknown-elf",
+                        "riscv-none-embed",
+                    ]),
+                    "riscv32imafc-unknown-none-elf" => self.find_working_gnu_prefix(&[
                         "riscv32-unknown-elf",
                         "riscv64-unknown-elf",
                         "riscv-none-embed",
@@ -3620,6 +3630,7 @@ impl Build {
                         "riscv-none-embed",
                     ]),
                     "riscv64gc-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
+                    "riscv64a23-unknown-linux-gnu" => Some("riscv64-linux-gnu"),
                     "riscv32gc-unknown-linux-gnu" => Some("riscv32-linux-gnu"),
                     "riscv64gc-unknown-linux-musl" => Some("riscv64-linux-musl"),
                     "riscv32gc-unknown-linux-musl" => Some("riscv32-linux-musl"),


### PR DESCRIPTION
This adds a few currently missing targets as mentioned in https://github.com/rust-lang/cc-rs/issues/1654.

However, long-term this matching of target names should be replaced with proper handling of target specification like I suggest in https://github.com/rust-lang/cc-rs/issues/1654#issuecomment-3746741694, so that this ever growing list will be easier to maintain and many new targets will be picked up automatically over time.

The list also has random order for some reason, but I didn't touch it to not increase the diff unnecessarily.