### PR TITLE
Add support for `aarch64-unknown-linux-pauthtest` target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1669,6 +1669,14 @@ impl Build {
                     ));
                 }
             }
+            // Pauthtest needs LLVM's libc++, libc++abi provided by the sysroot.
+            if target.abi == "pauthtest" {
+                let pauthtest_sysroot = self.pauthtest_sysroot()?;
+                self.cargo_output.print_metadata(&format_args!(
+                    "cargo:rustc-flags=-L {}/lib -lc++ -lc++abi",
+                    Path::new(&pauthtest_sysroot).display(),
+                ));
+            }
         }
 
         let cudart = match &self.cudart {
@@ -2280,6 +2288,34 @@ impl Build {
                             format!("--sysroot={}", Path::new(&musl_sysroot).display()).into(),
                         );
                         cmd.push_cc_arg("-pthread".into());
+                    } else if target.abi == "pauthtest" {
+                        let pauthtest_sysroot = self.pauthtest_sysroot()?;
+                        let pauthtest_resource_dir = self.pauthtest_resource_dir()?;
+                        cmd.push_cc_arg(
+                            format!("--sysroot={}", Path::new(&pauthtest_sysroot).display()).into(),
+                        );
+                        cmd.push_cc_arg(
+                            format!(
+                                "-resource-dir={}",
+                                Path::new(&pauthtest_resource_dir).display()
+                            )
+                            .into(),
+                        );
+                        cmd.push_cc_arg("-march=armv8.3-a+pauth".into());
+                        if self.cpp && self.cpp_set_stdlib.is_none() {
+                            cmd.push_cc_arg("-stdlib=libc++".into());
+                            cmd.push_cc_arg(
+                                format!(
+                                    "-I{}/include/c++/v1",
+                                    Path::new(&pauthtest_sysroot).display()
+                                )
+                                .into(),
+                            );
+
+                            cmd.push_cc_arg(
+                                format!("-L{}/lib", Path::new(&pauthtest_sysroot).display()).into(),
+                            );
+                        }
                     }
                     // Pass `--target` with the LLVM target to configure Clang for cross-compiling.
                     //
@@ -2987,7 +3023,7 @@ impl Build {
             // and many modern illumos distributions today ship GCC as "gcc" without
             // also making it available as "cc".
             Cow::Borrowed(Path::new(gnu))
-        } else if self.prefer_clang() {
+        } else if self.prefer_clang() || target.abi == "pauthtest" {
             self.which(Path::new(clang), None)
                 .map(Cow::Owned)
                 .unwrap_or(fallback)
@@ -3218,6 +3254,23 @@ impl Build {
                 .print_warning(&"GNU compiler is not supported for this target");
         }
 
+        if target.abi == "pauthtest" {
+            match tool.family {
+                ToolFamily::Clang { .. } => {}
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::ToolNotFound,
+                        format!(
+                            "target '{}' requires a Clang-based toolchain, but found {:?} ({})",
+                            raw_target,
+                            tool.family,
+                            tool.path.display()
+                        ),
+                    ));
+                }
+            }
+        }
+
         Ok(tool)
     }
 
@@ -3336,6 +3389,7 @@ impl Build {
                         || target.os == "aix"
                         || (target.os == "linux" && target.env == "ohos")
                         || target.os == "wasi"
+                        || target.abi == "pauthtest"
                     {
                         Ok(Some(Cow::Borrowed(Path::new("c++"))))
                     } else if target.os == "android" {
@@ -4366,6 +4420,36 @@ impl Build {
         }
 
         clang.into()
+    }
+
+    fn pauthtest_sysroot(&self) -> Result<OsString, Error> {
+        if let Some(pauthtest_sysroot) = self.get_env("PAUTHTEST_SYSROOT") {
+            Ok(pauthtest_sysroot)
+        } else {
+            let target = self.get_raw_target()?;
+            Err(Error::new(
+                ErrorKind::EnvVarNotFound,
+                format!(
+                    "Environment variable PAUTHTEST_SYSROOT not defined for the {} target. Please consult target's platform support document for instructions on how to obtain the sysroot and then setup the environment variable PAUTHTEST_SYSROOT.",
+                    target
+                ),
+            ))
+        }
+    }
+
+    fn pauthtest_resource_dir(&self) -> Result<OsString, Error> {
+        if let Some(pauthtest_resource_dir) = self.get_env("PAUTHTEST_RESOURCE_DIR") {
+            Ok(pauthtest_resource_dir)
+        } else {
+            let target = self.get_raw_target()?;
+            Err(Error::new(
+                ErrorKind::EnvVarNotFound,
+                format!(
+                    "Environment variable PAUTHTEST_RESOURCE_DIR not defined for the {} target. Please consult target's platform support document for instructions on how to obtain the sysroot and then setup the environment variable PAUTHTEST_RESOURCE_DIR.",
+                    target
+                ),
+            ))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1599,6 +1599,12 @@ impl Build {
         self.assemble(lib_name, &dst.join(gnu_lib_name), &objects)?;
 
         let target = self.get_target()?;
+        if target.abi == "pauthtest" {
+            self.cargo_output.print_warning(
+                &"cc-rs should not be used with `pauthtest` target: it only builds \
+                static libraries, while `pauthtest` requires shared objects.",
+            );
+        }
         if target.env == "msvc" {
             let compiler = self.get_base_compiler()?;
             let atlmfc_lib = compiler

--- a/src/target/llvm.rs
+++ b/src/target/llvm.rs
@@ -21,6 +21,13 @@ impl TargetInfo<'_> {
         if rustc_target == "armv7-apple-ios" {
             // FIXME(madsmtm): Unnecessary once we bump MSRV to Rust 1.74
             return Cow::Borrowed("armv7-apple-ios");
+        } else if rustc_target == "aarch64-unknown-linux-pauthtest" {
+            // `aarch64-unknown-linux-pauthtest` rustc target sets both
+            // environment and abi (to `musl` and `pauthtest` respectively`).
+            // However, the abi field exists mainly for `cfg(...)` evaluation in
+            // Rust, not for generating the actual LLVM triple. The logic of:
+            // `arch-vendor-os-env+abi` does not applay here.
+            return Cow::Borrowed("aarch64-unknown-linux-pauthtest");
         } else if self.os == "uefi" {
             // Override the UEFI LLVM targets.
             //


### PR DESCRIPTION
This PR adds support for `aarch64-unknown-linux-pauthtest`, a target that enables Pointer Authentication Code (PAC) support in Rust on AArch64 ELF based Linux systems. It uses the `aarch64-unknown-linux-pauthtest` LLVM target and a pointer-authentication-enabled sysroot with a custom [musl](https://github.com/access-softek/musl) as a reference libc implementation. Dynamic linking is required, with a dynamic linker acting as the ELF interpreter that can resolve pauth relocations and enforce pointer authentication constraints.

Please note, that while `cc-rs` is able to compile c/c++ sources and link against the target binary successfully this is not sufficient for `aarch64-unknown-linux-pauthtest`. The target has a hard requirement on shared objects and dynamic linker must be used. This seems to be incompatible with the [current state](https://github.com/jchlanda/cc-rs/blob/dd545adfde3725e876257f9113f651e36de14fb4/src/lib.rs#L795) of `cc-rs`.


Please consult a rust-lang PR for the details on the target: https://github.com/rust-lang/rust/pull/155722