### PR TITLE
Add relibc env and linux relibc cross targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3447,6 +3447,7 @@ impl Build {
                     "aarch64-uwp-windows-gnu" => Some("aarch64-w64-mingw32"),
                     "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
                     "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+                    "aarch64-unknown-linux-relibc" => Some("aarch64-linux-relibc"),
                     "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
                     "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
                     "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
@@ -3559,6 +3560,9 @@ impl Build {
                     ]), // explicit None if not found, so caller knows to fall back
                     "x86_64-unknown-linux-musl" => {
                         self.find_working_gnu_prefix(&["x86_64-linux-musl", "musl"])
+                    }
+                    "x86_64-unknown-linux-relibc" => {
+                        self.find_working_gnu_prefix(&["x86_64-linux-relibc", "relibc"])
                     }
                     "x86_64-unknown-netbsd" => Some("x86_64--netbsd"),
                     _ => None,

--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -222,6 +222,7 @@ fn parse_envabi(last_component: &str) -> Option<(&str, &str)> {
         "sgx" => ("sgx", ""),
         "threads" => ("threads", ""),
         "mlibc" => ("mlibc", ""),
+        "relibc" => ("relibc", ""),
 
         // ABIs
         "abi64" => ("", "abi64"),


### PR DESCRIPTION
Relibc, a libc primarily for Redox OS is another libc that also works on Linux. It's mainly for experimentation in the past, but some shows up interest to port it for linux, or other smaller OSes. This adds support for `target_env = "relibc"` and compiling the Rust std library for it.

Sources:

- [PoC for building the GCC and Rust toolchain](https://gitlab.redox-os.org/redox-os/redox/-/merge_requests/2063)
- [The tracking issue](https://gitlab.redox-os.org/redox-os/redox/-/issues/1798)
- [Evidence that it's used by libc crate](https://github.com/rust-lang/libc/blob/95c957237dcad9096ba26d712ca3e3aacc16e8de/src/new/mod.rs#L162)
