### PR TITLE
command_helpers.rs: fix `OutputKind::Capture` documentation

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -34,7 +34,7 @@ pub(crate) enum OutputKind {
     Forward,
     /// Discard the output ([`Stdio::null()`])
     Discard,
-    /// Capture the result (`[Stdio::piped()`])
+    /// Capture the result ([`Stdio::piped()`])
     Capture,
 }
 


### PR DESCRIPTION
Either both backticks should be inside of the brackets, or neither; go with both to match the other enum variants