### PR TITLE
target: recognize sh4 architecture in parse_arch()

### DIFF
--- a/src/target/parser.rs
+++ b/src/target/parser.rs
@@ -168,6 +168,7 @@ fn parse_arch(full_arch: &str) -> Option<&str> {
         arch if arch.starts_with("nvptx") => "nvptx",
 
         arch if arch.starts_with("bpf") => "bpf", // bpfeb | bpfel
+        arch if arch.starts_with("sh4") => "sh4", // sh4 | sh4-unknown-linux-gnu | sh4-unknown-redox
 
         // https://github.com/bytecodealliance/wasmtime/tree/v30.0.1/pulley
         arch if arch.starts_with("pulley64") => "pulley64",


### PR DESCRIPTION
SH4 (SuperH) is a real Rust target tier 3 — both `sh4-unknown-linux-gnu` and `sh4-unknown-redox` are in upstream rustc as of 1.79+ — but `parse_arch()` doesn't recognise the `sh4` prefix, so any C-touching crate compiled against an sh4-* target fails at config time:

```
error occurred in cc-rs: target `sh4-unknown-redox` had an unknown architecture
```

Adding the one-line arm here matches the existing convention for similar small soft-float architectures (mips, loongarch, riscv, bpf). SH4 has no architecture-specific compile-flag adjustments needed in cc-rs (no \`-march\` or similar), so normalising the arch name is sufficient.

## Test plan

Tested via the navhack-org/RustXToolchain SH4 cross-compilation toolchain build (rust-src + LLVM-from-source with SuperH target enabled). End-to-end:

- \`x.py build --stage 1 library --target sh4-unknown-redox\` succeeds without manual cargo-registry patches.
- Resulting toolchain compiles \`rustnav-broker\` (a real downstream crate; SH4 ELF, 6.6 MB) end-to-end.

Without this arm, the bootstrap fails immediately during config-time target resolution with the error shown above. Historic mitigation in our build pipeline was to manually patch the cargo-registry copy of cc-rs's parser.rs after every fresh checkout — this PR retires that workaround.

## Out of scope

No flag adjustments — SH4 is mostly a soft-float target (single-precision FPU only); the C compile flags from \`gcc-sh4-*\` are sufficient as-is. Any future SH4-specific tuning (e.g. \`-m4-single-only\`) can be added as a follow-up if needed.