### PR TITLE
Revert "Update rusqlite requirement from 0.39.0 to 0.40.0 (#1744)"

### DIFF
--- a/dev-tools/wasi-test/Cargo.toml
+++ b/dev-tools/wasi-test/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rusqlite = { version = "0.40.0", features = ["bundled"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }


### PR DESCRIPTION
This reverts commit a2bcb6e14c18e7191f5e0891b6925622eb3d5581.

```
$ cargo +1.63.0 clippy --workspace --all-targets --all-features -q
error: failed to download `hashlink v0.12.1`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `~/.cargo/registry/src/github.com-1ecc6299db9ec823/hashlink-0.12.1/Cargo.toml`

Caused by:
  failed to parse the `edition` key

Caused by:
  this version of Cargo is older than the `2024` edition, and only supports `2015`, `2018`, and `2021` editions.
```

```
cargo tree --workspace --invert hashlink                        
hashlink v0.12.1
└── rusqlite v0.40.1
    └── wasi-test v0.1.0 (~/cc-rs/dev-tools/wasi-test)
```