### PR TITLE
chore: workspace inheritance for edition and rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "cc"
 version = "1.4.0"
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"
@@ -16,6 +18,17 @@ readme = "README.md"
 categories = ["development-tools::build-utils"]
 # The binary target is only used by tests.
 exclude = ["/.github", "tests", "src/bin"]
+
+[workspace]
+members = [
+    "find-msvc-tools",
+    "dev-tools/cc-test",
+    "dev-tools/gen-target-info",
+    "dev-tools/gen-windows-sys-binding",
+    "dev-tools/wasi-test",
+]
+
+[workspace.package]
 edition = "2021"
 rust-version = "1.64.0"
 
@@ -37,15 +50,6 @@ jobserver = []
 
 [dev-dependencies]
 tempfile = "3"
-
-[workspace]
-members = [
-    "find-msvc-tools",
-    "dev-tools/cc-test",
-    "dev-tools/gen-target-info",
-    "dev-tools/gen-windows-sys-binding",
-    "dev-tools/wasi-test",
-]
 
 [patch.crates-io]
 cc = { path = "." }

--- a/dev-tools/cc-test/Cargo.toml
+++ b/dev-tools/cc-test/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cc-test"
 version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2021"
 publish = false
 
 [lib]

--- a/dev-tools/gen-target-info/Cargo.toml
+++ b/dev-tools/gen-target-info/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "gen-target-info"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/dev-tools/gen-windows-sys-binding/Cargo.toml
+++ b/dev-tools/gen-windows-sys-binding/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "gen-windows-sys-binding"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/dev-tools/wasi-test/Cargo.toml
+++ b/dev-tools/wasi-test/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wasi-test"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/find-msvc-tools/Cargo.toml
+++ b/find-msvc-tools/Cargo.toml
@@ -1,17 +1,14 @@
 [package]
 name = "find-msvc-tools"
 version = "0.1.9"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cc-rs"
 documentation = "https://docs.rs/find-msvc-tools"
 description = "Find windows-specific tools, read MSVC versions from the registry and from COM interfaces"
 keywords = ["build-dependencies"]
 categories = ["development-tools::build-utils"]
-rust-version = "1.64.0"
-
-
-[dependencies]
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }


### PR DESCRIPTION
Using feature `workspace-inheritance` from Rust 1.64.