### PR TITLE
ci: replace rustup installation with actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   CARGO_INCREMENTAL: 0
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CC_ENABLE_DEBUG_OUTPUT: true
 
 concurrency:
@@ -164,12 +163,12 @@ jobs:
           persist-credentials: false
       - run: curl -vv https://static.rust-lang.org/dist/channel-rust-1.87.0.toml.sha256
         shell: bash
-      - name: Install Rust (rustup)
-        run: |
-          set -euxo pipefail
-          rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal --target ${{ matrix.target }}
-          rustup default ${{ matrix.rust }}
-        shell: bash
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          target: ${{ matrix.target }}
+          toolchain: ${{ matrix.rust }}
       - name: Install g++-multilib
         run: |
           set -e
@@ -251,12 +250,12 @@ jobs:
        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
          with:
            persist-credentials: false
-       - name: Install Rust (rustup)
-         run: |
-           set -euxo pipefail
-           rustup toolchain install stable --no-self-update --profile minimal
-           rustup default stable
-         shell: bash
+
+       - name: Install Rust
+         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+         with:
+           cache: false
+           toolchain: stable
 
        - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
          with:
@@ -300,13 +299,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install Rust (rustup)
-        run: |
-          set -euxo pipefail
-          rustup toolchain install nightly --no-self-update --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup default nightly
-        shell: bash
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          components: rust-src
+          toolchain: nightly
       - run: cargo update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test -Z build-std=std --no-run --workspace --target ${{ matrix.target }}
@@ -326,10 +324,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install Rust (rustup)
-        run: |
-          rustup target add ${{ matrix.target }}
-        shell: bash
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          target: ${{ matrix.target }}
+          toolchain: stable
       - run: cargo update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --no-run --target ${{ matrix.target }}
@@ -352,13 +352,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install Rust (rustup)
-        run: |
-          set -euxo pipefail
-          rustup toolchain install nightly --no-self-update --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup default nightly
-        shell: bash
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          components: rust-src
+          toolchain: nightly
       - run: cargo update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check -Z build-std=std,panic_abort -p cc --target ${{ matrix.target }}
@@ -376,15 +375,17 @@ jobs:
         - wasm32-wasip1
         - wasm32-wasip2
         - wasm32-wasip1-threads
-    env:
-      TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install Rust (rustup)
-        run: |
-          rustup toolchain install nightly --no-self-update --profile minimal --target $TARGET
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          target: ${{ matrix.target }}
+          toolchain: nightly
 
       - name: Get latest version of wasi-sdk
         env:
@@ -415,7 +416,7 @@ jobs:
           cache-all-crates: "true"
 
       - name: Run tests
-        run: cargo +nightly build -p wasi-test --target $TARGET
+        run: cargo +nightly build -p wasi-test --target ${{ matrix.target }}
 
       # check that there are no uncommitted changes to prevent bugs like https://github.com/rust-lang/cc-rs/issues/1411
       - name: check clean Git workting tree
@@ -466,9 +467,10 @@ jobs:
       - name: Get msrv
         uses: ./.github/actions/get-msrv
       - name: Install Rust
-        run: |
-          rustup toolchain install $MSRV --no-self-update --profile minimal
-          rustup default $MSRV
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          toolchain: ${{ env.MSRV }}
       - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: |
@@ -476,7 +478,7 @@ jobs:
             cargo-minimal-versions
           fallback: none
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: env -u CARGO_REGISTRIES_CRATES_IO_PROTOCOL cargo minimal-versions check --workspace --all-targets --feature-powerset --ignore-private
+      - run: cargo minimal-versions check --workspace --all-targets --feature-powerset --ignore-private
 
   clippy:
     name: Clippy
@@ -490,10 +492,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        run: |
-          rustup toolchain install stable --no-self-update --profile minimal --component clippy
-          rustup default stable
-        shell: bash
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          components: clippy
+          toolchain: stable
       - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: |
@@ -513,10 +516,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        run: |
-          rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
-          rustup default stable
-        shell: bash
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          components: rustfmt
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo fmt -- --check
 

--- a/.github/workflows/regenerate-target-info.yml
+++ b/.github/workflows/regenerate-target-info.yml
@@ -32,9 +32,11 @@ jobs:
       - name: Get msrv
         uses: ./.github/actions/get-msrv
 
-      - name: Install rust
-        run: |
-          rustup toolchain install $MSRV stable nightly --no-self-update --profile minimal
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          toolchain: ${{ env.MSRV }}, stable, nightly
 
       - name: Create lockfile
         run: cargo update

--- a/.github/workflows/test-rustc-targets.yml
+++ b/.github/workflows/test-rustc-targets.yml
@@ -23,10 +23,12 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Install current nightly Rust
-        run: |
-          rustup toolchain install nightly --no-self-update --profile minimal
-          rustup default nightly
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+          toolchain: nightly
+
       - run: cargo update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 


### PR DESCRIPTION
There are a few advantages of this action:

- It handles setting `CARGO_REGISTRIES_CRATES_IO_PROTOCOL` appropriately (e.g. enabling the sparse registry).
- It sets a few useful CI defaults such as `CARGO_INCREMENTAL=0`, `RUST_BACKTRACE=short`, and `CARGO_TERM_COLOR=always`.
- It provides a Rust-specific problem matcher, so compiler and `rustfmt` errors are surfaced in the GitHub Actions UI.

https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml