### PR TITLE
Better CI for cross-compiling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,10 +231,10 @@ jobs:
       - name: Build and run binaries and tests
         run: |
           cargo build --bins --tests --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
-      - name: Compile tests but not run
+      - name: Compile all test targets but not run
         if: matrix.no_run
         run: |
-          cargo test --no-run --workspace --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
+          cargo test --no-run --workspace --all-targets --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
       - name: Compile and Run tests
         if: ${{ ! matrix.no_run }}
         run: |


### PR DESCRIPTION
## Title
Compile all test targets for cross builds

### Summary
This PR expands CI coverage for cross-compilation jobs that cannot run target binaries. Those jobs now compile all Cargo test targets instead of only the default test set, catching more target-specific build failures during CI.

### Logic Changes
- Update no-run cross-compilation CI jobs to pass `--all-targets` to `cargo test --no-run`.
- Rename the workflow step to reflect that it compiles all test targets.

### Changes at a Glance
| File                         | Change Type | Description                                    |
| ---------------------------- | ----------- | ---------------------------------------------- |
| `.github/workflows/main.yml` | Modified    | Expand no-run cross build test target coverage |

#### Issues Closes
Closes #1390 
