### PR TITLE
apply LDFLAGS env var to compiler commands as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@
 //! * `CFLAGS` - a series of space separated flags passed to compilers. Note that
 //!   individual flags cannot currently contain spaces, so doing
 //!   something like: `-L=foo\ bar` is not possible.
+//! * `LDFLAGS` - similar to CFLAGS, usually contains additional arguments to linker,
+//!   but through compiler driver command line. It will be appended after CFLAGS
 //! * `CC` - the actual C compiler used. Note that this supports passing a known
 //!   wrapper via `sccache cc`. This compiler must understand the `-c` flag. For
 //!   certain `TARGET`s, it also is assumed to know about other flags (most

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2012,7 +2012,19 @@ impl Build {
         // then we set them only if the environment doesn't already have
         // CFLAGS/CXXFLAGS, since those variables presumably already contain
         // the desired set of warnings flags.
-        let envflags = self.envflags(if self.cpp { "CXXFLAGS" } else { "CFLAGS" })?;
+        let envflags = {
+            let compiler_env_flags = self.envflags(if self.cpp { "CXXFLAGS" } else { "CFLAGS" })?;
+            let ldflags = self.envflags("LDFLAGS")?;
+            match (compiler_env_flags, ldflags) {
+                (Some(mut a), Some(b)) => {
+                    a.extend(b);
+                    Some(a)
+                }
+                (None, None) => None,
+                (x @ Some(_), None) | (None, x @ Some(_)) => x,
+            }
+        };
+
         match self.warnings {
             Some(true) => {
                 let wflags = cmd.family.warnings_flags().into();


### PR DESCRIPTION
LDFLAGS is also used in similar environment to pass additional flags to linker, something like 

```
LDFLAGS="--target=x86_64-unknown-linux-gnu -no-canonical-prefixes -lm -fuse-ld=lld -Wl,--build-id=md5 -Wl,--hash-style=gnu -Wl,-z,relro,-z,now -l:libstdc++.a --sysroot=....."
```

this PR makes LDFLAGS  part of envflags so link flags also included