### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "cc"
 version = "1.4.0"
 edition.workspace = true
 rust-version.workspace = true
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"
 homepage = "https://github.com/rust-lang/cc-rs"

--- a/dev-tools/cc-test/Cargo.toml
+++ b/dev-tools/cc-test/Cargo.toml
@@ -3,7 +3,6 @@ name = "cc-test"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 publish = false
 
 [lib]


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068