### PR TITLE
fix: run the Android llvm-ar probe in the caller's environment

### DIFF
--- a/src/bin/cc-shim.rs
+++ b/src/bin/cc-shim.rs
@@ -59,7 +59,7 @@ fn out_file(program: &str) -> Option<PathBuf> {
 }
 
 /// Record the args passed to the command, if this invocation records at all.
-fn record(program: &str, args: &[&String]) {
+fn record(program: &str, args: &[String]) {
     let Some(candidate) = out_file(program) else {
         return;
     };
@@ -96,12 +96,10 @@ fn record(program: &str, args: &[&String]) {
 }
 
 fn main() -> ExitCode {
-    let args = env::args().collect::<Vec<_>>();
-    let mut args = args.iter();
-    let program = args.next().expect("Unexpected empty args");
-    let args = args.collect::<Vec<_>>();
+    let argv = env::args().collect::<Vec<_>>();
+    let (program, args) = argv.split_first().expect("Unexpected empty args");
 
-    record(program, &args);
+    record(program, args);
 
     // Compiler family detection preprocesses a probe file with `-E` and reads
     // the family out of the expansion. The shim is not a preprocessor and

--- a/src/bin/cc-shim.rs
+++ b/src/bin/cc-shim.rs
@@ -10,30 +10,43 @@ use std::io::{self, prelude::*};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-fn main() -> ExitCode {
-    let args = env::args().collect::<Vec<_>>();
-    let mut args = args.iter();
-    let program = args.next().expect("Unexpected empty args");
+/// Test-only environment variable naming a directory to record invocations in.
+///
+/// Arguments are written to the first `out{i}` in it that does not exist yet, so
+/// a test reads the `i`-th invocation back with `Test::cmd(i)`. `Test::gcc()`
+/// sets this through `Build::env`, and the compile and archive commands that a
+/// build actually runs inherit it.
+const OUT_DIR: &str = "CC_SHIM_OUT_DIR";
 
-    let out_dir = env::var_os("CC_SHIM_OUT_DIR")
-        .map(PathBuf::from)
-        .or_else(|| {
-            // Flag probes use a fresh `Build`, so they don't inherit the
-            // test-only `CC_SHIM_OUT_DIR`. `is_flag_supported_inner` runs
-            // them with `out_dir` as their working directory, so we can
-            // record their arguments there.
-            //
-            // We only use this fallback for `-c` the compile-only flag probe
-            // in this flow. Family detection uses `-E` without `-c` and
-            // it must keep failing.
-            args.clone()
-                .any(|arg| arg == "-c")
-                .then(|| env::current_dir().expect("failed to get probe working directory"))
-        })
-        .unwrap_or_else(|| panic!("{}: CC_SHIM_OUT_DIR not found", program));
+/// Test-only environment variable naming an explicit `PATH`-separated list of
+/// files to record invocations in, the first that does not exist yet winning.
+///
+/// cc sets this on its own probing invocations by renaming the dedicated
+/// `CC_SHIM_OUT_FILES_FOR_*` variable for the class of probe it is about to
+/// spawn, and clears [`OUT_DIR`] for them at the same time. Which probes run at
+/// all depends on the compiler, the target and cc's internal caching, so a test
+/// opts one class in by name; every probe it did not ask about records nothing
+/// and cannot shift the `out{i}` numbering of the invocations it is asserting
+/// on. See `set_probe_env` in `src/command_helpers.rs`.
+const OUT_FILES: &str = "CC_SHIM_OUT_FILES";
 
+/// Pick the file this invocation should record its arguments in, if any.
+fn out_file(program: &str) -> Option<PathBuf> {
+    if let Some(files) = env::var_os(OUT_FILES) {
+        let candidate = env::split_paths(&files)
+            .filter(|file| !file.as_os_str().is_empty())
+            .find(|file| !file.exists());
+        return Some(candidate.unwrap_or_else(|| {
+            panic!(
+                "{}: every file named by {} has already been written to: {:?}",
+                program, OUT_FILES, files
+            )
+        }));
+    }
+
+    let out_dir = PathBuf::from(env::var_os(OUT_DIR)?);
     // Find the first nonexistent candidate file to which the program's args can be written.
-    let candidate = (0..).find_map(|i| {
+    Some((0..).find_map(|i| {
         let candidate = out_dir.join(format!("out{i}"));
 
         if candidate.exists() {
@@ -42,9 +55,15 @@ fn main() -> ExitCode {
         } else {
             Some(candidate)
         }
-    }).unwrap_or_else(|| panic!("Cannot find the first nonexistent candidate file to which the program's args can be written under out_dir '{}'", out_dir.display()));
+    }).unwrap_or_else(|| panic!("Cannot find the first nonexistent candidate file to which the program's args can be written under out_dir '{}'", out_dir.display())))
+}
 
-    // Create a file and record the args passed to the command.
+/// Record the args passed to the command, if this invocation records at all.
+fn record(program: &str, args: &[&String]) {
+    let Some(candidate) = out_file(program) else {
+        return;
+    };
+
     let f = File::create(&candidate).unwrap_or_else(|e| {
         panic!(
             "{}: can't create candidate: {}, error: {}",
@@ -56,7 +75,7 @@ fn main() -> ExitCode {
     let mut f = io::BufWriter::new(f);
 
     (|| {
-        for arg in args.clone() {
+        for arg in args {
             writeln!(f, "{arg}")?;
         }
 
@@ -74,13 +93,36 @@ fn main() -> ExitCode {
             e
         )
     });
+}
+
+fn main() -> ExitCode {
+    let args = env::args().collect::<Vec<_>>();
+    let mut args = args.iter();
+    let program = args.next().expect("Unexpected empty args");
+    let args = args.collect::<Vec<_>>();
+
+    record(program, &args);
+
+    // Compiler family detection preprocesses a probe file with `-E` and reads
+    // the family out of the expansion. The shim is not a preprocessor and
+    // cannot answer that, so it declines and cc falls back to deducing the
+    // family from the compiler's name, which is what every test here expects.
+    //
+    // This used to happen by accident: detection ran with a fresh environment,
+    // so the shim panicked on the missing `CC_SHIM_OUT_DIR` instead. It is
+    // spelled out now that detection runs in the environment the compile
+    // commands run in and reaches the shim on purpose.
+    if args.iter().any(|a| a.as_str() == "-E") {
+        eprintln!("{program}: the shim cannot preprocess");
+        return ExitCode::FAILURE;
+    }
 
     if program.starts_with("clang") {
         // Validate that we got no `-?` without a preceding `--driver-mode=cl`. Compiler family
         // detection depends on this.
-        if let Some(cl_like_help_option_idx) = args.clone().position(|a| a == "-?") {
+        if let Some(cl_like_help_option_idx) = args.iter().position(|a| a.as_str() == "-?") {
             let has_cl_clang_driver_before_cl_like_help_option = args
-                .clone()
+                .iter()
                 .take(cl_like_help_option_idx)
                 .rev()
                 .find_map(|a| a.strip_prefix("--driver-mode="))
@@ -98,22 +140,25 @@ fn main() -> ExitCode {
 
     // Allow tests to make the shim fail when a specific arg is present.
     if let Ok(fail_arg) = env::var("CC_SHIM_FAIL_IF_ARG") {
-        if args.any(|a| a == &fail_arg) {
+        if args.iter().any(|a| a.as_str() == fail_arg) {
             eprintln!("{program}: simulated failure for arg '{fail_arg}'");
             return ExitCode::FAILURE;
         }
     }
 
-    // Create a file used by some tests.
-    let path = &out_dir.join("libfoo.a");
-    File::create(path).unwrap_or_else(|e| {
-        panic!(
-            "{}: can't create libfoo.a: {}, error: {}",
-            program,
-            path.display(),
-            e
-        )
-    });
+    // Create a file used by some tests. Only the invocations a build actually
+    // performs are asked to do this; probes are not archiving anything.
+    if let Some(out_dir) = env::var_os(OUT_DIR) {
+        let path = &PathBuf::from(out_dir).join("libfoo.a");
+        File::create(path).unwrap_or_else(|e| {
+            panic!(
+                "{}: can't create libfoo.a: {}, error: {}",
+                program,
+                path.display(),
+                e
+            )
+        });
+    }
 
     ExitCode::SUCCESS
 }

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -353,6 +353,8 @@ enum ProbeKind {
     FamilyDetection,
     /// Checking whether a compiler accepts a flag.
     FlagSupportCheck,
+    /// Working out whether an Android NDK ships `llvm-ar` under that name.
+    ArDetection,
 }
 
 impl ProbeKind {
@@ -361,6 +363,7 @@ impl ProbeKind {
         match self {
             Self::FamilyDetection => "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
             Self::FlagSupportCheck => "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+            Self::ArDetection => "CC_SHIM_OUT_FILES_FOR_AR_DETECTION",
         }
     }
 }
@@ -559,6 +562,12 @@ pub(crate) trait CommandExt {
     where
         K: AsRef<OsStr>,
         V: AsRef<OsStr>;
+
+    /// Apply `Build::env` to the Android `llvm-ar` probe.
+    fn set_ar_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>;
 }
 
 impl CommandExt for Command {
@@ -577,6 +586,15 @@ impl CommandExt for Command {
         V: AsRef<OsStr>,
     {
         set_probe_env(self, env, ProbeKind::FlagSupportCheck);
+        self
+    }
+
+    fn set_ar_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        set_probe_env(self, env, ProbeKind::ArDetection);
         self
     }
 }

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -348,7 +348,7 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
 /// test shim records one only when a test names its class. See
 /// [`set_probe_env`] and `src/bin/cc-shim.rs`.
 #[derive(Clone, Copy, Debug)]
-pub(crate) enum ProbeKind {
+enum ProbeKind {
     /// Working out a compiler's [`ToolFamily`](crate::ToolFamily).
     FamilyDetection,
     /// Checking whether a compiler accepts a flag.
@@ -385,7 +385,7 @@ impl ProbeKind {
 /// test-only, like `CC_SHIM_OUT_DIR`, and so are documented in
 /// `src/bin/cc-shim.rs` rather than in the table of public variables in
 /// `src/lib.rs`.
-pub(crate) fn set_probe_env<K, V>(cmd: &mut Command, env: &[(K, V)], kind: ProbeKind)
+fn set_probe_env<K, V>(cmd: &mut Command, env: &[(K, V)], kind: ProbeKind)
 where
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,
@@ -542,5 +542,41 @@ pub(crate) fn command_add_output_file(cmd: &mut Command, dst: &Path, args: CmdAd
         cmd.arg(s);
     } else {
         cmd.arg("-o").arg(dst);
+    }
+}
+
+/// Naming the two probe classes at the call site, so a caller does not have
+/// to reach for [`ProbeKind`] to say which one it means.
+pub(crate) trait CommandExt {
+    /// Apply `Build::env` to a compiler family detection probe.
+    fn set_family_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>;
+
+    /// Apply `Build::env` to an `is_flag_supported` probe.
+    fn set_flag_supported_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>;
+}
+
+impl CommandExt for Command {
+    fn set_family_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        set_probe_env(self, env, ProbeKind::FamilyDetection);
+        self
+    }
+
+    fn set_flag_supported_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        set_probe_env(self, env, ProbeKind::FlagSupportCheck);
+        self
     }
 }

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::Cow,
     collections::hash_map,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fmt::Display,
     fs,
     hash::Hasher,
@@ -338,6 +338,70 @@ pub(crate) fn objects_from_files(files: &[Arc<Path>], dst: &Path) -> Result<Vec<
     }
 
     Ok(objects)
+}
+
+/// Which of cc's own probing invocations a [`Command`] is being set up for.
+///
+/// A probe is not a command the caller asked cc to run: it is how cc works out
+/// what the compiler it was handed can do. Which probes run, and how many of
+/// them, depends on the compiler, the target and cc's internal caching, so the
+/// test shim records one only when a test names its class. See
+/// [`set_probe_env`] and `src/bin/cc-shim.rs`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ProbeKind {
+    /// Working out a compiler's [`ToolFamily`](crate::ToolFamily).
+    FamilyDetection,
+    /// Checking whether a compiler accepts a flag.
+    FlagSupportCheck,
+}
+
+impl ProbeKind {
+    /// The test-only variable naming where the shim should record this class.
+    const fn out_files_var(self) -> &'static str {
+        match self {
+            Self::FamilyDetection => "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
+            Self::FlagSupportCheck => "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+        }
+    }
+}
+
+/// Apply [`Build::env`](crate::Build::env) to one of cc's own probing
+/// invocations.
+///
+/// A probe is a child process like any other, so it gets the environment the
+/// caller configured - `PATH` above all, without which a probe resolves a bare
+/// compiler name such as `cc` against the ambient environment rather than the
+/// one the compile commands run in, and answers a question about a different
+/// compiler than the one being built with (rust-lang/cc-rs#1859).
+///
+/// The `CC_SHIM_OUT_FILES_FOR_*` variables are the exception, and a third
+/// category beside the two that [`Build::env`](crate::Build::env) already
+/// distinguishes: they are set through `Build::env` but read by cc itself, and
+/// rewritten for exactly one child. cc renames the one matching `kind` to
+/// `CC_SHIM_OUT_FILES` and otherwise clears it, and clears `CC_SHIM_OUT_DIR`
+/// either way, instead of copying `Build::env` over blindly. A probe a test did
+/// not ask about then records nothing at all, rather than taking an `out{i}`
+/// slot and shifting the invocations the test is asserting on. They are
+/// test-only, like `CC_SHIM_OUT_DIR`, and so are documented in
+/// `src/bin/cc-shim.rs` rather than in the table of public variables in
+/// `src/lib.rs`.
+pub(crate) fn set_probe_env<K, V>(cmd: &mut Command, env: &[(K, V)], kind: ProbeKind)
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    for (key, value) in env {
+        cmd.env(key.as_ref(), value.as_ref());
+    }
+
+    cmd.env_remove("CC_SHIM_OUT_DIR");
+    match env
+        .iter()
+        .find(|(key, _)| key.as_ref() == OsStr::new(kind.out_files_var()))
+    {
+        Some((_, value)) => cmd.env("CC_SHIM_OUT_FILES", value.as_ref()),
+        None => cmd.env_remove("CC_SHIM_OUT_FILES"),
+    };
 }
 
 pub(crate) fn run(cmd: &mut Command, cargo_output: &CargoOutput) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3737,7 +3737,13 @@ impl Build {
             None => {
                 if target.os == "android" {
                     name = format!("llvm-{tool}").into();
-                    match Command::new(&name).arg("--version").status() {
+                    // This probe decides which archiver the build uses, so it has
+                    // to run in the environment the build was configured with: a
+                    // bare name resolves through `Build::env`'s `PATH`, not the
+                    // ambient one.
+                    let mut probe = Command::new(&name);
+                    probe.arg("--version").set_ar_detection_env(&self.env);
+                    match probe.status() {
                         Ok(status) if status.success() => (),
                         _ => {
                             // FIXME: Use parsed target.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1529,9 +1529,7 @@ impl Build {
             // being built with: a bare compiler name resolves through this
             // `PATH`, not the ambient one. Also share the caches, so that a
             // compiler family already worked out is not worked out again.
-            for (key, value) in self.env.iter() {
-                cfg.env(key, value);
-            }
+            cfg.env.clone_from(&self.env);
             cfg.build_cache = Arc::clone(&self.build_cache);
             if let Some(target) = &self.target {
                 cfg.target(target);
@@ -1554,7 +1552,7 @@ impl Build {
         }
 
         let mut cmd = compiler.to_command();
-        set_probe_env(&mut cmd, &self.env, ProbeKind::FlagSupportCheck);
+        cmd.set_flag_supported_env(&self.env);
         command_add_output_file(
             &mut cmd,
             &obj,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1520,9 +1520,19 @@ impl Build {
                 .debug(false)
                 .cpp(self.cpp)
                 .cuda(self.cuda)
+                .out_dir(&out_dir)
                 .inherit_rustflags(false)
                 .inherit_trim_paths(false)
                 .emit_rerun_if_env_changed(self.emit_rerun_if_env_changed);
+            // The probe has to see the environment the compiler is invoked in,
+            // or it answers a question about a different compiler than the one
+            // being built with: a bare compiler name resolves through this
+            // `PATH`, not the ambient one. Also share the caches, so that a
+            // compiler family already worked out is not worked out again.
+            for (key, value) in self.env.iter() {
+                cfg.env(key, value);
+            }
+            cfg.build_cache = Arc::clone(&self.build_cache);
             if let Some(target) = &self.target {
                 cfg.target(target);
             }
@@ -1544,6 +1554,7 @@ impl Build {
         }
 
         let mut cmd = compiler.to_command();
+        set_probe_env(&mut cmd, &self.env, ProbeKind::FlagSupportCheck);
         command_add_output_file(
             &mut cmd,
             &obj,
@@ -1581,7 +1592,10 @@ impl Build {
             }
         }
 
-        let output = cmd.current_dir(out_dir).output()?;
+        cmd.current_dir(out_dir);
+        self.cargo_output
+            .print_debug(&format_args!("running: {cmd:?}"));
+        let output = cmd.output()?;
         let is_supported = output.status.success() && output.stderr.is_empty();
 
         self.build_cache
@@ -3170,6 +3184,7 @@ impl Build {
         if let Some(c) = &self.compiler {
             return Ok(Tool::new(
                 (**c).to_owned(),
+                &self.env,
                 &self.build_cache.cached_compiler_family,
                 &self.cargo_output,
                 out_dir,
@@ -3217,6 +3232,7 @@ impl Build {
                 let mut t = Tool::with_args(
                     tool,
                     args.clone(),
+                    &self.env,
                     &self.build_cache.cached_compiler_family,
                     &self.cargo_output,
                     out_dir,
@@ -3244,6 +3260,7 @@ impl Build {
                     } else {
                         Some(Tool::new(
                             PathBuf::from(tool),
+                            &self.env,
                             &self.build_cache.cached_compiler_family,
                             &self.cargo_output,
                             out_dir,
@@ -3309,6 +3326,7 @@ impl Build {
 
                 let mut t = Tool::new(
                     compiler,
+                    &self.env,
                     &self.build_cache.cached_compiler_family,
                     &self.cargo_output,
                     out_dir,
@@ -3333,6 +3351,7 @@ impl Build {
                 nvcc,
                 vec![],
                 self.cuda,
+                &self.env,
                 &self.build_cache.cached_compiler_family,
                 &self.cargo_output,
                 out_dir,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,5 +1,7 @@
 use crate::{
-    command_helpers::{run_output, spawn_and_wait_for_output, CargoOutput},
+    command_helpers::{
+        run_output, set_probe_env, spawn_and_wait_for_output, CargoOutput, ProbeKind,
+    },
     run,
     tempfile::NamedTempfile,
     Error, ErrorKind, OutputKind,
@@ -10,12 +12,24 @@ use std::{
     env,
     ffi::{OsStr, OsString},
     io::Write,
+    iter,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
-    sync::RwLock,
+    sync::{Arc, RwLock},
 };
 
 pub(crate) type CompilerFamilyLookupCache = HashMap<Box<[Box<OsStr>]>, ToolFamily>;
+
+/// The environment a compiler is probed and invoked in, as set by
+/// [`Build::env`](crate::Build::env).
+pub(crate) type BuildEnv = [(Arc<OsStr>, Arc<OsStr>)];
+
+/// Separates the arguments from the environment in a
+/// [`CompilerFamilyLookupCache`] key.
+///
+/// `Command` rejects arguments containing a nul byte, so no argument can
+/// impersonate this and collide with an environment variable name.
+const CACHE_KEY_ENV_SEPARATOR: &str = "\0env\0";
 
 /// Configuration used to represent an invocation of a C compiler.
 ///
@@ -58,6 +72,7 @@ impl Tool {
 
     pub(crate) fn new(
         path: PathBuf,
+        env: &BuildEnv,
         cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
@@ -66,6 +81,7 @@ impl Tool {
             path,
             vec![],
             false,
+            env,
             cached_compiler_family,
             cargo_output,
             out_dir,
@@ -75,6 +91,7 @@ impl Tool {
     pub(crate) fn with_args(
         path: PathBuf,
         args: Vec<String>,
+        env: &BuildEnv,
         cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
@@ -83,6 +100,7 @@ impl Tool {
             path,
             args,
             false,
+            env,
             cached_compiler_family,
             cargo_output,
             out_dir,
@@ -108,13 +126,20 @@ impl Tool {
         path: PathBuf,
         args: Vec<String>,
         cuda: bool,
+        env: &BuildEnv,
         cached_compiler_family: &RwLock<CompilerFamilyLookupCache>,
         cargo_output: &CargoOutput,
         out_dir: Option<&Path>,
     ) -> Self {
-        fn is_zig_cc(path: &Path, cargo_output: &CargoOutput) -> bool {
+        /// Set up a compiler family detection probe to run in `env`.
+        fn probe<'cmd>(cmd: &'cmd mut Command, env: &BuildEnv) -> &'cmd mut Command {
+            set_probe_env(cmd, env, ProbeKind::FamilyDetection);
+            cmd
+        }
+
+        fn is_zig_cc(path: &Path, env: &BuildEnv, cargo_output: &CargoOutput) -> bool {
             run_output(
-                Command::new(path).arg("--version"),
+                probe(Command::new(path).arg("--version"), env),
                 // tool detection issues should always be shown as warnings
                 cargo_output,
             )
@@ -132,6 +157,7 @@ impl Tool {
             stdout: &str,
             path: &Path,
             args: &[String],
+            env: &BuildEnv,
             cargo_output: &CargoOutput,
         ) -> Result<ToolFamily, Error> {
             cargo_output.print_debug(&stdout);
@@ -139,7 +165,10 @@ impl Tool {
             // https://gitlab.kitware.com/cmake/cmake/-/blob/69a2eeb9dff5b60f2f1e5b425002a0fd45b7cadb/Modules/CMakeDetermineCompilerId.cmake#L267-271
             // stdin is set to null to ensure that the help output is never paginated.
             let accepts_cl_style_flags = run(
-                Command::new(path).args(args).arg("-?").stdin(Stdio::null()),
+                probe(
+                    Command::new(path).args(args).arg("-?").stdin(Stdio::null()),
+                    env,
+                ),
                 &{
                     // the errors are not errors!
                     let mut cargo_output = cargo_output.clone();
@@ -158,7 +187,7 @@ impl Tool {
             match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
                 (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),
                 (true, _, _, _, false) | (_, _, _, true, false) => Ok(ToolFamily::Clang {
-                    zig_cc: is_zig_cc(path, cargo_output),
+                    zig_cc: is_zig_cc(path, env, cargo_output),
                 }),
                 (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                 (false, false, false, false, false) => {
@@ -174,6 +203,7 @@ impl Tool {
         fn detect_family_inner(
             path: &Path,
             args: &[String],
+            env: &BuildEnv,
             cargo_output: &CargoOutput,
             out_dir: Option<&Path>,
         ) -> Result<ToolFamily, Error> {
@@ -215,7 +245,7 @@ impl Tool {
             compiler_detect_output.warnings = compiler_detect_output.debug;
 
             let mut cmd = Command::new(path);
-            cmd.arg("-E").arg(tmp.path());
+            probe(cmd.arg("-E").arg(tmp.path()), env);
 
             // The -Wslash-u-filename warning is normally part of stdout.
             // But with clang-cl it can be part of stderr instead and exit with a
@@ -233,7 +263,7 @@ impl Tool {
                 .any(|o| String::from_utf8_lossy(o).contains("-Wslash-u-filename"))
             {
                 run_output(
-                    Command::new(path).arg("-E").arg("--").arg(tmp.path()),
+                    probe(Command::new(path).arg("-E").arg("--").arg(tmp.path()), env),
                     &compiler_detect_output,
                 )?
             } else {
@@ -250,20 +280,26 @@ impl Tool {
             };
 
             let stdout = String::from_utf8_lossy(&stdout);
-            guess_family_from_stdout(&stdout, path, args, cargo_output)
+            guess_family_from_stdout(&stdout, path, args, env, cargo_output)
         }
         let detect_family = |path: &Path, args: &[String]| -> Result<ToolFamily, Error> {
+            // The detected family depends on the environment the probes run in
+            // - `PATH` decides what a bare compiler name even resolves to - so
+            // two lookups that agree on the path and arguments but differ in
+            // `Build::env` must not share an entry.
             let cache_key = [path.as_os_str()]
                 .iter()
                 .cloned()
                 .chain(args.iter().map(OsStr::new))
+                .chain(iter::once(OsStr::new(CACHE_KEY_ENV_SEPARATOR)))
+                .chain(env.iter().flat_map(|(key, value)| [&**key, &**value]))
                 .map(Into::into)
                 .collect();
             if let Some(family) = cached_compiler_family.read().unwrap().get(&cache_key) {
                 return Ok(*family);
             }
 
-            let family = detect_family_inner(path, args, cargo_output, out_dir)?;
+            let family = detect_family_inner(path, args, env, cargo_output, out_dir)?;
             cached_compiler_family
                 .write()
                 .unwrap()
@@ -288,7 +324,7 @@ impl Tool {
                         ToolFamily::Msvc { clang_cl: true }
                     } else {
                         ToolFamily::Clang {
-                            zig_cc: is_zig_cc(&path, cargo_output),
+                            zig_cc: is_zig_cc(&path, env, cargo_output),
                         }
                     }
                 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,7 +1,5 @@
 use crate::{
-    command_helpers::{
-        run_output, set_probe_env, spawn_and_wait_for_output, CargoOutput, ProbeKind,
-    },
+    command_helpers::{run_output, spawn_and_wait_for_output, CargoOutput, CommandExt},
     run,
     tempfile::NamedTempfile,
     Error, ErrorKind, OutputKind,
@@ -133,7 +131,7 @@ impl Tool {
     ) -> Self {
         /// Set up a compiler family detection probe to run in `env`.
         fn probe<'cmd>(cmd: &'cmd mut Command, env: &BuildEnv) -> &'cmd mut Command {
-            set_probe_env(cmd, env, ProbeKind::FamilyDetection);
+            cmd.set_family_detection_env(env);
             cmd
         }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -22,6 +22,7 @@ pub struct Test {
     pub env: GlobalEnv,
     family_detection_probes: bool,
     flag_supported_probes: bool,
+    ar_detection_probes: bool,
 }
 
 /// Files the shim records cc's own probing invocations in, per probe class.
@@ -30,6 +31,7 @@ pub struct Test {
 /// filled in the order the probes run.
 const FAMILY_DETECTION_PROBES: &str = "family-detection-probe";
 const FLAG_SUPPORTED_PROBES: &str = "flag-supported-probe";
+const AR_DETECTION_PROBES: &str = "ar-detection-probe";
 const PROBE_SLOTS: usize = 4;
 
 pub struct Execution {
@@ -77,6 +79,7 @@ impl Test {
             env,
             family_detection_probes: false,
             flag_supported_probes: false,
+            ar_detection_probes: false,
         }
     }
 
@@ -150,6 +153,12 @@ impl Test {
                 self.probe_out_files(FLAG_SUPPORTED_PROBES),
             );
         }
+        if self.ar_detection_probes {
+            cfg.env(
+                "CC_SHIM_OUT_FILES_FOR_AR_DETECTION",
+                self.probe_out_files(AR_DETECTION_PROBES),
+            );
+        }
         if self.msvc {
             cfg.compiler(self.td.path().join("cl"));
             cfg.archiver(self.td.path().join("lib.exe"));
@@ -198,6 +207,19 @@ impl Test {
     /// [`Test::collect_flag_supported_probes`].
     pub fn get_flag_supported_probes(&self, i: usize) -> Execution {
         self.execution(self.probe_slot(FLAG_SUPPORTED_PROBES, i))
+    }
+
+    /// Record cc's Android `llvm-ar` probe, so
+    /// [`Test::get_ar_detection_probes`] can read it back.
+    pub fn collect_ar_detection_probes(&mut self) -> &mut Self {
+        self.ar_detection_probes = true;
+        self
+    }
+
+    /// Read back the `i`-th archiver detection probe recorded after
+    /// [`Test::collect_ar_detection_probes`].
+    pub fn get_ar_detection_probes(&self, i: usize) -> Execution {
+        self.execution(self.probe_slot(AR_DETECTION_PROBES, i))
     }
 
     fn probe_slot(&self, class: &str, i: usize) -> PathBuf {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -20,7 +20,17 @@ pub struct Test {
     pub msvc: bool,
     pub msvc_autodetect: bool,
     pub env: GlobalEnv,
+    family_detection_probes: bool,
+    flag_supported_probes: bool,
 }
+
+/// Files the shim records cc's own probing invocations in, per probe class.
+///
+/// A build can run a class more than once, so each class gets several slots,
+/// filled in the order the probes run.
+const FAMILY_DETECTION_PROBES: &str = "family-detection-probe";
+const FLAG_SUPPORTED_PROBES: &str = "flag-supported-probe";
+const PROBE_SLOTS: usize = 4;
 
 pub struct Execution {
     pub args: Vec<String>,
@@ -65,6 +75,8 @@ impl Test {
             msvc: false,
             msvc_autodetect: false,
             env,
+            family_detection_probes: false,
+            flag_supported_probes: false,
         }
     }
 
@@ -126,6 +138,18 @@ impl Test {
             .out_dir(self.td.path())
             .env("PATH", self.path())
             .env("CC_SHIM_OUT_DIR", self.td.path());
+        if self.family_detection_probes {
+            cfg.env(
+                "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
+                self.probe_out_files(FAMILY_DETECTION_PROBES),
+            );
+        }
+        if self.flag_supported_probes {
+            cfg.env(
+                "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+                self.probe_out_files(FLAG_SUPPORTED_PROBES),
+            );
+        }
         if self.msvc {
             cfg.compiler(self.td.path().join("cl"));
             cfg.archiver(self.td.path().join("lib.exe"));
@@ -148,17 +172,40 @@ impl Test {
         self.execution(self.td.path().join(format!("out{}", i)))
     }
 
-    /// Declare where the shim should record one class of cc's own probing
-    /// invocations, for a `CC_SHIM_OUT_FILES_FOR_*` variable: a
-    /// `PATH`-separated list of files under this test's temp dir, filled in the
-    /// order the probes run.
-    pub fn probe_out_files(&self, names: &[&str]) -> OsString {
-        env::join_paths(names.iter().map(|name| self.td.path().join(name))).unwrap()
+    /// Record cc's own compiler family detection probes, so
+    /// [`Test::get_family_detection_probes`] can read them back. Probe classes a
+    /// test does not ask for record nothing and so cannot shift the `out{i}`
+    /// numbering [`Test::cmd`] uses.
+    pub fn collect_family_detection_probes(&mut self) -> &mut Self {
+        self.family_detection_probes = true;
+        self
     }
 
-    /// Read back a probe recording declared with [`Test::probe_out_files`].
-    pub fn probe_cmd(&self, name: &str) -> Execution {
-        self.execution(self.td.path().join(name))
+    /// Record cc's own `is_flag_supported` probes, so
+    /// [`Test::get_flag_supported_probes`] can read them back.
+    pub fn collect_flag_supported_probes(&mut self) -> &mut Self {
+        self.flag_supported_probes = true;
+        self
+    }
+
+    /// Read back the `i`-th family detection probe recorded after
+    /// [`Test::collect_family_detection_probes`].
+    pub fn get_family_detection_probes(&self, i: usize) -> Execution {
+        self.execution(self.probe_slot(FAMILY_DETECTION_PROBES, i))
+    }
+
+    /// Read back the `i`-th flag support probe recorded after
+    /// [`Test::collect_flag_supported_probes`].
+    pub fn get_flag_supported_probes(&self, i: usize) -> Execution {
+        self.execution(self.probe_slot(FLAG_SUPPORTED_PROBES, i))
+    }
+
+    fn probe_slot(&self, class: &str, i: usize) -> PathBuf {
+        self.td.path().join(format!("{class}{i}"))
+    }
+
+    fn probe_out_files(&self, class: &str) -> OsString {
+        env::join_paths((0..PROBE_SLOTS).map(|i| self.probe_slot(class, i))).unwrap()
     }
 
     #[track_caller]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -139,10 +139,33 @@ impl Test {
         env::join_paths(path).unwrap()
     }
 
+    /// Read back the `i`-th invocation a build actually performed.
+    ///
+    /// cc's own probing invocations are not recorded unless a test asks for
+    /// them by name with [`Test::probe_out_files`], so this numbering covers
+    /// the compile and archive commands only.
     pub fn cmd(&self, i: u32) -> Execution {
+        self.execution(self.td.path().join(format!("out{}", i)))
+    }
+
+    /// Declare where the shim should record one class of cc's own probing
+    /// invocations, for a `CC_SHIM_OUT_FILES_FOR_*` variable: a
+    /// `PATH`-separated list of files under this test's temp dir, filled in the
+    /// order the probes run.
+    pub fn probe_out_files(&self, names: &[&str]) -> OsString {
+        env::join_paths(names.iter().map(|name| self.td.path().join(name))).unwrap()
+    }
+
+    /// Read back a probe recording declared with [`Test::probe_out_files`].
+    pub fn probe_cmd(&self, name: &str) -> Execution {
+        self.execution(self.td.path().join(name))
+    }
+
+    #[track_caller]
+    fn execution(&self, path: PathBuf) -> Execution {
         let mut s = String::new();
-        File::open(self.td.path().join(format!("out{}", i)))
-            .unwrap()
+        File::open(&path)
+            .unwrap_or_else(|e| panic!("no recording at {}: {}", path.display(), e))
             .read_to_string(&mut s)
             .unwrap();
         Execution {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -420,24 +420,18 @@ fn gnu_flag_if_supported() {
 /// <https://github.com/rust-lang/cc-rs/issues/1859>
 #[test]
 fn probe_env_overrides() {
-    let test = Test::gnu();
+    let mut test = Test::gnu();
+    test.collect_family_detection_probes()
+        .collect_flag_supported_probes();
     test.gcc()
-        .env(
-            "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
-            test.probe_out_files(&["family-probe"]),
-        )
-        .env(
-            "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
-            test.probe_out_files(&["flag-probe"]),
-        )
         .flag_if_supported("-Wprobed")
         .file("foo.c")
         .compile("foo");
 
     // Both probes went to the shim this `PATH` resolves `cc` to, rather than to
     // whatever compiler the ambient environment happens to have.
-    test.probe_cmd("family-probe").must_have("-E");
-    test.probe_cmd("flag-probe")
+    test.get_family_detection_probes(0).must_have("-E");
+    test.get_flag_supported_probes(0)
         .must_have("-Wprobed")
         .must_have("-c");
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -896,14 +896,20 @@ fn clang_android() {
     // we use "clang" and set the target correctly.
     #[cfg(windows)]
     {
-        let test = Test::new();
+        let mut test = Test::new();
         test.shim("clang").shim("llvm-ar");
+        test.collect_ar_detection_probes();
         test.gcc()
             .target(target)
             .host("x86_64-pc-windows-msvc")
             .file("foo.c")
             .compile("foo");
         test.cmd(0).must_have("--target=arm-linux-androideabi");
+
+        // The NDK probe runs in the environment `Build::env` set up, so it
+        // finds the `llvm-ar` this test put on `PATH` rather than falling
+        // back to a target-prefixed name that is not there.
+        test.get_ar_detection_probes(0).must_have("--version");
     }
 
     // On non-Windows, we do use the shims, so make sure that we use the shim

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -396,23 +396,54 @@ fn gnu_shared() {
 
 #[test]
 fn gnu_flag_if_supported() {
-    if cfg!(windows) {
-        return;
-    }
     let test = Test::gnu();
     test.gcc()
         .file("foo.c")
         .flag("-v")
+        // The probe runs against the shim on this `PATH`, so tell the shim to
+        // reject one flag and stand in for a compiler that does not know it.
+        // Before this was hermetic the probe reached whatever compiler the
+        // machine happened to have, and the test had to skip Windows.
+        .env("CC_SHIM_FAIL_IF_ARG", "-Wflag-does-not-exist")
         .flag_if_supported("-Wall")
         .flag_if_supported("-Wflag-does-not-exist")
-        .flag_if_supported("-std=c++11")
         .compile("foo");
 
     test.cmd(0)
         .must_have("-v")
         .must_have("-Wall")
-        .must_not_have("-Wflag-does-not-exist")
-        .must_not_have("-std=c++11");
+        .must_not_have("-Wflag-does-not-exist");
+}
+
+/// cc's own probing invocations run in the environment `Build::env` sets up,
+/// and record only the class of probe a test asks for by name.
+/// <https://github.com/rust-lang/cc-rs/issues/1859>
+#[test]
+fn probe_env_overrides() {
+    let test = Test::gnu();
+    test.gcc()
+        .env(
+            "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
+            test.probe_out_files(&["family-probe"]),
+        )
+        .env(
+            "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+            test.probe_out_files(&["flag-probe"]),
+        )
+        .flag_if_supported("-Wprobed")
+        .file("foo.c")
+        .compile("foo");
+
+    // Both probes went to the shim this `PATH` resolves `cc` to, rather than to
+    // whatever compiler the ambient environment happens to have.
+    test.probe_cmd("family-probe").must_have("-E");
+    test.probe_cmd("flag-probe")
+        .must_have("-Wprobed")
+        .must_have("-c");
+
+    // Neither took an `out{i}` slot, so the compile is still the first
+    // invocation however many probes cc decided to run.
+    test.cmd(0).must_have("foo.c").must_have("-Wprobed");
 }
 
 #[cfg(not(windows))]

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -172,13 +172,10 @@ fn clang_cl_scope_all() {
     test.shim("clang-cl.exe");
     test.env.set("CARGO_TRIM_PATHS_SCOPE", "all");
     test.env.set("CARGO_TRIM_PATHS_REMAP", remap());
+    test.collect_flag_supported_probes();
     let mut build = test.gcc();
     build
         .compiler(test.td.path().join("clang-cl.exe"))
-        .env(
-            "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
-            test.probe_out_files(&["macro-probe", "debug-probe"]),
-        )
         .file("foo.c")
         .compile("foo");
 
@@ -186,9 +183,9 @@ fn clang_cl_scope_all() {
     // https://releases.llvm.org/8.0.0/tools/clang/docs/UsersManual.html#the-clang-option
     // The two probes that establish this are recorded where this test asked for
     // them, so the compile it is really asserting on is still `cmd(0)`.
-    test.probe_cmd("macro-probe")
+    test.get_flag_supported_probes(0)
         .must_have("/clang:-fmacro-prefix-map=/probe=/probe");
-    test.probe_cmd("debug-probe")
+    test.get_flag_supported_probes(1)
         .must_have("/clang:-fdebug-prefix-map=/probe=/probe");
 
     let cmd = test.cmd(0);

--- a/tests/trim_paths.rs
+++ b/tests/trim_paths.rs
@@ -175,17 +175,23 @@ fn clang_cl_scope_all() {
     let mut build = test.gcc();
     build
         .compiler(test.td.path().join("clang-cl.exe"))
+        .env(
+            "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+            test.probe_out_files(&["macro-probe", "debug-probe"]),
+        )
         .file("foo.c")
         .compile("foo");
 
     // clang-cl forwards Clang driver options through `/clang:<arg>`:
     // https://releases.llvm.org/8.0.0/tools/clang/docs/UsersManual.html#the-clang-option
-    test.cmd(0)
+    // The two probes that establish this are recorded where this test asked for
+    // them, so the compile it is really asserting on is still `cmd(0)`.
+    test.probe_cmd("macro-probe")
         .must_have("/clang:-fmacro-prefix-map=/probe=/probe");
-    test.cmd(1)
+    test.probe_cmd("debug-probe")
         .must_have("/clang:-fdebug-prefix-map=/probe=/probe");
 
-    let cmd = test.cmd(2);
+    let cmd = test.cmd(0);
     for flag in MACRO_FLAGS.iter().chain(OBJECT_FLAGS) {
         cmd.must_not_have(flag).must_have(format!("/clang:{flag}"));
     }


### PR DESCRIPTION
The `clang_android` follow-up from #1866. Related: #1859.

**This is stacked on #1866 and contains its two commits.** Only the last one, `fix: run the Android llvm-ar probe in the caller's environment`, is new here. The diff will shrink to that once #1866 lands, so this is best read after it.

## What broke

The Android branch of `get_base_archiver_variant` works out whether the NDK ships `llvm-ar` under that name by running `llvm-ar --version`, and it built that probe with a bare `Command::new`:

```rust
name = format!("llvm-{tool}").into();
match Command::new(&name).arg("--version").status() {
```

A bare name resolves through the ambient `PATH`, not the one `Build::env` set up. So a caller that points `PATH` at its own toolchain gets the question answered about a different toolchain, and cc falls back to the target-prefixed name.

This is the third site of the same root cause as #1859, after family detection and `is_flag_supported`. It is also the one that made `clang_android` unable to run on my machine: the test puts `llvm-ar` on `PATH` through `Build::env`, the probe never saw it, and the fallback `arm-linux-androideabi-ar` is not there either, so cc's error path exited the process and took the whole test binary with it.

```
error occurred in cc-rs: failed to find tool "arm-linux-androideabi-ar": program not found
```

Green on CI because the runners have something the probe can find in the ambient `PATH`.

## The change

The probe goes through `set_ar_detection_env`, so it inherits `Build::env` and gets its own recording class rather than consuming an `out{i}` slot. That is the third class you and I discussed on #1866, and it is the reason this is a separate PR: it widens the design from two classes to three.

`ProbeKind::ArDetection` maps to `CC_SHIM_OUT_FILES_FOR_AR_DETECTION`, and `Test` gains `collect_ar_detection_probes` and `get_ar_detection_probes` alongside the other two.

I did not touch the fallback logic itself, only which environment the probe asks the question in.

## Verified

Windows 11, `x86_64-pc-windows-msvc`, `rustc 1.97.1`.

Before, on the unmodified branch, `clang_android` did not fail, it aborted the process, which is why the rest of that binary never reported. After:

```
tests/test.rs   59 passed, 0 failed, 0 ignored
```

That is the whole binary green in one run for the first time here. Previously 58 of 59 passed when run one test per process, with `clang_android` killing the shared run.

Everything else, on this branch: every other test binary green, doc-tests 28 passed, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, and MSRV `check -p cc` on 1.65.0 clean.

The new assertion is `test.get_ar_detection_probes(0).must_have("--version")`, which fails on unmodified source because the probe never reaches the shim and no recording exists.

## One thing worth your call

The probe still runs `--version` and inherits stdio, so under the shim it is a real process spawn per Android build. That was already true, and I left it alone rather than widening the PR, but if you would rather it were quieted or cached, say so and I will fold it in.


LLM usage, per the Rust policy: this change was developed with AI assistance (Claude). Adding this retroactively, since it should have been disclosed when the PR was opened.
