### PR TITLE
add `-fsanitize=...` flag if sanitizer is enabled in rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2026,6 +2026,12 @@ impl Build {
             self.add_inherited_rustflags(&mut cmd, &target)?;
         }
 
+        if let Some(sanitizer) = self.getenv("CARGO_CFG_SANITIZE") {
+            let mut sanitizer_flag = OsString::from("-fsanitize=");
+            sanitizer_flag.push(sanitizer);
+            cmd.args.push(sanitizer_flag);
+        }
+
         // Set flags configured in the builder (do this second-to-last, to allow these to override
         // everything above).
         for flag in self.flags.iter() {


### PR DESCRIPTION
resolves #1666 

I tried this mainly using ASAN. It works for me on gnu linux using `clang` and `gcc`. It triggers when the `x86_64-unknown-linux-gnuasan` target is used, and also when `RUSTFLAGS="-Z sanitizer=address"` is set.

I don't know this crate well, so I am unsure about a few things:

1. Where is the correct place in the source code to put this?
2. Hopefully `CARGO_CFG_SANITIZE` is only set on targets, that support a specific sanitizer. Does this mean, there are no additional checks of the target necessary?
3. Especially with MSVC I have no idea if this would work or what would need to be changed
4. Should it be this general (just passing the sanitizer string to the C compiler) or should it be more like a whitelist (for example enabling it only for asan and then extending it in the future)?