### PR TITLE
cc-test: add loongarch64 assembly shim

### DIFF
--- a/dev-tools/cc-test/src/loongarch64.S
+++ b/dev-tools/cc-test/src/loongarch64.S
@@ -1,0 +1,9 @@
+.globl asm
+asm:
+    li.w $a0, 7
+    jirl $r0, $r1, 0
+
+.globl _asm
+_asm:
+    li.w $a0, 7
+    jirl $r0, $r1, 0


### PR DESCRIPTION
## Problem

`dev-tools/cc-test`'s `build.rs` compiles `src/<arch>.S` based on the target architecture. `aarch64.S`, `armv7.S`, `i686.S`, `riscv64gc.S`, and `x86_64.S` are all present, but there is no `loongarch64.S`. On `loongarch64-unknown-linux-gnu` (stable Rust target since 1.75) this fails with:

```
cc1: fatal error: src/loongarch64.S: No such file or directory
```

The `cc` crate itself already declares support for LoongArch64 (`loongarch64-unknown-linux-gnu => loongarch64-linux-gnu` in `src/lib.rs`), so this is purely a missing dev-tool shim.

## Fix

Add `dev-tools/cc-test/src/loongarch64.S`, modeled on `riscv64gc.S`, exporting both `asm` and `_asm` symbols. Verified on real LoongArch64 hardware: `cargo build` succeeds and `cargo test` passes 9/9 — the `asm_here` test asserts the shim returns 7.
