### PR TITLE
chore: add toml formatting rules

### DIFF
--- a/.tombi.toml
+++ b/.tombi.toml
@@ -1,0 +1,2 @@
+[format.rules]
+indent-width = 4


### PR DESCRIPTION
Add TOML formatting rules when using the Tombi formatter.