### PR TITLE
fix `-Cforce-frame-pointers`'s corresponding `CFLAGS`

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -244,15 +244,13 @@ impl<'this> RustcCodegenFlags<'this> {
                 }
             }
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fno-omit-frame-pointer
-            // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fomit-frame-pointer
+            // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-momit-leaf-frame-pointer
             // https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fomit-frame-pointer
             if let Some(value) = self.force_frame_pointers {
-                let cc_flag = if value {
-                    "-fno-omit-frame-pointer"
-                } else {
-                    "-fomit-frame-pointer"
-                };
-                push_if_supported(cc_flag.into());
+                if value {
+                    push_if_supported("-fno-omit-frame-pointer".into());
+                    push_if_supported("-mno-omit-leaf-frame-pointer".into());
+                }
             }
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mno-red-zone
             // https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#index-mno-red-zone

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -553,6 +553,7 @@ impl ToolFamily {
         match *self {
             ToolFamily::Gnu | ToolFamily::Clang { .. } => {
                 cmd.push_cc_arg("-fno-omit-frame-pointer".into());
+                cmd.push_cc_arg("-mno-omit-leaf-frame-pointer".into());
             }
             _ => (),
         }

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -10,6 +10,7 @@ fn sanity() {
     test.gcc().file("foo.c").compile("foo");
     test.cmd(0)
         .must_not_have("-fno-omit-frame-pointer")
+        .must_not_have("-mno-omit-leaf-frame-pointer")
         .must_not_have("-mcmodel=small")
         .must_not_have("-msoft-float")
         .must_not_have("-fstack-protector-strong");
@@ -26,6 +27,7 @@ fn inherits_rustflags() {
     test.gcc().file("foo.c").compile("foo");
     test.cmd(0)
         .must_have("-fno-omit-frame-pointer")
+        .must_have("-mno-omit-leaf-frame-pointer")
         .must_have("-mcmodel=small")
         .must_have("-msoft-float")
         .must_have("-gdwarf-5")
@@ -43,6 +45,7 @@ fn no_stack_protector() {
     test.gcc().file("foo.c").compile("foo");
     test.cmd(0)
         .must_have("-fno-omit-frame-pointer")
+        .must_have("-mno-omit-leaf-frame-pointer")
         .must_have("-mcmodel=small")
         .must_have("-msoft-float")
         .must_have("-gdwarf-5")

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -101,6 +101,7 @@ fn gnu_debug_fp_auto() {
         .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_have("-fno-omit-frame-pointer");
+    test.cmd(0).must_have("-mno-omit-leaf-frame-pointer");
 }
 
 #[test]
@@ -113,6 +114,7 @@ fn gnu_debug_fp() {
         .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_have("-fno-omit-frame-pointer");
+    test.cmd(0).must_have("-mno-omit-leaf-frame-pointer");
 }
 
 #[test]
@@ -126,6 +128,7 @@ fn gnu_debug_nofp() {
         .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_not_have("-fno-omit-frame-pointer");
+    test.cmd(0).must_not_have("-mno-omit-leaf-frame-pointer");
     drop(test);
 
     let test = Test::gnu();
@@ -137,6 +140,7 @@ fn gnu_debug_nofp() {
         .compile("foo");
     test.cmd(0).must_have("-gdwarf-4");
     test.cmd(0).must_not_have("-fno-omit-frame-pointer");
+    test.cmd(0).must_not_have("-mno-omit-leaf-frame-pointer");
 }
 
 #[test]


### PR DESCRIPTION
1. `-Cforce-frame-pointers` should imply `-mno-omit-leaf-frame-pointer` to align `rustc`'s behavior. See also [rustc's command-line argument -> rustc's `FramePointer`](https://github.com/rust-lang/rust/blob/be3d26db984c6f96335faca1f254dc04873cb1c1/compiler/rustc_session/src/options.rs#L1218-L1228).

2. `-Cforce-frame-pointers=no` should not imply `-fomit-frame-pointer`. [The rustc book](https://doc.rust-lang.org/rustc/codegen-options/index.html#force-frame-pointers) says:

> `n`, `no`, `off` or `false`: do not force-enable frame pointers. This does not necessarily mean frame pointers will be removed.