### PR TITLE
Update MSRV to 1.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rust-version = "1.65.0"
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
 ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = [
 edition = "2021"
 rust-version = "1.64.0"
 
+[workspace.lints.clippy]
+ptr_as_ptr = "warn"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = [
 edition = "2021"
 rust-version = "1.64.0"
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }
+
 [dependencies]
 find-msvc-tools = { path = "find-msvc-tools", version = "0.1.10" }
 jobserver = { version = "0.1.30", default-features = false, optional = true }
@@ -50,8 +53,8 @@ libc = { version = "0.2.168", default-features = false, optional = true }
 jobserver = []
 parallel = ["dep:jobserver", "dep:libc"]
 
-[lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }
+[lints]
+workspace = true
 
 [patch.crates-io]
 cc = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rust-version = "1.65.0"
 
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
+manual_let_else = "warn"
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ edition = "2021"
 rust-version = "1.64.0"
 
 [workspace.lints.clippy]
+borrow_as_ptr = "warn"
 ptr_as_ptr = "warn"
 
 [workspace.lints.rust]

--- a/dev-tools/cc-test/Cargo.toml
+++ b/dev-tools/cc-test/Cargo.toml
@@ -16,3 +16,6 @@ which = "8.0"
 [features]
 parallel = ["cc/parallel"]
 test_cuda = []
+
+[lints]
+workspace = true

--- a/dev-tools/gen-target-info/Cargo.toml
+++ b/dev-tools/gen-target-info/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [dependencies]
 serde = { version = "1.0.166", features = ["derive"] }
 serde_json = "1.0.107"
+
+[lints]
+workspace = true

--- a/dev-tools/gen-windows-sys-binding/Cargo.toml
+++ b/dev-tools/gen-windows-sys-binding/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 regex = "1.9"
 tempfile = "3"
 windows-bindgen = "0.66"
+
+[lints]
+workspace = true

--- a/dev-tools/wasi-test/Cargo.toml
+++ b/dev-tools/wasi-test/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [dependencies]
 rusqlite = { version = "0.40.0", features = ["bundled"] }
+
+[lints]
+workspace = true

--- a/find-msvc-tools/Cargo.toml
+++ b/find-msvc-tools/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT OR Apache-2.0"
 keywords = ["build-dependencies"]
 categories = ["development-tools::build-utils"]
 
-[lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(disable_clang_cl_tests)'] }
+[lints]
+workspace = true

--- a/find-msvc-tools/src/com.rs
+++ b/find-msvc-tools/src/com.rs
@@ -47,7 +47,7 @@ where
     }
     /// For internal use only.
     fn as_unknown(&self) -> &IUnknown {
-        unsafe { &*(self.0 as *mut IUnknown) }
+        unsafe { &*self.0.cast() }
     }
     /// Performs `QueryInterface` fun.
     pub fn cast<U>(&self) -> Result<ComPtr<U>, i32>
@@ -59,7 +59,7 @@ where
         if err < 0 {
             return Err(err);
         }
-        Ok(unsafe { ComPtr::from_raw(obj as *mut U) })
+        Ok(unsafe { ComPtr::from_raw(obj.cast()) })
     }
 }
 impl<T> Deref for ComPtr<T>

--- a/find-msvc-tools/src/find_tools.rs
+++ b/find-msvc-tools/src/find_tools.rs
@@ -356,7 +356,7 @@ mod impl_ {
 
     impl LibraryHandle {
         fn new(name: &[u8]) -> Option<Self> {
-            let handle = unsafe { LoadLibraryA(name.as_ptr() as _) };
+            let handle = unsafe { LoadLibraryA(name.as_ptr().cast()) };
             (!handle.is_null()).then_some(Self(handle))
         }
 
@@ -369,7 +369,7 @@ mod impl_ {
         ///
         /// The function returned cannot be used after the handle is dropped.
         unsafe fn get_proc_address<F>(&self, name: &[u8]) -> Option<F> {
-            let symbol = GetProcAddress(self.0, name.as_ptr() as _);
+            let symbol = GetProcAddress(self.0, name.as_ptr().cast());
             symbol.map(|symbol| mem::transmute_copy(&symbol))
         }
     }

--- a/find-msvc-tools/src/registry.rs
+++ b/find-msvc-tools/src/registry.rs
@@ -118,7 +118,7 @@ impl RegistryKey {
                 name.as_ptr(),
                 null_mut(),
                 null_mut(),
-                v.as_mut_ptr() as *mut _,
+                v.as_mut_ptr().cast(),
                 &mut len,
             );
             // We don't check for `ERROR_MORE_DATA` (which would if the value

--- a/find-msvc-tools/src/setup_config.rs
+++ b/find-msvc-tools/src/setup_config.rs
@@ -175,7 +175,7 @@ impl SetupConfiguration {
         if err < 0 {
             return Err(err);
         }
-        let obj = unsafe { ComPtr::from_raw(obj as *mut ISetupConfiguration) };
+        let obj = unsafe { ComPtr::from_raw(obj.cast()) };
         Ok(SetupConfiguration(obj))
     }
     pub fn get_instance_for_current_process(&self) -> Result<SetupInstance, i32> {

--- a/find-msvc-tools/src/winapi.rs
+++ b/find-msvc-tools/src/winapi.rs
@@ -102,7 +102,7 @@ macro_rules! RIDL {
             type Target = $pinterface;
             #[inline]
             fn deref(&self) -> &$pinterface {
-                unsafe { &*(self as *const $interface as *const $pinterface) }
+                unsafe { &*(self as *const Self).cast() }
             }
         }
     );

--- a/find-msvc-tools/src/winapi.rs
+++ b/find-msvc-tools/src/winapi.rs
@@ -111,7 +111,10 @@ macro_rules! RIDL {
     )+}) => (
         impl $interface {
             $(#[inline] pub unsafe fn $method(&self, $($p: $t,)*) -> $rtr {
-                ((*self.lpVtbl).$method)(self as *const _ as *mut _, $($p,)*)
+                ((*self.lpVtbl).$method)(
+                    (self as *const Self).cast_mut(),
+                    $($p,)*
+                )
             })+
         }
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2701,10 +2701,9 @@ impl Build {
         cmd: &mut Tool,
         target: &TargetInfo<'_>,
     ) -> Result<(), Error> {
-        let env_os = match cargo_env_var_os("CARGO_ENCODED_RUSTFLAGS") {
-            Some(env) => env,
+        let Some(env_os) = cargo_env_var_os("CARGO_ENCODED_RUSTFLAGS") else {
             // No encoded RUSTFLAGS -> nothing to do
-            None => return Ok(()),
+            return Ok(());
         };
 
         let env = env_os.to_string_lossy();
@@ -2722,13 +2721,11 @@ impl Build {
         if cmd.is_like_msvc() && !cmd.is_like_clang_cl() {
             return Ok(());
         }
-        let scope = match cargo_env_var_os("CARGO_TRIM_PATHS_SCOPE") {
-            Some(scope) => scope,
-            None => return Ok(()),
+        let Some(scope) = cargo_env_var_os("CARGO_TRIM_PATHS_SCOPE") else {
+            return Ok(());
         };
-        let remap = match cargo_env_var_os("CARGO_TRIM_PATHS_REMAP") {
-            Some(remap) => remap,
-            None => return Ok(()),
+        let Some(remap) = cargo_env_var_os("CARGO_TRIM_PATHS_REMAP") else {
+            return Ok(());
         };
 
         // * `macro` scope -> `-fmacro-prefix-map`
@@ -4327,14 +4324,11 @@ impl Build {
             &self.cargo_output,
         )?;
 
-        let sdk_path = match String::from_utf8(sdk_path) {
-            Ok(p) => p,
-            Err(_) => {
-                return Err(Error::new(
-                    ErrorKind::IOError,
-                    "Unable to determine Apple SDK path.",
-                ));
-            }
+        let Ok(sdk_path) = String::from_utf8(sdk_path) else {
+            return Err(Error::new(
+                ErrorKind::IOError,
+                "Unable to determine Apple SDK path.",
+            ));
         };
         Ok(Cow::Owned(sdk_path.trim().into()))
     }


### PR DESCRIPTION
- Bump MSRV to 1.65
- Use some workspace lints:
  - `borrow_as_ptr`
  - `manual_let_else`
  - `ptr_as_ptr`
  - `ptr_cast_constness`