### PR TITLE
Add support for CUDA on Windows on ARM.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1817,6 +1817,10 @@ impl Build {
                 } else if cfg!(target_env = "msvc") {
                     libdir.push("lib");
                     match target.arch {
+                        "aarch64" => {
+                            libdir.push("arm64");
+                            libtst = true;
+                        }
                         "x86_64" => {
                             libdir.push("x64");
                             libtst = true;


### PR DESCRIPTION
Side note. Depending on what one does one might have to set NVCC_PREPEND_FLAGS environment varialbe to "-std c++20 -Xcompiler /Zc:preprocessor".