### PR TITLE
Fix x86_64-unknown-linux-gnuasan parsing

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -449,7 +449,6 @@ impl<'a> TargetInfo<'a> {
             abi = "";
         }
 
-
         Ok(Self {
             full_arch,
             arch,


### PR DESCRIPTION
The abi should be empty for this target

Fix https://github.com/rust-lang/cc-rs/issues/1426#issuecomment-3783980154