### PR TITLE
fix: Prevent check_exe from dropping flags on the floor.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4857,10 +4857,23 @@ impl AsmFileExt {
     }
 }
 
-fn check_exe(mut exe: PathBuf) -> Option<PathBuf> {
+fn check_exe(exe: PathBuf) -> Option<PathBuf> {
+    if exe.exists() {
+        return Some(exe);
+    }
     let exe_ext = std::env::consts::EXE_EXTENSION;
-    let check = exe.exists() || (!exe_ext.is_empty() && exe.set_extension(exe_ext) && exe.exists());
-    check.then_some(exe)
+    if exe_ext.is_empty() {
+        return None;
+    }
+    // TODO: Replace the code below with `exe.add_extension(exe_ext)` when MSRV supports it.
+    let _ = exe.file_name()?;
+    let with_ext = {
+        let mut buf = exe.into_os_string();
+        buf.push(".");
+        buf.push(exe_ext);
+        PathBuf::from(buf)
+    };
+    with_ext.exists().then_some(with_ext)
 }
 
 #[cfg(test)]

--- a/tests/cc_env.rs
+++ b/tests/cc_env.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 mod support;
@@ -120,6 +120,9 @@ fn clang_cl() {
             assert_eq!(compiler.path(), Path::new(&*bin));
             assert!(compiler.is_like_msvc());
             assert!(compiler.is_like_clang_cl());
+            let cmd = compiler.to_command();
+            let args = cmd.get_args().collect::<Vec<_>>();
+            assert!(args.contains(&OsStr::new("--driver-mode=cl")), "{args:?}");
         };
         test_compiler(test.gcc());
     }


### PR DESCRIPTION
This prevents CC=/path/to/clang.exe --flags from losing flags.

Fixes #1883