### PR TITLE
fix(ar): suppress warnings from `D` modifier probe

### DIFF
--- a/src/bin/cc-shim.rs
+++ b/src/bin/cc-shim.rs
@@ -84,6 +84,14 @@ fn main() -> ExitCode {
         }
     }
 
+    // Allow tests to make the shim fail when a specific arg is present.
+    if let Some(fail_arg) = env::var("CC_SHIM_FAIL_IF_ARG").ok() {
+        if args.clone().any(|a| a == &fail_arg) {
+            eprintln!("{program}: simulated failure for arg '{fail_arg}'");
+            return ExitCode::FAILURE;
+        }
+    }
+
     // Create a file used by some tests.
     let path = &out_dir.join("libfoo.a");
     File::create(path).unwrap_or_else(|e| {

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -345,6 +345,39 @@ pub(crate) fn run(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<(), E
     wait_on_child(cmd, &mut child, cargo_output)
 }
 
+/// Like [`run`], but stderr is only forwarded as `cargo:warning=` when the
+/// command succeeds. On failure, stderr is silently discarded.
+///
+/// Useful for probe commands where failure is expected and the error
+/// message is not actionable.
+pub(crate) fn run_silent_on_error(
+    cmd: &mut Command,
+    cargo_output: &CargoOutput,
+) -> Result<(), Error> {
+    let Output {
+        status,
+        stdout: _,
+        stderr,
+    } = spawn_and_wait_for_output(cmd, cargo_output)?;
+
+    cargo_output.print_debug(&status);
+
+    if status.success() {
+        if cargo_output.warnings {
+            stderr
+                .split(|&b| b == b'\n')
+                .filter(|line| !line.is_empty())
+                .for_each(write_warning);
+        }
+        Ok(())
+    } else {
+        Err(Error::new(
+            ErrorKind::ToolExecError,
+            format!("command did not execute successfully (status code {status}): {cmd:?}"),
+        ))
+    }
+}
+
 pub(crate) fn spawn_and_wait_for_output(
     cmd: &mut Command,
     cargo_output: &CargoOutput,

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -366,6 +366,7 @@ pub(crate) fn run_silent_on_error(
         if cargo_output.warnings {
             stderr
                 .split(|&b| b == b'\n')
+                .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
                 .filter(|line| !line.is_empty())
                 .for_each(write_warning);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2746,7 +2746,7 @@ impl Build {
                     run(ar.arg("sD").arg(dst), &self.cargo_output)?;
                 }
                 None => {
-                    if run(ar.arg("sD").arg(dst), &self.cargo_output).is_err() {
+                    if run_silent_on_error(ar.arg("sD").arg(dst), &self.cargo_output).is_err() {
                         let mut ar = self.try_get_archiver()?;
                         ar.env("ZERO_AR_DATE", "1");
                         run(ar.arg("s").arg(dst), &self.cargo_output)?;
@@ -2822,7 +2822,9 @@ impl Build {
                 }
                 None => {
                     // Probe: try `D` and remember the result for later batches.
-                    if run(cmd.arg("cqD").arg(dst).args(objs), &self.cargo_output).is_ok() {
+                    if run_silent_on_error(cmd.arg("cqD").arg(dst).args(objs), &self.cargo_output)
+                        .is_ok()
+                    {
                         *deterministic_ar = Some(true);
                     } else {
                         *deterministic_ar = Some(false);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1101,8 +1101,8 @@ fn gnu_ar_probe_failure_no_warning() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     // The shim writes "simulated failure for arg 'cqD'" to stderr on probe failure.
     assert!(
-        stdout.contains("simulated failure"),
-        "expected probe stderr to be forwarded, got:\n{}",
+        !stdout.contains("simulated failure"),
+        "probe stderr should not appear as cargo:warning=, got:\n{}",
         stdout
     );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::disallowed_methods)]
 
+use std::env;
+use std::process::Command;
+
 use crate::support::Test;
 
 mod support;
@@ -1054,4 +1057,52 @@ fn gnu_ar_deterministic_flag() {
 
     test.cmd(1).must_have("cqD");
     test.cmd(2).must_have("sD");
+}
+
+#[test]
+fn gnu_ar_deterministic_flag_fallback() {
+    let test = Test::gnu();
+    test.gcc()
+        .env("CC_SHIM_FAIL_IF_ARG", "cqD")
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_have("foo.c");
+    test.cmd(1).must_have("cqD");
+    // fallback to `ar cq` without D
+    test.cmd(2).must_have("cq").must_not_have("cqD");
+    test.cmd(3).must_have("s").must_not_have("sD");
+}
+
+/// Stderr from a failed `ar D` probe
+/// should not be forwarded as `cargo:warning=`.
+///
+/// This test runs the build in a subprocess so we
+/// can capture and assert on the actual stdout output.
+#[test]
+fn gnu_ar_probe_failure_no_warning() {
+    // When invoked as subprocess, perform the build and return.
+    if env::var_os("__CC_TEST_AR_PROBE_STDERR").is_some() {
+        let test = Test::gnu();
+        test.gcc()
+            .env("CC_SHIM_FAIL_IF_ARG", "cqD")
+            .file("foo.c")
+            .compile("foo");
+        return;
+    }
+
+    let output = Command::new(env::current_exe().unwrap())
+        .env("__CC_TEST_AR_PROBE_STDERR", "1")
+        .args(["--exact", "gnu_ar_probe_failure_no_warning", "--nocapture"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "subprocess failed: {:?}", output);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The shim writes "simulated failure for arg 'cqD'" to stderr on probe failure.
+    assert!(
+        stdout.contains("simulated failure"),
+        "expected probe stderr to be forwarded, got:\n{}",
+        stdout
+    );
 }


### PR DESCRIPTION
On macOS, the system `ar` doesn't support the `D` modifier. It causes `illegal option -- D` to be emitted as `cargo:warning=` during the probe.

Add a `run_silent_on_error()` helper that buffers stderr and only forwards it when the command succeeds.

Repro script:

```bash
#!/usr/bin/env bash
# Reproduce the "illegal option -- D" cargo:warning= issue on macOS.
# Requires macOS system ar (which does not support the D modifier).
set -euo pipefail

DIR=$(mktemp -d)
trap 'rm -rf "$DIR"' EXIT

mkdir -p "$DIR/src"

cat > "$DIR/Cargo.toml" <<'TOML'
[package]
name = "cc-repro"
version = "0.0.0"
edition = "2021"

[build-dependencies]
#cc = { path = "/path/local/cc-rs" }
cc = "=1.2.59"
TOML

echo 'fn main() {}' > "$DIR/src/main.rs"
echo 'void foo(void) {}' > "$DIR/foo.c"
echo 'fn main() { cc::Build::new().file("foo.c").compile("foo"); }' > "$DIR/build.rs"

echo "==> Building in $DIR ..."
cd "$DIR"
OUTPUT=$(cargo build 2>&1)

if echo "$OUTPUT" | grep -qi "illegal option"; then
    echo "BUG: found spurious 'illegal option' warning:"
    echo "$OUTPUT" | grep -i "illegal option"
    exit 1
else
    echo "OK: no spurious warnings."
fi
```

Address <https://github.com/rust-lang/cc-rs/pull/1697#issuecomment-4189000198>