### PR TITLE
Allow exceptions on wasm platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2161,15 +2161,6 @@ impl Build {
                         cmd.push_cc_arg("-fno-plt".into());
                     }
                 }
-                if target.arch == "wasm32" || target.arch == "wasm64" {
-                    // WASI does not support exceptions yet.
-                    // https://github.com/WebAssembly/exception-handling
-                    //
-                    // `rustc` also defaults to (currently) disable exceptions
-                    // on all WASM targets:
-                    // <https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_target/src/spec/base/wasm.rs#L72-L77>
-                    cmd.push_cc_arg("-fno-exceptions".into());
-                }
 
                 if target.os == "wasi" {
                     // Link clang sysroot


### PR DESCRIPTION
## Content

WASM now supports exceptions.
Remove the hardcoded `-fno-exceptions` option.

Resolves #1680

## Discussion

Should we remain compatible with programs that rely on the old behavior of the library? Should we keep the old behavior as default, and add a function that will allow the user to select between, e.g., `-fno-exceptions`, `-fwasm-exceptions`, and `-fexceptions`?