### PR TITLE
Use lp64d ABI for Managarm riscv64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2614,7 +2614,7 @@ impl Build {
                     // get the 32i/32imac/32imc/64gc/64imac/... part
                     let arch = &target.full_arch[5..];
                     if arch.starts_with("64") {
-                        if matches!(target.os, "linux" | "freebsd" | "netbsd") {
+                        if matches!(target.os, "linux" | "freebsd" | "netbsd" | "managarm") {
                             cmd.args.push(("-march=rv64gc").into());
                             cmd.args.push("-mabi=lp64d".into());
                         } else {


### PR DESCRIPTION
We already use cc-rs on Managarm since #1488 is upstream, however this change is needed to support riscv64.