### PR TITLE
CI: Hash-pin all actions, apply other suggestions from zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  cooldown:
+    default-days: 7
 - package-ecosystem: cargo
   directory: "/"
   schedule:
     interval: daily
     time: "08:00"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   test:
     name: Test
@@ -158,6 +160,8 @@ jobs:
             CXX: clang-cl
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: curl -vv https://static.rust-lang.org/dist/channel-rust-1.87.0.toml.sha256
         shell: bash
       - name: Install Rust (rustup)
@@ -217,8 +221,10 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: startsWith(matrix.build, 'windows-clang')
 
-      - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
         if: ${{ ! matrix.no_run }}
+        with:
+          tool: cargo-nextest
 
       - run: cargo update
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -240,6 +246,8 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+         with:
+           persist-credentials: false
        - name: Install Rust (rustup)
          run: |
            set -euxo pipefail
@@ -247,7 +255,9 @@ jobs:
            rustup default stable
          shell: bash
 
-       - uses: taiki-e/install-action@cargo-nextest
+       - uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
+         with:
+           tool: cargo-nextest
 
        - run: cargo update
        - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -285,6 +295,8 @@ jobs:
           - aarch64-apple-visionos-sim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust (rustup)
         run: |
           set -euxo pipefail
@@ -309,6 +321,8 @@ jobs:
         target: [wasm32-unknown-unknown]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust (rustup)
         run: |
           rustup target add ${{ matrix.target }}
@@ -335,6 +349,8 @@ jobs:
       TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust (rustup)
         run: |
           rustup toolchain install nightly --no-self-update --profile minimal --target $TARGET
@@ -379,6 +395,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install cuda-minimal-build-11-8
         working-directory: ${{ runner.temp }}
         shell: bash
@@ -390,7 +408,9 @@ jobs:
           sudo apt-get -y install cuda-minimal-build-11-8
           echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
       - run: cargo update
-      - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Test 'cudart' feature
         shell: bash
@@ -412,6 +432,8 @@ jobs:
       MSRV: 1.63.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: |
           rustup toolchain install $MSRV --no-self-update --profile minimal
@@ -429,6 +451,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: |
           rustup toolchain install stable --no-self-update --profile minimal --component clippy
@@ -445,6 +469,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: |
           rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
@@ -458,6 +484,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
             CC: clang-cl
             CXX: clang-cl
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: curl -vv https://static.rust-lang.org/dist/channel-rust-1.87.0.toml.sha256
         shell: bash
       - name: Install Rust (rustup)
@@ -214,14 +214,14 @@ jobs:
           UPPERCASE_TARGET_NAME=$(echo "${{ matrix.target }}" | tr '[:lower:]-' '[:upper:]_')
           echo "CARGO_TARGET_${UPPERCASE_TARGET_NAME}_LINKER=rust-lld" >> $GITHUB_ENV
       - name: setup dev environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: startsWith(matrix.build, 'windows-clang')
 
       - uses: taiki-e/install-action@cargo-nextest
         if: ${{ ! matrix.no_run }}
 
       - run: cargo update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Compile tests but not run
         if: matrix.no_run
         run: |
@@ -239,7 +239,7 @@ jobs:
      name: Test linker-plugin-lto
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v6
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
        - name: Install Rust (rustup)
          run: |
            set -euxo pipefail
@@ -250,7 +250,7 @@ jobs:
        - uses: taiki-e/install-action@cargo-nextest
 
        - run: cargo update
-       - uses: Swatinem/rust-cache@v2
+       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
        - run: |
            cargo nextest run --workspace --release
          env:
@@ -284,7 +284,7 @@ jobs:
           - aarch64-apple-visionos
           - aarch64-apple-visionos-sim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust (rustup)
         run: |
           set -euxo pipefail
@@ -293,7 +293,7 @@ jobs:
           rustup default nightly
         shell: bash
       - run: cargo update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }}
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --release
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }} --features parallel
@@ -308,13 +308,13 @@ jobs:
       matrix:
         target: [wasm32-unknown-unknown]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust (rustup)
         run: |
           rustup target add ${{ matrix.target }}
         shell: bash
       - run: cargo update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --no-run --target ${{ matrix.target }}
       - run: cargo test --no-run --target ${{ matrix.target }} --release
       - run: cargo test --no-run --target ${{ matrix.target }} --features parallel
@@ -334,7 +334,7 @@ jobs:
     env:
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust (rustup)
         run: |
           rustup toolchain install nightly --no-self-update --profile minimal --target $TARGET
@@ -362,7 +362,7 @@ jobs:
           echo "WASI_SDK_PATH=$WASI_SDK_PATH" >> "$GITHUB_ENV"
 
       - run: cargo update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           env-vars: "WASI_TOOLCHAIN_VERSION"
           cache-all-crates: "true"
@@ -378,7 +378,7 @@ jobs:
     name: Test CUDA support
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install cuda-minimal-build-11-8
         working-directory: ${{ runner.temp }}
         shell: bash
@@ -391,7 +391,7 @@ jobs:
           echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
       - run: cargo update
       - uses: taiki-e/install-action@cargo-nextest
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Test 'cudart' feature
         shell: bash
         run: |
@@ -411,7 +411,7 @@ jobs:
     env:
       MSRV: 1.63.0
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust
         run: |
           rustup toolchain install $MSRV --no-self-update --profile minimal
@@ -420,7 +420,7 @@ jobs:
         shell: bash
       - name: Create Cargo.lock with minimal version
         run: cargo +nightly update -Zminimal-versions
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: env -u CARGO_REGISTRIES_CRATES_IO_PROTOCOL cargo check --lib -p cc --locked
       - run: env -u CARGO_REGISTRIES_CRATES_IO_PROTOCOL cargo check --lib -p cc --locked --all-features
 
@@ -428,13 +428,13 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust
         run: |
           rustup toolchain install stable --no-self-update --profile minimal --component clippy
           rustup default stable
         shell: bash
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo clippy --no-deps
       # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
       - name: check clean Git workting tree
@@ -444,22 +444,22 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust
         run: |
           rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
           rustup default stable
         shell: bash
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt -- --check
 
   semver-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:
           release-type: minor
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish release
 
-permissions:
-  pull-requests: write
-  contents: write
-  id-token: write     # Required for OIDC token exchange
+permissions: {}
 
 on:
   push:
@@ -16,13 +13,20 @@ jobs:
     name: Release-plz release
     runs-on: ubuntu-latest
     environment: publish
+    permissions:
+      pull-requests: write
+      contents: write
+      id-token: write     # Required for OIDC token exchange
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - name: Run release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,13 @@ jobs:
     environment: publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release
         env:

--- a/.github/workflows/regenerate-target-info.yml
+++ b/.github/workflows/regenerate-target-info.yml
@@ -10,11 +10,16 @@ on:
     paths:
       - 'dev-tools/gen-target-info/**'
 
+permissions: {}
+
 jobs:
   regenerate:
     if: github.repository_owner == 'rust-lang'
     name: Regenerate target info & Open Pull Request if necessary
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/regenerate-target-info.yml
+++ b/.github/workflows/regenerate-target-info.yml
@@ -16,7 +16,7 @@ jobs:
     name: Regenerate target info & Open Pull Request if necessary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 
@@ -32,7 +32,7 @@ jobs:
       - name: Create lockfile
         run: cargo update
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-all-crates: 'true'
       - name: Regenerate target info

--- a/.github/workflows/regenerate-windows-sys.yml
+++ b/.github/workflows/regenerate-windows-sys.yml
@@ -10,11 +10,16 @@ on:
     paths:
       - 'dev-tools/gen-windows-sys-binding/**'
 
+permissions: {}
+
 jobs:
   regenerate:
     if: github.repository_owner == 'rust-lang'
     name: Regenerate windows sys bindings & Open Pull Request if necessary
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/regenerate-windows-sys.yml
+++ b/.github/workflows/regenerate-windows-sys.yml
@@ -16,7 +16,7 @@ jobs:
     name: Regenerate windows sys bindings & Open Pull Request if necessary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 
@@ -27,7 +27,7 @@ jobs:
       - name: Create lockfile
         run: cargo update
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-all-crates: 'true'
       

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,8 +1,6 @@
 name: Create release PR
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: {}
 
 on:
   workflow_dispatch: # Allow running on-demand
@@ -16,13 +14,19 @@ jobs:
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: true
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - name: Run release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,13 +18,13 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
         env:

--- a/.github/workflows/test-rustc-targets.yml
+++ b/.github/workflows/test-rustc-targets.yml
@@ -10,10 +10,14 @@ on:
     paths:
       - 'src/target/**'
 
+permissions: {}
+
 jobs:
   rustc_target_test:
     if: github.repository_owner == 'rust-lang'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to add issue comment
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-rustc-targets.yml
+++ b/.github/workflows/test-rustc-targets.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'rust-lang'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 
@@ -24,7 +24,7 @@ jobs:
           rustup toolchain install nightly --no-self-update --profile minimal
           rustup default nightly
       - run: cargo update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Test with `RUSTFLAGS=--cfg=rustc_target_test cargo test --lib`
         id: test


### PR DESCRIPTION
Hello! Apologies for the cold PR.

I'm opening this in my capacity as one of [uv](https://github.com/astral-sh/uv)'s maintainers; we have a set of downstreams (including `cc`!) that we depend on, and we'd like to ensure their CI/CD processes are as hermetic and secure as possible (within the limits of GitHub's platform).

To that effect, this PR contains a few different commits that aim to make `cc`'s CI more secure. None of these changes fix _vulnerabilities_; they're purely defense-in-depth changes that will make a future [Trivy-style compromise](https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack) less fruitful for an attacker. 

To summarize:

- I've hash-pinned all of your action dependencies with `pinact run -v`. Dependabot will keep these action references up to date (and will bump the version comments too), so this shouldn't add any additional maintenance burden.
- I've enabled [cooldowns](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) on your Dependabot ecosystem groups, to reduce the "window of opportunity" for compromise if/when a downstream of `cc`'s is compromised.
- I've disabled `actions/checkout`'s default credential-persistence behavior with `persist-credentials: false`, where possible. You have a few workflows that intentionally push back to the repo (or create issues/PRs), so for those workflows I've ensured that `persist-credentials: true` is explicitly set.
- I've dropped your default `permissions` to `{}`, wherever possible. I've also moved all non-empty permissions into their respective jobs rather than setting them at the entire workspace level.

_Most_ of the above was detected automatically with [zizmor](https://docs.zizmor.sh), which you can [integrate](https://docs.zizmor.sh/integrations/#github-actions) into GitHub Actions if you'd like. I've left that out of this PR however, since not every project wants another thing running in CI. But let me know if you'd like it and I'd be happy to send a follow-up PR!

Last but not least, please let me know if there's any other information I can provide. All of the above was 100% human written and reviewed 🙂 