### PR TITLE
fix: run the Android llvm-ar probe in the caller's environment

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -353,6 +353,8 @@ enum ProbeKind {
     FamilyDetection,
     /// Checking whether a compiler accepts a flag.
     FlagSupportCheck,
+    /// Working out whether an Android NDK ships `llvm-ar` under that name.
+    ArDetection,
 }
 
 impl ProbeKind {
@@ -361,6 +363,7 @@ impl ProbeKind {
         match self {
             Self::FamilyDetection => "CC_SHIM_OUT_FILES_FOR_FAMILY_DETECTION",
             Self::FlagSupportCheck => "CC_SHIM_OUT_FILES_FOR_FLAG_SUPPORT_CHECK",
+            Self::ArDetection => "CC_SHIM_OUT_FILES_FOR_AR_DETECTION",
         }
     }
 }
@@ -559,6 +562,12 @@ pub(crate) trait CommandExt {
     where
         K: AsRef<OsStr>,
         V: AsRef<OsStr>;
+
+    /// Apply `Build::env` to the Android `llvm-ar` probe.
+    fn set_ar_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>;
 }
 
 impl CommandExt for Command {
@@ -577,6 +586,15 @@ impl CommandExt for Command {
         V: AsRef<OsStr>,
     {
         set_probe_env(self, env, ProbeKind::FlagSupportCheck);
+        self
+    }
+
+    fn set_ar_detection_env<K, V>(&mut self, env: &[(K, V)]) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        set_probe_env(self, env, ProbeKind::ArDetection);
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3737,7 +3737,13 @@ impl Build {
             None => {
                 if target.os == "android" {
                     name = format!("llvm-{tool}").into();
-                    match Command::new(&name).arg("--version").status() {
+                    // This probe decides which archiver the build uses, so it has
+                    // to run in the environment the build was configured with: a
+                    // bare name resolves through `Build::env`'s `PATH`, not the
+                    // ambient one.
+                    let mut probe = Command::new(&name);
+                    probe.arg("--version").set_ar_detection_env(&self.env);
+                    match probe.status() {
                         Ok(status) if status.success() => (),
                         _ => {
                             // FIXME: Use parsed target.

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -22,6 +22,7 @@ pub struct Test {
     pub env: GlobalEnv,
     family_detection_probes: bool,
     flag_supported_probes: bool,
+    ar_detection_probes: bool,
 }
 
 /// Files the shim records cc's own probing invocations in, per probe class.
@@ -30,6 +31,7 @@ pub struct Test {
 /// filled in the order the probes run.
 const FAMILY_DETECTION_PROBES: &str = "family-detection-probe";
 const FLAG_SUPPORTED_PROBES: &str = "flag-supported-probe";
+const AR_DETECTION_PROBES: &str = "ar-detection-probe";
 const PROBE_SLOTS: usize = 4;
 
 pub struct Execution {
@@ -77,6 +79,7 @@ impl Test {
             env,
             family_detection_probes: false,
             flag_supported_probes: false,
+            ar_detection_probes: false,
         }
     }
 
@@ -150,6 +153,12 @@ impl Test {
                 self.probe_out_files(FLAG_SUPPORTED_PROBES),
             );
         }
+        if self.ar_detection_probes {
+            cfg.env(
+                "CC_SHIM_OUT_FILES_FOR_AR_DETECTION",
+                self.probe_out_files(AR_DETECTION_PROBES),
+            );
+        }
         if self.msvc {
             cfg.compiler(self.td.path().join("cl"));
             cfg.archiver(self.td.path().join("lib.exe"));
@@ -198,6 +207,19 @@ impl Test {
     /// [`Test::collect_flag_supported_probes`].
     pub fn get_flag_supported_probes(&self, i: usize) -> Execution {
         self.execution(self.probe_slot(FLAG_SUPPORTED_PROBES, i))
+    }
+
+    /// Record cc's Android `llvm-ar` probe, so
+    /// [`Test::get_ar_detection_probes`] can read it back.
+    pub fn collect_ar_detection_probes(&mut self) -> &mut Self {
+        self.ar_detection_probes = true;
+        self
+    }
+
+    /// Read back the `i`-th archiver detection probe recorded after
+    /// [`Test::collect_ar_detection_probes`].
+    pub fn get_ar_detection_probes(&self, i: usize) -> Execution {
+        self.execution(self.probe_slot(AR_DETECTION_PROBES, i))
     }
 
     fn probe_slot(&self, class: &str, i: usize) -> PathBuf {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -896,14 +896,20 @@ fn clang_android() {
     // we use "clang" and set the target correctly.
     #[cfg(windows)]
     {
-        let test = Test::new();
+        let mut test = Test::new();
         test.shim("clang").shim("llvm-ar");
+        test.collect_ar_detection_probes();
         test.gcc()
             .target(target)
             .host("x86_64-pc-windows-msvc")
             .file("foo.c")
             .compile("foo");
         test.cmd(0).must_have("--target=arm-linux-androideabi");
+
+        // The NDK probe runs in the environment `Build::env` set up, so it
+        // finds the `llvm-ar` this test put on `PATH` rather than falling
+        // back to a target-prefixed name that is not there.
+        test.get_ar_detection_probes(0).must_have("--version");
     }
 
     // On non-Windows, we do use the shims, so make sure that we use the shim


### PR DESCRIPTION
Replaces #1867, which you approved but which went conflicted the moment #1866 squash-merged. Same commit, rebased onto `main`, now a single commit rather than three. Related: #1859.

I could not update #1867 in place because rebasing a pushed branch needs a force-push and my setup gates that on a human, so a fresh branch was the clean way to give you a mergeable version. Sorry for the extra PR number.

## What broke

The Android branch of `get_base_archiver_variant` decides whether the NDK ships `llvm-ar` under that name by running `llvm-ar --version`, and it built that probe with a bare `Command::new`:

```rust
name = format!("llvm-{tool}").into();
match Command::new(&name).arg("--version").status() {
```

A bare name resolves through the ambient `PATH`, not the one `Build::env` set up, so a caller pointing `PATH` at its own toolchain gets the question answered about a different toolchain and cc falls back to the target-prefixed name.

This is the third site of the same root cause as #1859, after family detection and `is_flag_supported`, and it is the one that made `clang_android` unable to run here: the test puts `llvm-ar` on `PATH` through `Build::env`, the probe never saw it, and the fallback `arm-linux-androideabi-ar` is not there either, so cc's error path exited the process and took the whole test binary with it.

```
error occurred in cc-rs: failed to find tool "arm-linux-androideabi-ar": program not found
```

## The change

The probe goes through `set_ar_detection_env`, so it inherits `Build::env` and gets its own recording class rather than consuming an `out{i}` slot. That is the third class we discussed on #1866, and it is why this is separate: it widens the design from two classes to three.

`ProbeKind::ArDetection` maps to `CC_SHIM_OUT_FILES_FOR_AR_DETECTION`, and `Test` gains `collect_ar_detection_probes` and `get_ar_detection_probes` alongside the other two. The fallback logic itself is untouched; only the environment the probe asks the question in changes.

## Verified after the rebase, not before

Windows 11, `x86_64-pc-windows-msvc`, `rustc 1.97.1`, run against `main` at `c5cc913`:

```
tests/test.rs   59 passed, 0 failed, 0 ignored
```

That is the whole binary green in a single run. Before this change `clang_android` did not fail, it aborted the process, which is why the rest of that binary never reported.

Every other test binary green, doc-tests 28 passed, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, MSRV `check -p cc` on 1.65.0 clean.

The new assertion is `test.get_ar_detection_probes(0).must_have("--version")`, which fails on unmodified source because the probe never reaches the shim and no recording exists.


LLM usage, per the Rust policy: this change was developed with AI assistance (Claude). Adding this retroactively, since it should have been disclosed when the PR was opened.
