### PR TITLE
Fix use of windows_bindgen::bindgen

### DIFF
--- a/dev-tools/gen-windows-sys-binding/src/lib.rs
+++ b/dev-tools/gen-windows-sys-binding/src/lib.rs
@@ -33,11 +33,9 @@ pub fn generate_bindings() {
     windows_bindgen::bindgen([
         "--flat",
         "--sys",
-        "--no-deps",
         "--out",
         temp_file.path().to_str().unwrap(),
         "--filter",
-        "--etc",
         &filter,
     ]);
 

--- a/dev-tools/gen-windows-sys-binding/src/lib.rs
+++ b/dev-tools/gen-windows-sys-binding/src/lib.rs
@@ -35,7 +35,7 @@ pub fn generate_bindings() {
         "--sys",
         "--out",
         temp_file.path().to_str().unwrap(),
-        "--filter",
+        "--filter-file",
         &filter,
     ]);
 


### PR DESCRIPTION
 - --no-deps removed after depreciation
 - --etc no longer needed, use --filter-file instead