### PR TITLE
feat: inherit path remap rules from cargo trim-paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,11 @@ struct CompilerFlag {
     flag: Box<OsStr>,
 }
 
+enum PrefixMapFlag {
+    Macro,
+    Debug,
+}
+
 #[derive(Debug, Default)]
 struct BuildCache {
     apple_sdk_root_cache: RwLock<HashMap<Box<str>, Arc<OsStr>>>,
@@ -2083,7 +2088,7 @@ impl Build {
 
         // Add path remap flags inherited from cargo's `-Ztrim-paths`.
         if self.inherit_trim_paths {
-            self.add_trim_paths_flags(&mut cmd)?;
+            self.add_trim_paths_flags(&mut cmd, &target)?;
         }
 
         // Set flags configured in the builder (do this second-to-last, to allow these to override
@@ -2702,7 +2707,7 @@ impl Build {
     /// Translate cargo's `-Ztrim-paths` remap rules into compiler flags.
     ///
     /// [`trim-paths`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option
-    fn add_trim_paths_flags(&self, cmd: &mut Tool) -> Result<(), Error> {
+    fn add_trim_paths_flags(&self, cmd: &mut Tool, target: &TargetInfo<'_>) -> Result<(), Error> {
         // MSVC has no equivalent of the `-f*-prefix-map` flag family.
         // Left out until there is demand for it.
         if cmd.is_like_msvc() {
@@ -2744,6 +2749,12 @@ impl Build {
                 _ => {}
             }
         }
+
+        let macro_scope =
+            macro_scope && self.probe_prefix_map_flag(PrefixMapFlag::Macro, cmd, target);
+        let object_scope =
+            object_scope && self.probe_prefix_map_flag(PrefixMapFlag::Debug, cmd, target);
+
         if !macro_scope && !object_scope {
             return Ok(());
         }
@@ -2765,6 +2776,45 @@ impl Build {
             }
         }
         Ok(())
+    }
+
+    /// Check if `-f*-prefix-map` flag is supported.
+    ///
+    /// * `-fdebug-prefix-map`: supported since GCC 4.3 (2008-03), Clang 3.8 (2016-03):
+    ///   * <https://gcc.gnu.org/onlinedocs/gcc-4.3.0/gcc/Debugging-Options.html>
+    ///   * <https://github.com/llvm/llvm-project/commit/436256a71316a1e6ad68ebee8439c88d75>
+    /// * `-fmacro-prefix-map`: supported since GCC 8.1 (2018-05), Clang 10.0 (2020-03)
+    ///   * <https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Option-Summary.html>
+    ///   * <https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html>
+    fn probe_prefix_map_flag(
+        &self,
+        flag: PrefixMapFlag,
+        cmd: &Tool,
+        target: &TargetInfo<'_>,
+    ) -> bool {
+        let (flag, unsupported_warning) = match flag {
+            PrefixMapFlag::Macro => (
+                "-fmacro-prefix-map",
+                "paths embedded by macros will not be remapped",
+            ),
+            PrefixMapFlag::Debug => (
+                "-fdebug-prefix-map",
+                "paths embedded in debug info will not be remapped",
+            ),
+        };
+        let probe = format!("{flag}=/probe=/probe");
+        let supported = self
+            .is_flag_supported_inner(OsStr::new(&probe), cmd, target)
+            .unwrap_or(false);
+
+        if !supported {
+            self.cargo_output.print_warning(&format_args!(
+                "{flag} is not supported by {:?}, {unsupported_warning}",
+                cmd.path()
+            ));
+        }
+
+        supported
     }
 
     fn msvc_macro_assembler(&self) -> Result<Command, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,7 @@ pub struct Build {
     shell_escaped_flags: Option<bool>,
     build_cache: Arc<BuildCache>,
     inherit_rustflags: bool,
+    inherit_trim_paths: bool,
     prefer_clang_cl_over_msvc: bool,
 }
 
@@ -549,6 +550,7 @@ impl Build {
             shell_escaped_flags: None,
             build_cache: Arc::default(),
             inherit_rustflags: true,
+            inherit_trim_paths: true,
             prefer_clang_cl_over_msvc: false,
         }
     }
@@ -1380,6 +1382,29 @@ impl Build {
         self
     }
 
+    /// Configure whether cc should automatically inherit path remap rules
+    /// from cargo's [`trim-paths`] profile setting,
+    /// and translate them into `-fmacro-prefix-map`/ `-fdebug-prefix-map` flags.
+    ///
+    /// This option defaults to `true`.
+    ///
+    /// This option doesn't support Windows MSVC cl.exe yet.
+    /// Only clang and GCC are supported.
+    ///
+    /// <div class="warning">
+    ///
+    /// [`trim-paths`] is currently an unstable cargo feature,
+    /// only available on nightly with `-Ztrim-paths`.
+    /// The contract around this option may change as the cargo feature evolves.
+    ///
+    /// </div>
+    ///
+    /// [`trim-paths`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option
+    pub fn inherit_trim_paths(&mut self, inherit_trim_paths: bool) -> &mut Build {
+        self.inherit_trim_paths = inherit_trim_paths;
+        self
+    }
+
     /// Prefer to use clang-cl over msvc.
     ///
     /// This option defaults to `false`.
@@ -1495,6 +1520,7 @@ impl Build {
                 .cpp(self.cpp)
                 .cuda(self.cuda)
                 .inherit_rustflags(false)
+                .inherit_trim_paths(false)
                 .emit_rerun_if_env_changed(self.emit_rerun_if_env_changed);
             if let Some(target) = &self.target {
                 cfg.target(target);
@@ -2053,6 +2079,11 @@ impl Build {
         // Add cc flags inherited from matching rustc flags.
         if self.inherit_rustflags {
             self.add_inherited_rustflags(&mut cmd, &target)?;
+        }
+
+        // Add path remap flags inherited from cargo's `-Ztrim-paths`.
+        if self.inherit_trim_paths {
+            self.add_trim_paths_flags(&mut cmd)?;
         }
 
         // Set flags configured in the builder (do this second-to-last, to allow these to override
@@ -2665,6 +2696,74 @@ impl Build {
         let env = env_os.to_string_lossy();
         let codegen_flags = RustcCodegenFlags::parse(&env)?;
         codegen_flags.cc_flags(self, cmd, target);
+        Ok(())
+    }
+
+    /// Translate cargo's `-Ztrim-paths` remap rules into compiler flags.
+    ///
+    /// [`trim-paths`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option
+    fn add_trim_paths_flags(&self, cmd: &mut Tool) -> Result<(), Error> {
+        // MSVC has no equivalent of the `-f*-prefix-map` flag family.
+        // Left out until there is demand for it.
+        if cmd.is_like_msvc() {
+            return Ok(());
+        }
+        let scope = match cargo_env_var_os("CARGO_TRIM_PATHS_SCOPE") {
+            Some(scope) => scope,
+            None => return Ok(()),
+        };
+        let remap = match cargo_env_var_os("CARGO_TRIM_PATHS_REMAP") {
+            Some(remap) => remap,
+            None => return Ok(()),
+        };
+
+        // * `macro` scope -> `-fmacro-prefix-map`
+        // * `object` scope -> `-fmacro-prefix-map` + `-fdebug-prefix-map`
+        // * `all` scope -> both
+        // * `diagnostics` and `none` scopes have no C equivalent
+        let mut macro_scope = false;
+        let mut object_scope = false;
+        for scope in scope.to_string_lossy().split(',') {
+            match scope {
+                "all" => {
+                    macro_scope = true;
+                    object_scope = true;
+                    break;
+                }
+                // `__FILE__` and friends
+                "macro" => macro_scope = true,
+                // Everything embedded in object files.
+                // rustc defines this scope as macro + debuginfo.
+                // Both `__FILE__` strings and debug info end up in the object,
+                // so the C analogue must remap both as well.
+                "object" => {
+                    macro_scope = true;
+                    object_scope = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        if !macro_scope && !object_scope {
+            return Ok(());
+        }
+
+        for pair in env::split_paths(&remap) {
+            let pair = pair.as_os_str();
+            if pair.is_empty() {
+                continue;
+            }
+            if macro_scope {
+                let mut flag = OsString::from("-fmacro-prefix-map=");
+                flag.push(pair);
+                cmd.push_cc_arg(flag);
+            }
+            if object_scope {
+                let mut flag = OsString::from("-fdebug-prefix-map=");
+                flag.push(pair);
+                cmd.push_cc_arg(flag);
+            }
+        }
         Ok(())
     }
 

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -1,0 +1,139 @@
+//! Tests for inheriting path remap from cargo's unstable `-Ztrim-paths` feature.
+//!
+//! This test is in its own module because it modifies the environment and
+//! would affect other tests when run in parallel with them.
+
+// Windows only beccause `-f*-prefix-map` flag family is GNU/Clang-only anyway.
+// If needed, Windows support will be added in the future.
+#![cfg(not(windows))]
+
+mod support;
+
+use crate::support::Test;
+
+// `<from>=<to>` pairs as cargo passes them (`;` on Windows though not supported in cc-rs yet)
+
+const REMAP: &str =
+    "/path/to/pkg=foo-0.1.0:/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef";
+
+const MACRO_FLAGS: &[&str] = &[
+    "-fmacro-prefix-map=/path/to/pkg=foo-0.1.0",
+    "-fmacro-prefix-map=/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef",
+];
+
+const OBJECT_FLAGS: &[&str] = &[
+    "-fdebug-prefix-map=/path/to/pkg=foo-0.1.0",
+    "-fdebug-prefix-map=/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef",
+];
+
+#[test]
+fn scope_all() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag);
+    }
+}
+
+#[test]
+fn scope_macro() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "macro");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS {
+        cmd.must_not_have(flag);
+    }
+    for flag in OBJECT_FLAGS {
+        cmd.must_not_have(flag);
+    }
+}
+
+#[test]
+fn scope_object() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "object");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in OBJECT_FLAGS {
+        cmd.must_not_have(flag);
+    }
+    for flag in MACRO_FLAGS {
+        cmd.must_not_have(flag);
+    }
+}
+
+/// `diagnostics` has no C compiler equivalent; combined with `macro` only
+/// the macro remap flags apply.
+#[test]
+fn scope_macro_and_diagnostics() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "diagnostics,macro");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS {
+        cmd.must_not_have(flag);
+    }
+    for flag in OBJECT_FLAGS {
+        cmd.must_not_have(flag);
+    }
+}
+
+/// `none` disables path sanitization; no remap flags should ever be emitted.
+#[test]
+fn scope_none() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "none");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag);
+    }
+}
+
+/// Without the cargo-provided env vars nothing is emitted.
+#[test]
+fn no_env_vars() {
+    let mut test = Test::gnu();
+    test.env.remove("CARGO_TRIM_PATHS_SCOPE");
+    test.env.remove("CARGO_TRIM_PATHS_REMAP");
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag);
+    }
+}
+
+/// `Build::inherit_trim_paths(false)` opts out of the inheritance.
+#[test]
+fn opt_out() {
+    let mut test = Test::gnu();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag);
+    }
+}

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -36,7 +36,7 @@ fn scope_all() {
 
     let cmd = test.cmd(0);
     for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
-        cmd.must_not_have(flag);
+        cmd.must_have(flag);
     }
 }
 
@@ -50,7 +50,7 @@ fn scope_macro() {
 
     let cmd = test.cmd(0);
     for flag in MACRO_FLAGS {
-        cmd.must_not_have(flag);
+        cmd.must_have(flag);
     }
     for flag in OBJECT_FLAGS {
         cmd.must_not_have(flag);
@@ -67,10 +67,10 @@ fn scope_object() {
 
     let cmd = test.cmd(0);
     for flag in OBJECT_FLAGS {
-        cmd.must_not_have(flag);
+        cmd.must_have(flag);
     }
     for flag in MACRO_FLAGS {
-        cmd.must_not_have(flag);
+        cmd.must_have(flag);
     }
 }
 
@@ -86,7 +86,7 @@ fn scope_macro_and_diagnostics() {
 
     let cmd = test.cmd(0);
     for flag in MACRO_FLAGS {
-        cmd.must_not_have(flag);
+        cmd.must_have(flag);
     }
     for flag in OBJECT_FLAGS {
         cmd.must_not_have(flag);
@@ -130,7 +130,10 @@ fn opt_out() {
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
     test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
 
-    test.gcc().file("foo.c").compile("foo");
+    test.gcc()
+        .inherit_trim_paths(false)
+        .file("foo.c")
+        .compile("foo");
 
     let cmd = test.cmd(0);
     for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {


### PR DESCRIPTION
### What this is for

Fixes <https://github.com/rust-lang/cc-rs/issues/593>

Cargo with `-Ztrim-paths` feature would set
`CARGO_TRIM_PATHS_SCOPE` and `CARGO_TRIM_PATHS_REMAP` for build scripts,
so they can forward path remaps to C/C++ compilers.

* `macro` scope -> `-fmacro-prefix-map` (`__FILE__` and friends)
* `object` scope -> `-fdebug-prefix-map` (debug info)
* `all` scope -> both
* `diagnostics` and `none` scopes have no C equivalent

MSVC is skipped as it has no equivalent flag family.
It seems to have an undocumented `/pathmap` though,
see bazelbuild/bazel#9466

This is inherited by default. Rationale:

* Mirroring `inherit_rustflags`
* The env vars only exist when the user opted into Cargo profile trim-paths.
* It is easy to opt-out from user. Cargo only looks at your local
  package's profile, and you can also do a per-dependency profile
  override.

Do note again this is nightly only feature from Cargo's point of view,
so I put a warning in the doc comment.


See also <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option>

### How to review

Commit by commit.
The first one capture the current behavior.
Subsequent commits show the behavior change through the diff.

I have a cargo `-Zscript` repro you can run against master or this PR:

<details><summary>repro script</summary>
<p>

```rust
#!/usr/bin/env -S cargo +nightly -Zscript
---
[package]
edition = "2024"
---

//! End-to-end repro: cargo `-Ztrim-paths` -> cc path remap inheritance.
//!
//! Put this under the cc-rs repo root and run it.
//!
//! - `__FILE__` carrier: absolute `.file()` + `debug = false`
//!   -> trimmed by `-fmacro-prefix-map` (scopes `macro`, `object`, `all`)
//! - DWARF carrier: relative `.file()` + `debug = true`
//!   (`DW_AT_comp_dir` embeds the build-script cwd)
//!   -> trimmed by `-fdebug-prefix-map` (scopes `object`, `all`);
//!   `macro` must leave it EMBEDDED, mirroring rustc scope semantics.

use std::path::{Path, PathBuf};
use std::process::Command;
use std::{env, fs};

fn main() {
    let cc_root = env::current_dir().unwrap();
    assert!(
        fs::read_to_string("Cargo.toml")
            .unwrap_or_default()
            .contains("name = \"cc\""),
        "run this from the cc-rs repo root"
    );

    let work = env::temp_dir().join(format!("cc-trim-e2e-{}", std::process::id()));
    let _ = fs::remove_dir_all(&work);
    fs::create_dir_all(&work).unwrap();
    // cargo's remap pairs use canonical paths,
    // and prefix remapping is plain string matching.
    let work = work.canonicalize().unwrap();
    let abs = work.display().to_string();

    let mut ok = true;
    for dwarf in [false, true] {
        eprintln!("== {} carrier ==", if dwarf { "DWARF" } else { "__FILE__" });
        for scope in ["all", "object", "macro", "none"] {
            // `none` trims nothing; `macro` does not touch debug info.
            let expect = scope == "none" || (dwarf && scope == "macro");
            let archive = build(&cc_root, &work, dwarf, scope);
            let found = contains(&archive, abs.as_bytes());
            let emb = |b| if b { "EMBEDDED" } else { "absent" };
            eprintln!(
                "trim-paths = {scope:8}: absolute path {:8} (expected {})",
                emb(found),
                emb(expect)
            );
            if found != expect {
                ok = false;
            }
        }
    }

    let _ = fs::remove_dir_all(&work);
    if !ok {
        eprintln!(
            "\nFAIL (does this cc checkout have trim-paths inheritance,\n\
             and does this cargo set CARGO_TRIM_PATHS_* for build scripts?)"
        );
        std::process::exit(1);
    }
    eprintln!("\nOK: cc inherited cargo's trim-paths remap end to end");
}

/// Scaffold a package
///
/// * `build.rs` compiles `hello.c` through this cc checkout
/// * `cargo build`
/// * return the built archive bytes
fn build(cc_root: &Path, work: &Path, dwarf: bool, scope: &str) -> Vec<u8> {
    let pkg = work.join(format!("pkg-{}-{scope}", u8::from(dwarf)));
    fs::create_dir_all(pkg.join("src")).unwrap();
    // Absolute `.file()` makes `__FILE__` carry the absolute path; a
    // relative one leaves only DWARF (`DW_AT_comp_dir` = cwd) carrying it.
    let src = if dwarf {
        PathBuf::from("src/hello.c")
    } else {
        pkg.join("src/hello.c")
    };
    fs::write(
        pkg.join("Cargo.toml"),
        format!(
            r#"cargo-features = ["trim-paths"]

[package]
name = "trim-repro"
edition = "2021"

[build-dependencies]
cc = {{ path = "{}" }}

[profile.dev]
trim-paths = "{scope}"
debug = {dwarf}
"#,
            cc_root.display()
        ),
    )
    .unwrap();
    fs::write(
        pkg.join("build.rs"),
        format!(
            "fn main() {{ cc::Build::new().file(r\"{}\").compile(\"hello\"); }}\n",
            src.display()
        ),
    )
    .unwrap();
    fs::write(pkg.join("src/lib.rs"), "").unwrap();
    fs::write(
        pkg.join("src/hello.c"),
        "const char *embedded = __FILE__;\nconst char *get(void) { return embedded; }\n",
    )
    .unwrap();

    let out = Command::new("cargo")
        .args(["+nightly", "build", "-Ztrim-paths"])
        .current_dir(&pkg)
        .output()
        .unwrap();
    assert!(
        out.status.success(),
        "cargo build failed:\n{}",
        String::from_utf8_lossy(&out.stderr)
    );

    fs::read_dir(pkg.join("target/debug/build"))
        .unwrap()
        .find_map(|e| {
            let a = e.ok()?.path().join("out/libhello.a");
            a.exists().then(|| fs::read(a).unwrap())
        })
        .expect("no libhello.a produced")
}

fn contains(hay: &[u8], needle: &[u8]) -> bool {
    hay.windows(needle.len()).any(|w| w == needle)
}
```


</p>
</details> 

### Note

~I don't know if this is a known issue,~
~but the flag-support probe (`is_flag_supported_inner`) doesn't inherit env vars from parent or `Build::env`.~
~This would result in a different invocation from the real compile.~
~For example you may set `CC="zig cc"`,~
~and `zig cc` may support less flags than latest gcc/clang.~

See <https://github.com/rust-lang/cc-rs/pull/1794#issuecomment-5009715734>