### PR TITLE
Disable PIC for armv7-sony-vita-newlibeabihf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2127,6 +2127,7 @@ impl Build {
                     target.os != "windows"
                         && target.os != "none"
                         && target.os != "uefi"
+                        && target.os != "vita"
                         && target.arch != "wasm32"
                         && target.arch != "wasm64",
                 ) {


### PR DESCRIPTION
PIC is not compatible with vitasdk (the required toolchain). It is also not used by rustc, as [defined in the target](https://github.com/rust-lang/rust/blob/e96bb7e44fbcc23c1e6009e8d0ee8ab208668fb4/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs#L44)