### PR TITLE
feat: support trim paths with clang-cl.exe

### DIFF
--- a/src/bin/cc-shim.rs
+++ b/src/bin/cc-shim.rs
@@ -15,10 +15,22 @@ fn main() -> ExitCode {
     let mut args = args.iter();
     let program = args.next().expect("Unexpected empty args");
 
-    let out_dir = PathBuf::from(
-        env::var_os("CC_SHIM_OUT_DIR")
-            .unwrap_or_else(|| panic!("{}: CC_SHIM_OUT_DIR not found", program)),
-    );
+    let out_dir = env::var_os("CC_SHIM_OUT_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            // Flag probes use a fresh `Build`, so they don't inherit the
+            // test-only `CC_SHIM_OUT_DIR`. `is_flag_supported_inner` runs
+            // them with `out_dir` as their working directory, so we can
+            // record their arguments there.
+            //
+            // We only use this fallback for `-c` the compile-only flag probe
+            // in this flow. Family detection uses `-E` without `-c` and
+            // it must keep failing.
+            args.clone()
+                .any(|arg| arg == "-c")
+                .then(|| env::current_dir().expect("failed to get probe working directory"))
+        })
+        .unwrap_or_else(|| panic!("{}: CC_SHIM_OUT_DIR not found", program));
 
     // Find the first nonexistent candidate file to which the program's args can be written.
     let candidate = (0..).find_map(|i| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2708,9 +2708,9 @@ impl Build {
     ///
     /// [`trim-paths`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option
     fn add_trim_paths_flags(&self, cmd: &mut Tool, target: &TargetInfo<'_>) -> Result<(), Error> {
-        // MSVC has no equivalent of the `-f*-prefix-map` flag family.
-        // Left out until there is demand for it.
-        if cmd.is_like_msvc() {
+        // Native MSVC has no documented equivalent of the `-f*-prefix-map` flag family.
+        // clang-cl parses Clang driver options when wrapped in `/clang:`.
+        if cmd.is_like_msvc() && !cmd.is_like_clang_cl() {
             return Ok(());
         }
         let scope = match cargo_env_var_os("CARGO_TRIM_PATHS_SCOPE") {
@@ -2759,18 +2759,28 @@ impl Build {
             return Ok(());
         }
 
+        // clang-cl parses Clang driver options when wrapped in `/clang:`.
+        // <https://clang.llvm.org/docs/UsersManual.html#the-clang-option>
+        let clang_driver = if cmd.is_like_clang_cl() {
+            "/clang:"
+        } else {
+            ""
+        };
+
         for pair in env::split_paths(&remap) {
             let pair = pair.as_os_str();
             if pair.is_empty() {
                 continue;
             }
             if macro_scope {
-                let mut flag = OsString::from("-fmacro-prefix-map=");
+                let mut flag = OsString::from(clang_driver);
+                flag.push("-fmacro-prefix-map=");
                 flag.push(pair);
                 cmd.push_cc_arg(flag);
             }
             if object_scope {
-                let mut flag = OsString::from("-fdebug-prefix-map=");
+                let mut flag = OsString::from(clang_driver);
+                flag.push("-fdebug-prefix-map=");
                 flag.push(pair);
                 cmd.push_cc_arg(flag);
             }
@@ -2801,6 +2811,13 @@ impl Build {
                 "-fdebug-prefix-map",
                 "paths embedded in debug info will not be remapped",
             ),
+        };
+        // clang-cl parses Clang driver options when wrapped in `/clang:`.
+        // <https://clang.llvm.org/docs/UsersManual.html#the-clang-option>
+        let flag = if cmd.is_like_clang_cl() {
+            format!("/clang:{flag}")
+        } else {
+            flag.to_owned()
         };
         let probe = format!("{flag}=/probe=/probe");
         let supported = self

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -178,9 +178,15 @@ fn clang_cl_scope_all() {
         .file("foo.c")
         .compile("foo");
 
-    let cmd = test.cmd(1);
+    // clang-cl forwards Clang driver options through `/clang:<arg>`:
+    // https://releases.llvm.org/8.0.0/tools/clang/docs/UsersManual.html#the-clang-option
+    test.cmd(0)
+        .must_have("/clang:-fmacro-prefix-map=/probe=/probe");
+    test.cmd(1)
+        .must_have("/clang:-fdebug-prefix-map=/probe=/probe");
+
+    let cmd = test.cmd(2);
     for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
-        cmd.must_not_have(flag)
-            .must_not_have(format!("/clang:{flag}"));
+        cmd.must_not_have(flag).must_have(format!("/clang:{flag}"));
     }
 }

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -3,10 +3,6 @@
 //! This test is in its own module because it modifies the environment and
 //! would affect other tests when run in parallel with them.
 
-// Windows only beccause `-f*-prefix-map` flag family is GNU/Clang-only anyway.
-// If needed, Windows support will be added in the future.
-#![cfg(not(windows))]
-
 mod support;
 
 use crate::support::Test;
@@ -33,6 +29,7 @@ fn remap() -> OsString {
     env::join_paths(REMAP_PAIRS.iter().map(Path::new)).unwrap()
 }
 
+#[cfg(not(windows))]
 #[test]
 fn scope_all() {
     let mut test = Test::gnu();
@@ -47,6 +44,7 @@ fn scope_all() {
     }
 }
 
+#[cfg(not(windows))]
 #[test]
 fn scope_macro() {
     let mut test = Test::gnu();
@@ -64,6 +62,7 @@ fn scope_macro() {
     }
 }
 
+#[cfg(not(windows))]
 #[test]
 fn scope_object() {
     let mut test = Test::gnu();
@@ -83,6 +82,7 @@ fn scope_object() {
 
 /// `diagnostics` has no C compiler equivalent; combined with `macro` only
 /// the macro remap flags apply.
+#[cfg(not(windows))]
 #[test]
 fn scope_macro_and_diagnostics() {
     let mut test = Test::gnu();
@@ -101,6 +101,7 @@ fn scope_macro_and_diagnostics() {
 }
 
 /// `none` disables path sanitization; no remap flags should ever be emitted.
+#[cfg(not(windows))]
 #[test]
 fn scope_none() {
     let mut test = Test::gnu();
@@ -116,6 +117,7 @@ fn scope_none() {
 }
 
 /// Without the cargo-provided env vars nothing is emitted.
+#[cfg(not(windows))]
 #[test]
 fn no_env_vars() {
     let mut test = Test::gnu();
@@ -131,6 +133,7 @@ fn no_env_vars() {
 }
 
 /// `Build::inherit_trim_paths(false)` opts out of the inheritance.
+#[cfg(not(windows))]
 #[test]
 fn opt_out() {
     let mut test = Test::gnu();
@@ -145,5 +148,39 @@ fn opt_out() {
     let cmd = test.cmd(0);
     for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
         cmd.must_not_have(flag);
+    }
+}
+
+#[test]
+fn msvc_cl_scope_all() {
+    let mut test = Test::msvc();
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
+
+    test.gcc().file("foo.c").compile("foo");
+
+    let cmd = test.cmd(0);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag)
+            .must_not_have(format!("/clang:{flag}"));
+    }
+}
+
+#[test]
+fn clang_cl_scope_all() {
+    let mut test = Test::msvc();
+    test.shim("clang-cl.exe");
+    test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
+    let mut build = test.gcc();
+    build
+        .compiler(test.td.path().join("clang-cl.exe"))
+        .file("foo.c")
+        .compile("foo");
+
+    let cmd = test.cmd(1);
+    for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
+        cmd.must_not_have(flag)
+            .must_not_have(format!("/clang:{flag}"));
     }
 }

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -10,11 +10,14 @@
 mod support;
 
 use crate::support::Test;
+use std::env;
+use std::ffi::OsString;
+use std::path::Path;
 
-// `<from>=<to>` pairs as cargo passes them (`;` on Windows though not supported in cc-rs yet)
-
-const REMAP: &str =
-    "/path/to/pkg=foo-0.1.0:/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef";
+const REMAP_PAIRS: &[&str] = &[
+    "/path/to/pkg=foo-0.1.0",
+    "/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef",
+];
 
 const MACRO_FLAGS: &[&str] = &[
     "-fmacro-prefix-map=/path/to/pkg=foo-0.1.0",
@@ -26,11 +29,15 @@ const OBJECT_FLAGS: &[&str] = &[
     "-fdebug-prefix-map=/path/to/sysroot/lib/rustlib/src/rust=/rustc/1234567890abcdef",
 ];
 
+fn remap() -> OsString {
+    env::join_paths(REMAP_PAIRS.iter().map(Path::new)).unwrap()
+}
+
 #[test]
 fn scope_all() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc().file("foo.c").compile("foo");
 
@@ -44,7 +51,7 @@ fn scope_all() {
 fn scope_macro() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "macro");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc().file("foo.c").compile("foo");
 
@@ -61,7 +68,7 @@ fn scope_macro() {
 fn scope_object() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "object");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc().file("foo.c").compile("foo");
 
@@ -80,7 +87,7 @@ fn scope_object() {
 fn scope_macro_and_diagnostics() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "diagnostics,macro");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc().file("foo.c").compile("foo");
 
@@ -98,7 +105,7 @@ fn scope_macro_and_diagnostics() {
 fn scope_none() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "none");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc().file("foo.c").compile("foo");
 
@@ -128,7 +135,7 @@ fn no_env_vars() {
 fn opt_out() {
     let mut test = Test::gnu();
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
-    test.env.set("CARGO_TRIM_PATHS_REMAP", REMAP);
+    test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
 
     test.gcc()
         .inherit_trim_paths(false)


### PR DESCRIPTION
### Summary

A follow-up of #1794

MSVC-family compilers were skipped before this, including `clang-cl.exe`,
which actually accepts Clang driver options through `/clang:<arg>`.

This PR enables the existing remap flags for clang-cl via `/clang:<arg>`.

The behavior remains unchanged for `cl.exe`.

Do note this only remaps fields covered by Clang's prefix-map options.
It does not mean every absolute path disappears from Windows artifacts.

* A debug `.obj` can still contain its absolute output name in CodeView
  `S_OBJNAME` somehow, and the recorded clang command line still contains
  the old side of the remap pairs.
* A separate PDB still contains linker module/object paths.
  Cargo also says `object` does not sanitize debug info stored separately on Windows MSVC.
  <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option>
* The `.exe` stores the PDB filename and GUID.
  Two builds can have no checkout path in the executable
  and still not be byte-identical when the PDB GUID changes.
  <https://llvm.org/docs/PDB/PdbStream.html#matching-a-pdb-to-its-executable>

So far as I tested it,
the final `.exe` no longer exposes the checkout path,
though it does not make the Windows artifacts byte-reproducible.

### How to review

Commit by commit.

* The first one lets the test shim record nested MSVC flag probes.
* The second makes the existing remap test data work with the Windows path-list separator.
* The third captures the current `cl.exe` and `clang-cl.exe` behavior.
* The last one is the feature commit that probes and forwards the Clang flags for `clang-cl.exe`.

### How to test

I used the LLVM tools installed with Visual Studio:

```powershell
$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
$hostTriple = rustc +nightly --print host-tuple
$llvmArch = switch -Regex ($hostTriple) {
    '^aarch64-' { 'ARM64'; break }
    '^(x86_64|i686)-' { 'x64'; break }
    default { throw "unsupported host: $hostTriple" }
}
$clangCl = & $vswhere -latest -products * -find "**\Llvm\$llvmArch\bin\clang-cl.exe" |
    Select-Object -First 1
if (!$clangCl) {
    throw "clang-cl.exe was not found"
}
& $clangCl --version
$env:CC = $clangCl
cargo +nightly -Zscript .\trim-paths-repro.rs
```

Tested with clang-cl 19.1.5.

<details><summary>repro script</summary>
<p>

```rust
#!/usr/bin/env -S cargo +nightly -Zscript
---
[package]
edition = "2024"
---

//! End-to-end repro: cargo `-Ztrim-paths` -> cc -> clang-cl.
//!
//! Put this under the cc-rs repo root and run it with `CC` set to clang-cl.
//!
//! - `__FILE__` carrier: absolute `.file()` + `debug = false`
//!   -> trimmed by `-fmacro-prefix-map` (scopes `macro`, `object`, `all`)
//! - CodeView carrier: relative `.file()` + `debug = true`
//!   (debug info embeds the source path)
//!   -> trimmed by `-fdebug-prefix-map` (scopes `object`, `all`);
//!   `macro` must leave it EMBEDDED, mirroring rustc scope semantics.

use std::path::{Path, PathBuf};
use std::process::Command;
use std::{env, fs};

fn main() {
    let cc_root = env::current_dir().unwrap();
    assert!(
        fs::read_to_string("Cargo.toml")
            .unwrap_or_default()
            .contains("name = \"cc\""),
        "run this from the cc-rs repo root"
    );

    let work = env::temp_dir().join(format!("cc-trim-e2e-{}", std::process::id()));
    let _ = fs::remove_dir_all(&work);
    fs::create_dir_all(&work).unwrap();
    // Keep the normal drive-letter spelling. `canonicalize()` produces a
    // `\\?\` path on Windows, while Cargo's remap source uses `C:\...`.
    // Prefix-map matching is textual.
    let abs = work.display().to_string();

    eprintln!("work directory: {}", work.display());
    let mut ok = true;
    for debug in [false, true] {
        eprintln!("== {} carrier ==", if debug { "CodeView" } else { "__FILE__" });
        for scope in ["all", "object", "macro", "none"] {
            // `none` trims nothing; `macro` does not touch debug info.
            let expect = scope == "none" || (debug && scope == "macro");
            let object = build(&cc_root, &work, debug, scope);
            let found = if debug {
                codeview_filenames_contain(&object, &abs)
            } else {
                contains(&fs::read(object).unwrap(), abs.as_bytes())
            };
            let emb = |b| if b { "EMBEDDED" } else { "absent" };
            eprintln!(
                "trim-paths = {scope:8}: absolute path {:8} (expected {})",
                emb(found),
                emb(expect)
            );
            if found != expect {
                ok = false;
            }
        }
    }

    if !ok {
        eprintln!(
            "\nFAIL (does this cc checkout support clang-cl trim-paths,\n\
             and does this cargo set CARGO_TRIM_PATHS_* for build scripts?)"
        );
        eprintln!("build files retained under {}", work.display());
        std::process::exit(1);
    }
    let _ = fs::remove_dir_all(&work);
    eprintln!("\nOK: cc inherited cargo's trim-paths remap end to end");
}

/// Scaffold a package
///
/// * `build.rs` compiles `hello.c` through this cc checkout
/// * `cargo build`
/// * return the compiled object path
fn build(cc_root: &Path, work: &Path, debug: bool, scope: &str) -> PathBuf {
    let pkg = work.join(format!("pkg-{}-{scope}", u8::from(debug)));
    fs::create_dir_all(pkg.join("src")).unwrap();
    // Absolute `.file()` makes `__FILE__` carry the absolute path; a
    // relative one leaves only CodeView carrying an absolute path.
    let src = if debug {
        PathBuf::from("src/hello.c")
    } else {
        pkg.join("src/hello.c")
    };
    fs::write(
        pkg.join("Cargo.toml"),
        format!(
            r#"cargo-features = ["trim-paths"]

[package]
name = "trim-repro"
edition = "2021"

[build-dependencies]
cc = {{ path = '{}' }}

[profile.dev]
trim-paths = "{scope}"
debug = {debug}
"#,
            cc_root.display()
        ),
    )
    .unwrap();
    fs::write(
        pkg.join("build.rs"),
        format!(
            "fn main() {{ cc::Build::new().file(r\"{}\").compile(\"hello\"); }}\n",
            src.display()
        ),
    )
    .unwrap();
    fs::write(pkg.join("src/lib.rs"), "").unwrap();
    fs::write(
        pkg.join("src/hello.c"),
        "const char *embedded = __FILE__;\nconst char *get(void) { return embedded; }\n",
    )
    .unwrap();

    let target_dir = pkg.join("target");
    let out = Command::new("cargo")
        .args(["+nightly", "build", "-Ztrim-paths", "--target-dir"])
        .arg(&target_dir)
        .current_dir(&pkg)
        .output()
        .unwrap();
    assert!(
        out.status.success(),
        "cargo build failed:\n{}",
        String::from_utf8_lossy(&out.stderr)
    );

    fs::read_dir(target_dir.join("debug/build"))
        .unwrap()
        .find_map(|e| {
            fs::read_dir(e.ok()?.path().join("out"))
                .ok()?
                .find_map(|e| {
                    let object = e.ok()?.path();
                    object
                        .file_name()?
                        .to_string_lossy()
                        .ends_with("-hello.o")
                        .then_some(object)
                })
        })
        .expect("no hello object produced")
}

fn codeview_filenames_contain(object: &Path, needle: &str) -> bool {
    let mut readobj = PathBuf::from(env::var_os("CC").expect("CC must name clang-cl"));
    readobj.set_file_name("llvm-readobj.exe");
    let out = Command::new(readobj)
        .arg("--codeview")
        .arg(object)
        .output()
        .unwrap();
    assert!(
        out.status.success(),
        "llvm-readobj failed:\n{}",
        String::from_utf8_lossy(&out.stderr)
    );
    String::from_utf8_lossy(&out.stdout)
        .lines()
        .filter(|line| line.trim_start().starts_with("Filename:"))
        .any(|line| line.contains(needle))
}

fn contains(hay: &[u8], needle: &[u8]) -> bool {
    hay.windows(needle.len()).any(|w| w == needle)
}
```

</p>
</details>
