### PR TITLE
ci: allow flaky failure of check-motor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -535,7 +535,6 @@ jobs:
       - test-linker-plugin-lto
       - check-build-std
       - check-wasm
-      - check-motor
       - test-wasi
       - cuda
       - msrv


### PR DESCRIPTION
Nightly error in stdlib itself, we do not want our CI to be blocked