### PR TITLE
fix: Infer NEON, not VFPv4, from `neon` in the target name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2478,7 +2478,7 @@ impl Build {
                 }
 
                 if target.full_arch.contains("neon") {
-                    cmd.args.push("-mfpu=neon-vfpv4".into());
+                    cmd.args.push("-mfpu=neon".into());
                 }
 
                 if target.full_arch == "armv4t" && target.os == "linux" {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -145,6 +145,24 @@ fn gnu_debug_nofp() {
 }
 
 #[test]
+fn gnu_arm_neon_is_vfpv3_not_vfpv4() {
+    for (target, prefix) in [
+        ("thumbv7neon-unknown-linux-gnueabihf", "arm-linux-gnueabihf"),
+        ("thumbv7neon-unknown-linux-musleabihf", "arm-linux-musleabihf"),
+        ("armv7neon-unknown-linux-gnueabihf", "arm-linux-gnueabihf"),
+    ] {
+        let test = Test::gnu();
+        test.shim(&format!("{prefix}-gcc"))
+            .shim(&format!("{prefix}-ar"));
+        test.gcc().target(target).file("foo.c").compile("foo");
+        test.cmd(0)
+            .must_have("-mfpu=neon")
+            .must_not_have("-mfpu=neon-vfpv4");
+        drop(test);
+    }
+}
+
+#[test]
 fn gnu_warnings_into_errors() {
     let test = Test::gnu();
     test.gcc()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -148,7 +148,10 @@ fn gnu_debug_nofp() {
 fn gnu_arm_neon_is_vfpv3_not_vfpv4() {
     for (target, prefix) in [
         ("thumbv7neon-unknown-linux-gnueabihf", "arm-linux-gnueabihf"),
-        ("thumbv7neon-unknown-linux-musleabihf", "arm-linux-musleabihf"),
+        (
+            "thumbv7neon-unknown-linux-musleabihf",
+            "arm-linux-musleabihf",
+        ),
         ("armv7neon-unknown-linux-gnueabihf", "arm-linux-gnueabihf"),
     ] {
         let test = Test::gnu();


### PR DESCRIPTION
I recently ran into programs compiled for `thumbv7neon-unknown-linux-gnueabihf` sometimes crashing with SIGILL. The reason appears to be that `cc` appends `-mfpu=neon-vfpv4` [^1] to the compiler command line for any target whose architecture string contains `neon`, which my target CPU does not support. Setting `CFLAGS_thumbv7neon_unknown_linux_gnueabihf="-mfpu=neon"` makes the issue go away. Since `rustc` does not specify this feature for the target [^3], we shouldn't either.

I tried making a minimal example that runs in GitHub Actions and demonstrates the crash and the workaround [^2].

[^1]: https://github.com/rust-lang/cc-rs/blob/303e57e06d83d05d5b9c95242cd39f941fc773f3/src/lib.rs#L2480-L2481
[^2]: https://github.com/apljungquist/cc-bug
[^3]: `rustc +nightly -Z unstable-options --print target-spec-json --target thumbv7neon-unknown-linux-gnueabihf | jq '.features'` prints `"+v7,+thumb-mode,+thumb2,+vfp3,+neon"`

Fixes: #1842 