### PR TITLE
chore: update rust-version to 1.64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -429,7 +429,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      MSRV: 1.63.0
+      MSRV: 1.64.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["development-tools::build-utils"]
 # The binary target is only used by tests.
 exclude = ["/.github", "tests", "src/bin"]
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.64.0"
 
 [dependencies]
 jobserver = { version = "0.1.30", default-features = false, optional = true }

--- a/dev-tools/gen-target-info/src/read.rs
+++ b/dev-tools/gen-target-info/src/read.rs
@@ -4,7 +4,7 @@ use crate::{RustcTargetSpecs, TargetSpec};
 
 pub fn get_targets_msrv() -> Vec<u8> {
     let mut cmd = process::Command::new("rustc");
-    cmd.args(["+1.63", "--print", "target-list"]);
+    cmd.args(["+1.64", "--print", "target-list"]);
     cmd.stdout(process::Stdio::piped());
     cmd.stderr(process::Stdio::inherit());
 
@@ -20,7 +20,7 @@ pub fn get_targets_msrv() -> Vec<u8> {
 pub fn get_target_spec_from_msrv(target: &str) -> TargetSpec {
     let mut cmd = process::Command::new("rustc");
     cmd.args([
-        "+1.63",
+        "+1.64",
         "-Zunstable-options",
         "--print",
         "target-spec-json",

--- a/find-msvc-tools/Cargo.toml
+++ b/find-msvc-tools/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/find-msvc-tools"
 description = "Find windows-specific tools, read MSVC versions from the registry and from COM interfaces"
 keywords = ["build-dependencies"]
 categories = ["development-tools::build-utils"]
-rust-version = "1.63"
+rust-version = "1.64.0"
 
 
 [dependencies]

--- a/find-msvc-tools/src/winapi.rs
+++ b/find-msvc-tools/src/winapi.rs
@@ -7,15 +7,13 @@
 
 #![allow(bad_style, clippy::upper_case_acronyms)]
 
-use std::os::raw;
-
 pub type wchar_t = u16;
 
 pub use crate::windows_sys::{FILETIME, GUID, HRESULT, SAFEARRAY};
 
 pub type REFIID = *const IID;
 pub type IID = GUID;
-pub type ULONG = raw::c_ulong;
+pub type ULONG = core::ffi::c_ulong;
 pub type DWORD = u32;
 pub type LPFILETIME = *mut FILETIME;
 pub type OLECHAR = WCHAR;
@@ -139,7 +137,7 @@ RIDL! {#[uuid(0x00000000, 0x0000, 0x0000, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x
 interface IUnknown(IUnknownVtbl) {
     fn QueryInterface(
         riid: REFIID,
-        ppvObject: *mut *mut raw::c_void,
+        ppvObject: *mut *mut core::ffi::c_void,
     ) -> HRESULT,
     fn AddRef() -> ULONG,
     fn Release() -> ULONG,

--- a/src/parallel/stderr.rs
+++ b/src/parallel/stderr.rs
@@ -25,7 +25,7 @@ fn get_flags(fd: std::os::unix::io::RawFd) -> Result<i32, Error> {
 }
 
 #[cfg(unix)]
-fn set_flags(fd: std::os::unix::io::RawFd, flags: std::os::raw::c_int) -> Result<(), Error> {
+fn set_flags(fd: std::os::unix::io::RawFd, flags: core::ffi::c_int) -> Result<(), Error> {
     if unsafe { libc::fcntl(fd, libc::F_SETFL, flags) } == -1 {
         Err(Error::new(
             ErrorKind::IOError,


### PR DESCRIPTION
use `core::ffi` types